### PR TITLE
update uphold prod pin, tweak settlement README, xc settlement tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ grantTokens.json
 /verify-tokens
 /settlement-submit
 /vault-*
+/get-cert-fingerprint

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,7 @@ before_install:
 - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64
   -o $GOPATH/bin/dep
 - chmod +x $GOPATH/bin/dep
-- go get -u github.com/alecthomas/gometalinter
-- go get -u github.com/client9/misspell/cmd/misspell
-- gometalinter --install
+- go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 install:
 - dep ensure
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   fast_finish: true
 env:
   matrix:
-  - DEP_VERSION="0.3.2"
+  - DEP_VERSION="0.4.1"
   global:
   - TEST_TAGS="integration"
   - secure: gGqNxojD1sfTk4qnFUTQ2vx5V9ryOLEctChxv6iZa1rxbyRE1cB65IPCFquU8Qo7rN4LcqlwpCvEfJHkRs41mOtrkBuRFUSMA1Z0wp6Gpz3jT7nvygRLfkcWMbfHDa2oKS6c9cTWlmanuGl8KWKxZrWzvl7WwtD0Rqfbr3cH74JmOfq5h05ermhE0YNFNKrnra2WZYQGeS9i/qh2nDvnuVw0nI6pXsGpl7fZ/bMDDUipCqSDtfRyV389UAUA5pab+BCp0/hLrDiUOL/xSB2zIoyenQ8mM01MpM1Hx2vh+PrbCJE880ON1374tPRkyNvPlQMeSYv+eZQBT8zxYsQ+xEmfxVvkqvyGo630X5trV5IVQqn+6xlyIFHwemLIpGqwZMg3DlQ2JujQGy6/xfvfd3tMdnzi6NoTtE1h5CYYJ168tnytAz4d3xJ7nGYl4zGejO4971c97JdUY078PYaKDkbRGA0pCk0MYmA9VnkcsPO9v6vW8kV09VFRgNKBJV0YNycWvdTLBF+i8Xe3/aAGMxfJLsbb+gYPTI4cQiIlIc7AlDpd7LzHUuUMQr8cCvK2IoJNnTsgyqtfZZBIbvJkZlEp6EjbKT0Wawh6oC0u+2+9LXYB4tuLDYkprA6NhN5bna4rh/uB826/BXhX6J5SpC4PzDlf985cazEGpyAwyQQ=

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
   only:
   - master
 go:
-- "1.9"
 - "1.10"
 - "master"
 services:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,7 +3,12 @@
 
 [[projects]]
   name = "github.com/SermoDigital/jose"
-  packages = [".","crypto","jws","jwt"]
+  packages = [
+    ".",
+    "crypto",
+    "jws",
+    "jwt"
+  ]
   revision = "f6df55f235c24f236d11dbcf665249a59ac2021f"
   version = "1.1"
 
@@ -57,7 +62,10 @@
 
 [[projects]]
   name = "github.com/garyburd/redigo"
-  packages = ["internal","redis"]
+  packages = [
+    "internal",
+    "redis"
+  ]
   revision = "47dc60e71eed504e3ef8e77ee3c6fe720f3be57f"
   version = "v1.3.0"
 
@@ -69,14 +77,23 @@
 
 [[projects]]
   name = "github.com/go-chi/chi"
-  packages = [".","middleware"]
+  packages = [
+    ".",
+    "middleware"
+  ]
   revision = "f7c66f685bcab06bcce78ac212c5f3553c063d19"
   version = "v3.3.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -105,6 +122,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/hashicorp/go-immutable-radix"
+  packages = ["."]
+  revision = "7f3cd4390caab3250a57f30efdb2a65dd7649ecf"
+
+[[projects]]
+  branch = "master"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
@@ -114,6 +137,12 @@
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
   revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/go-retryablehttp"
+  packages = ["."]
+  revision = "3b087ef2d313afe6c55b2f511d20db04ca767075"
 
 [[projects]]
   branch = "master"
@@ -142,20 +171,56 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
   name = "github.com/hashicorp/vault"
-  packages = ["api","command/config","command/token","helper/certutil","helper/compressutil","helper/consts","helper/errutil","helper/jsonutil","helper/kdf","helper/keysutil","helper/locksutil","helper/logging","helper/mlock","helper/parseutil","helper/pluginutil","helper/strutil","helper/wrapping","logical","physical","physical/inmem","version"]
-  revision = "756fdc4587350daf1c65b93647b2cc31a6f119cd"
-  version = "v0.10.1"
+  packages = [
+    "api",
+    "command/config",
+    "command/token",
+    "helper/certutil",
+    "helper/compressutil",
+    "helper/consts",
+    "helper/errutil",
+    "helper/jsonutil",
+    "helper/kdf",
+    "helper/keysutil",
+    "helper/locksutil",
+    "helper/logging",
+    "helper/mlock",
+    "helper/parseutil",
+    "helper/pathmanager",
+    "helper/pluginutil",
+    "helper/strutil",
+    "helper/wrapping",
+    "logical",
+    "physical",
+    "physical/inmem",
+    "version"
+  ]
+  revision = "3ee0802ed08cb7f4046c2151ec4671a076b76166"
+  version = "v0.10.2"
 
 [[projects]]
   branch = "master"
@@ -219,7 +284,12 @@
 
 [[projects]]
   name = "github.com/posener/complete"
-  packages = [".","cmd","cmd/install","match"]
+  packages = [
+    ".",
+    "cmd",
+    "cmd/install",
+    "match"
+  ]
   revision = "98eb9847f27ba2008d380a32c98be474dea55bdf"
   version = "v1.1.1"
 
@@ -231,7 +301,10 @@
 
 [[projects]]
   name = "github.com/prometheus/client_golang"
-  packages = ["prometheus","prometheus/promhttp"]
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
   revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
   version = "v0.9.0-pre1"
 
@@ -244,13 +317,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "e3fb1a1acd7605367a2b378bc2e2f893c05174b7"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
@@ -264,12 +344,6 @@
   packages = ["."]
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/sethgrid/pester"
-  packages = ["."]
-  revision = "03e26c9abbbf5accb8349790bf9f41bde09d72c3"
 
 [[projects]]
   branch = "master"
@@ -292,26 +366,73 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["cast5","chacha20poly1305","chacha20poly1305/internal/chacha20","ed25519","ed25519/internal/edwards25519","hkdf","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","poly1305","ssh/terminal"]
+  packages = [
+    "cast5",
+    "chacha20poly1305",
+    "chacha20poly1305/internal/chacha20",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "hkdf",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "poly1305",
+    "ssh/terminal"
+  ]
   revision = "6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "a8b9294777976932365dabb6640cf1468d95c70f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "1e2299c37cc91a509f1b12369872d27be0ce98a6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "75cc3cad82b5f47d3fb229ddda8c5167da14f294"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
   branch = "master"
@@ -321,19 +442,48 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclb/grpc_lb_v1/messages","grpclog","health","health/grpc_health_v1","internal","keepalive","metadata","naming","peer","resolver","resolver/dns","resolver/passthrough","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "health",
+    "health/grpc_health_v1",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "d11072e7ca9811b1100b80ca0269ac831f06d024"
   version = "v1.11.3"
 
 [[projects]]
   name = "gopkg.in/square/go-jose.v2"
-  packages = ["cipher","json"]
+  packages = [
+    "cipher",
+    "json"
+  ]
   revision = "f8f38de21b4dcd69d0413faf231983f5fd6634b1"
   version = "v2.1.3"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "79ddd76343bb6176e9fdb2cded56138c50a8cec451de2ec77f5a8460294f1f43"
+  inputs-digest = "4e3226f93c710f0b0a95df3412c225258604813a4a4aad7e1cc3461f7b6093a4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,7 +85,6 @@
   version = "v3.3.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -94,7 +93,8 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -161,7 +161,7 @@
   branch = "master"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,4 +48,4 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  version = "0.10.1"
+  version = "0.10.2"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test:
 	go test -v --tags=$(TEST_TAGS) ./...
 
 lint:
-	gometalinter --vendor --disable=gocyclo --enable=misspell --deadline=5m ./...
+	golangci-lint run -E gofmt
 
 clean:
 	rm -f $(BINS)

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ settlement-tools:
 	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-import-key
 	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-create-wallet
 	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-sign-settlement
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/settlement-submit
 	GOOS=$(GOOS) GOARCH=$(GOARCH) make download-vault
 
 grant-signing-tools:

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,26 @@ mac:
 	GOOS=darwin GOARCH=amd64 make bins
 
 settlement-tools:
+	$(eval GOOS?=darwin)
+	$(eval GOARCH?=amd64)
+	rm -rf target/settlement-tools
 	mkdir -p target/settlement-tools
 	cp settlement/config.hcl target/settlement-tools/
 	cp settlement/README.md target/settlement-tools/
-	GOOS=darwin GOARCH=amd64 make target/settlement-tools/vault-init
-	GOOS=darwin GOARCH=amd64 make target/settlement-tools/vault-unseal
-	GOOS=darwin GOARCH=amd64 make target/settlement-tools/vault-import-key
-	GOOS=darwin GOARCH=amd64 make target/settlement-tools/vault-create-wallet
-	GOOS=darwin GOARCH=amd64 make target/settlement-tools/vault-sign-settlement
-	GOOS=darwin GOARCH=amd64 make download-vault
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-init
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-unseal
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-import-key
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-create-wallet
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/settlement-tools/vault-sign-settlement
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make download-vault
+
+grant-signing-tools:
+	$(eval GOOS?=darwin)
+	$(eval GOARCH?=amd64)
+	rm -rf target/grant-signing-tools
+	mkdir -p target/grant-signing-tools
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/grant-signing-tools/create-tokens
+	GOOS=$(GOOS) GOARCH=$(GOARCH) make target/grant-signing-tools/verify-tokens
 
 download-vault:
 	cd target/settlement-tools && curl -Os https://releases.hashicorp.com/vault/$(VAULT_VERSION)/vault_$(VAULT_VERSION)_$(GOOS)_$(GOARCH).zip

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ is installed then run `make docker`.
 
 ## Developer Setup
 
-1. [Install Go 1.10](https://golang.org/doc/install)
+1. [Install Go 1.10](https://golang.org/doc/install) (NOTE: Go 1.9 and earlier will not work!)
 
 2. Run `go get -d github.com/brave-intl/bat-go`. 
 

--- a/bin/create-tokens/main.go
+++ b/bin/create-tokens/main.go
@@ -130,7 +130,7 @@ func main() {
 	grants := grant.CreateGrants(signer, promotionUUID, *numGrants, altCurrency, *value, maturityDate, expiryDate)
 	var grantReg grantRegistration
 	grantReg.Grants = grants
-	grantReg.Promotions = []promotionInfo{{promotionUUID, 0, false, maturityDate.Unix() * 1000}}
+	grantReg.Promotions = []promotionInfo{{ID: promotionUUID, Priority: 0, Active: false, MinimumReconcileTimestamp: maturityDate.Unix() * 1000}}
 	serializedGrants, err := json.Marshal(grantReg)
 	if err != nil {
 		log.Fatalln(err)

--- a/bin/create-tokens/main.go
+++ b/bin/create-tokens/main.go
@@ -130,7 +130,7 @@ func main() {
 	grants := grant.CreateGrants(signer, promotionUUID, *numGrants, altCurrency, *value, maturityDate, expiryDate)
 	var grantReg grantRegistration
 	grantReg.Grants = grants
-	grantReg.Promotions = []promotionInfo{promotionInfo{promotionUUID, 0, false, maturityDate.Unix() * 1000}}
+	grantReg.Promotions = []promotionInfo{{promotionUUID, 0, false, maturityDate.Unix() * 1000}}
 	serializedGrants, err := json.Marshal(grantReg)
 	if err != nil {
 		log.Fatalln(err)

--- a/bin/get-cert-fingerprint/main.go
+++ b/bin/get-cert-fingerprint/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/brave-intl/bat-go/utils/pindialer"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	flag.Usage = func() {
+		log.Printf("A helper for fetching tls fingerprint info for pinning.\n\n")
+		log.Printf("Usage:\n\n")
+		log.Printf("        %s HOST:PORT...", os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if len(flag.Args()) < 1 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	for _, address := range flag.Args() {
+		fmt.Println("Dialing", address)
+		c, err := tls.Dial("tcp", address, nil)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		prints, err := pindialer.GetFingerprints(c)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		for key, value := range prints {
+			fmt.Println("Issuer:", key, "Fingerprint:", value)
+		}
+	}
+}

--- a/bin/vault-create-wallet/main.go
+++ b/bin/vault-create-wallet/main.go
@@ -84,4 +84,10 @@ func main() {
 
 	fmt.Printf("Success, registered new keypair and wallet \"%s\"\n", name)
 	fmt.Printf("Uphold card ID %s", wallet.Info.ProviderID)
+	_, err = client.Logical().Write("wallets/"+name, map[string]interface{}{
+		"providerId": wallet.Info.ProviderID,
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
 }

--- a/controllers/grants.go
+++ b/controllers/grants.go
@@ -31,10 +31,11 @@ func GrantsRouter() chi.Router {
 		if err != nil {
 			panic("THROTTLE_GRANT_REQUESTS was provided but not a valid number")
 		}
-		r.Use(chiware.Throttle(int(throttle)))
+		r.Method("POST", "/", chiware.Throttle(int(throttle))(middleware.InstrumentHandlerFunc("RedeemGrants", RedeemGrants)))
+	} else {
+		r.Post("/", middleware.InstrumentHandlerFunc("RedeemGrants", RedeemGrants))
 	}
 	r.Put("/{grantId}", middleware.InstrumentHandlerFunc("ClaimGrant", ClaimGrant))
-	r.Post("/", middleware.InstrumentHandlerFunc("RedeemGrants", RedeemGrants))
 	return r
 }
 

--- a/grant/grant_test.go
+++ b/grant/grant_test.go
@@ -100,13 +100,13 @@ func TestVerifyAndConsume(t *testing.T) {
 	ctx := context.Background()
 	ctx = lg.WithLoggerContext(ctx, logger)
 
-	request := RedeemGrantsRequest{grants, walletInfo, transaction}
+	request := RedeemGrantsRequest{Grants: grants, WalletInfo: walletInfo, Transaction: transaction}
 	_, err = request.VerifyAndConsume(ctx)
 	if err == nil {
 		t.Error("Should not be able to redeem without a valid claim on a grant")
 	}
 
-	claimReq := ClaimGrantRequest{walletInfo}
+	claimReq := ClaimGrantRequest{WalletInfo: walletInfo}
 	err = claimReq.Claim(ctx, "18f7cada-2e9c-4c6e-a541-b2032c43a92e")
 	if err != nil {
 		t.Error("Claim failed")
@@ -131,7 +131,7 @@ func TestVerifyAndConsume(t *testing.T) {
 		t.Error("Claim failed")
 	}
 
-	request = RedeemGrantsRequest{grants, walletInfo, transaction}
+	request = RedeemGrantsRequest{Grants: grants, WalletInfo: walletInfo, Transaction: transaction}
 	_, err = request.VerifyAndConsume(ctx)
 	if err == nil {
 		t.Error("expected re-redeem with the same wallet and promotion to fail")

--- a/grant/grant_test.go
+++ b/grant/grant_test.go
@@ -18,14 +18,17 @@ import (
 func TestFromCompactJWS(t *testing.T) {
 	GrantSignatorPublicKeyHex = "f2eb37b5eb30ad5b888c680ab8848a46fc2a6be81324de990ad20dc9b6e569fe"
 	registerGrantInstrumentation = false
-	InitGrantService(nil)
+	err := InitGrantService(nil)
+	if err != nil {
+		t.Error("unexpected error")
+	}
 
 	expectedGrantJSON := []byte(`{"altcurrency":"BAT","grantId":"9614ade7-58af-4df0-86c6-2f70051b43de","probi":"30000000000000000000","promotionId":"880309fc-df27-40a8-8d51-9cf39885e61d","maturityTime":1511769862,"expiryTime":1513843462}`)
 
 	jwsGrant := "eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiI5NjE0YWRlNy01OGFmLTRkZjAtODZjNi0yZjcwMDUxYjQzZGUiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiI4ODAzMDlmYy1kZjI3LTQwYTgtOGQ1MS05Y2YzOTg4NWU2MWQiLCJtYXR1cml0eVRpbWUiOjE1MTE3Njk4NjIsImV4cGlyeVRpbWUiOjE1MTM4NDM0NjJ9.OOEBJUHPE21OyFw5Vq1tRTxYQc7aEL-KL5Lb4nb1TZn_3LFkXEPY7bNo0GhJ6k9X2UkZ19rnfBbpXHKuqBupDA"
 
 	expectedGrant := Grant{}
-	err := json.Unmarshal(expectedGrantJSON, &expectedGrant)
+	err = json.Unmarshal(expectedGrantJSON, &expectedGrant)
 	if err != nil {
 		t.Error("unexpected error")
 	}
@@ -49,7 +52,10 @@ func TestVerifyAndConsume(t *testing.T) {
 	refreshBalance = false
 	testSubmit = false
 	registerGrantInstrumentation = false
-	InitGrantService(nil)
+	err := InitGrantService(nil)
+	if err != nil {
+		t.Error("unexpected error")
+	}
 
 	// Populate grant wallet balance to pass check
 	oneHundred, err := decimal.NewFromString("100")
@@ -101,7 +107,10 @@ func TestVerifyAndConsume(t *testing.T) {
 	}
 
 	claimReq := ClaimGrantRequest{walletInfo}
-	claimReq.Claim(ctx, "18f7cada-2e9c-4c6e-a541-b2032c43a92e")
+	err = claimReq.Claim(ctx, "18f7cada-2e9c-4c6e-a541-b2032c43a92e")
+	if err != nil {
+		t.Error("Claim failed")
+	}
 
 	_, err = request.VerifyAndConsume(ctx)
 	if err != nil {
@@ -117,7 +126,10 @@ func TestVerifyAndConsume(t *testing.T) {
 	grants = []string{"eyJhbGciOiJFZERTQSIsImtpZCI6IiJ9.eyJhbHRjdXJyZW5jeSI6IkJBVCIsImdyYW50SWQiOiI1MzZjNWZhZC0zYWJiLTQwM2UtOWI5Mi1kNjE5ZDc0YjNhZjQiLCJwcm9iaSI6IjMwMDAwMDAwMDAwMDAwMDAwMDAwIiwicHJvbW90aW9uSWQiOiJmNmQwNDg0Yy1kNzA5LTRjYTYtOWJhMS1lN2Q5MTI3YTQxOTAiLCJtYXR1cml0eVRpbWUiOjE1MTQ5MjM3MTMsImV4cGlyeVRpbWUiOjIyOTI2MTAxMTN9.Y5QruXFJVV0qqRauP3ah4UAHk6TgtNPySkbq3VBv3dCKpAvYmSnfBRipKjVCicP2s0lQQn8Rcu3aIP4VDBCjDQ"}
 
 	// claim this grant as well to ensure we are testing re-redeem with same wallet and promotion
-	claimReq.Claim(ctx, "f87e7fb4-0f80-40ad-b092-84f70e448421")
+	err = claimReq.Claim(ctx, "f87e7fb4-0f80-40ad-b092-84f70e448421")
+	if err != nil {
+		t.Error("Claim failed")
+	}
 
 	request = RedeemGrantsRequest{grants, walletInfo, transaction}
 	_, err = request.VerifyAndConsume(ctx)

--- a/settlement/README.md
+++ b/settlement/README.md
@@ -8,35 +8,35 @@ echo "export VAULT_ADDR=http://127.0.0.1:8200" >> ~/.profile
 export VAULT_ADDR=http://127.0.0.1:8200
 
 # start vault server
-vault server -config=config.hcl
+./vault server -config=config.hcl
 
 # initialize
-vault-init -key-shares=1 -key-threshold=1 GPG_PUB_KEY_FILE...
+./vault-init -key-shares=1 -key-threshold=1 GPG_PUB_KEY_FILE...
 
 # unseal vault
-gpg -d SHARE.GPG | vault-unseal
+gpg -d SHARE.GPG | ./vault-unseal
 ```
 
 ## Running settlement
 
 On the offline computer, in one window run:
 ```
-vault server -config=config.hcl
+./vault server -config=config.hcl
 ```
 
 In another run:
 ```
-gpg -d SHARE.GPG | vault-unseal
+gpg -d SHARE.GPG | ./vault-unseal
 ```
 
 You are now ready to transact
 ```
-vault-sign-settlement -in <SETTLEMENT_REPORT.JSON> <SETTLEMENT_WALLET_CARD_ID>
+./vault-sign-settlement -in <SETTLEMENT_REPORT.JSON> <SETTLEMENT_WALLET_CARD_ID>
 ```
 
 Finally seal the vault:
 ```
-vault operator seal
+./vault operator seal
 ```
 You can now stop the server instance.
 

--- a/settlement/config.hcl
+++ b/settlement/config.hcl
@@ -1,5 +1,5 @@
 storage "file" {
-  path = "/srv/vault/data"
+  path = "./vault-data"
 }
 
 listener "tcp" {

--- a/utils/kv/kv.go
+++ b/utils/kv/kv.go
@@ -10,7 +10,7 @@ type UnsafeMapKv struct {
 
 // NewUnsafe creates a new UnsafeMapKv
 func NewUnsafe() *UnsafeMapKv {
-	return &UnsafeMapKv{map[string]string{}}
+	return &UnsafeMapKv{m: map[string]string{}}
 }
 
 // Set the key to value, updating possible existing if upsert is true

--- a/utils/kv/kv_test.go
+++ b/utils/kv/kv_test.go
@@ -3,7 +3,7 @@ package kv
 import "testing"
 
 func TestMapKv(t *testing.T) {
-	store := UnsafeMapKv{map[string]string{}}
+	store := UnsafeMapKv{m: map[string]string{}}
 
 	if r, err := store.Set("FOO", "BAR", -1, true); !r || err != nil {
 		t.Error("Set to empty kv store should always succeed")

--- a/wallet/provider/uphold/uphold.go
+++ b/wallet/provider/uphold/uphold.go
@@ -92,7 +92,7 @@ func New(info wallet.Info, privKey crypto.Signer, pubKey httpsignature.Verifier)
 	if !info.AltCurrency.IsValid() {
 		return nil, errors.New("A wallet must have a valid altcurrency")
 	}
-	return &Wallet{info, privKey, pubKey}, nil
+	return &Wallet{Info: info, PrivKey: privKey, PubKey: pubKey}, nil
 }
 
 // FromWalletInfo returns an uphold wallet matching the provided wallet info
@@ -142,7 +142,7 @@ type createCardRequest struct {
 
 // Register a wallet with Uphold with label
 func (w *Wallet) Register(label string) error {
-	reqPayload := createCardRequest{label, w.Info.AltCurrency, w.PubKey.String()}
+	reqPayload := createCardRequest{Label: label, AltCurrency: w.Info.AltCurrency, PublicKey: w.PubKey.String()}
 	payload, err := json.Marshal(reqPayload)
 	if err != nil {
 		return err
@@ -235,7 +235,7 @@ type transactionRequest struct {
 }
 
 func (w *Wallet) signTransfer(altcurrency altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string) (*http.Request, error) {
-	transferReq := transactionRequest{denomination{altcurrency.FromProbi(probi), &altcurrency}, destination, message}
+	transferReq := transactionRequest{Denomination: denomination{Amount: altcurrency.FromProbi(probi), Currency: &altcurrency}, Destination: destination, Message: message}
 	unsignedTransaction, err := json.Marshal(&transferReq)
 	if err != nil {
 		return nil, err

--- a/wallet/provider/uphold/uphold.go
+++ b/wallet/provider/uphold/uphold.go
@@ -45,9 +45,12 @@ var (
 		"sandbox": "https://api-sandbox.uphold.com",
 		"prod":    "https://api.uphold.com",
 	}[environment]
-
-	upholdCertFingerprint = "YM2Dejq4VOK/7CorxWBIcHnhKlHzvgFgrLYchGroakc="
-	client                *http.Client
+	upholdCertFingerprint = map[string]string{
+		"":        "YM2Dejq4VOK/7CorxWBIcHnhKlHzvgFgrLYchGroakc=", // os.Getenv() will return empty string if not set
+		"sandbox": "YM2Dejq4VOK/7CorxWBIcHnhKlHzvgFgrLYchGroakc=",
+		"prod":    "U3Ny8QcC3uKPNnMK3a3V4W4nby2YjSeS+/+0XHFhDs4=",
+	}[environment]
+	client *http.Client
 )
 
 func init() {

--- a/wallet/provider/uphold/uphold_test.go
+++ b/wallet/provider/uphold/uphold_test.go
@@ -55,7 +55,7 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	destWallet := &Wallet{info, privateKey, publicKey}
+	destWallet := &Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
 	err = destWallet.Register("bat-go test card")
 	if err != nil {
 		t.Error(err)
@@ -143,7 +143,7 @@ func TestTransactions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	donorWallet := &Wallet{donorInfo, donorPrivateKey, donorPublicKey}
+	donorWallet := &Wallet{Info: donorInfo, PrivKey: donorPrivateKey, PubKey: donorPublicKey}
 
 	var info wallet.Info
 	info.Provider = "uphold"
@@ -158,7 +158,7 @@ func TestTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	destWallet := &Wallet{info, privateKey, publicKey}
+	destWallet := &Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
 	err = destWallet.Register("bat-go test transaction card")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
for context we pin the Uphold cert - they've switched their prod cert to digicert.

this PR adds a new tool for easily querying the current cert fingerprint needed to pin, and updates the pin for their production environment.

there are also some README tweaks and changes to the makefile to make cross compiling the settlement tools for non-mac easier