### PR TITLE
Add basic rate limiting

### DIFF
--- a/bin/grant-server/main.go
+++ b/bin/grant-server/main.go
@@ -53,6 +53,7 @@ func setupRouter(ctx context.Context, logger *logrus.Logger) (context.Context, *
 	r.Use(chiware.Heartbeat("/"))
 	r.Use(chiware.Timeout(60 * time.Second))
 	r.Use(middleware.BearerToken)
+	r.Use(middleware.RateLimiter())
 	if logger != nil {
 		// Also handles panic recovery
 		r.Use(middleware.RequestLogger(logger))

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/superp00t/niceware v0.0.0-20170614015008-16cb30c384b5
+	github.com/throttled/throttled v2.2.4+incompatible // indirect
 	github.com/tyler-smith/go-bip39 v0.0.0-20180716170310-95c66720ed7a
 	golang.org/x/crypto v0.0.0-20190909091759-094676da4a83
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.4.0
 	github.com/superp00t/niceware v0.0.0-20170614015008-16cb30c384b5
-	github.com/throttled/throttled v2.2.4+incompatible // indirect
+	github.com/throttled/throttled v2.2.4+incompatible
 	github.com/tyler-smith/go-bip39 v0.0.0-20180716170310-95c66720ed7a
 	golang.org/x/crypto v0.0.0-20190909091759-094676da4a83
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b

--- a/go.sum
+++ b/go.sum
@@ -296,6 +296,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/superp00t/niceware v0.0.0-20170614015008-16cb30c384b5 h1:UOKr78K7smMjkKuwZjbOCzIFTUhIUzXc5+tYeaPRirE=
 github.com/superp00t/niceware v0.0.0-20170614015008-16cb30c384b5/go.mod h1:asllDl3XCEQ1lFPD4Y1juAn5p35Zd4ghNGcDKN7U7dU=
+github.com/throttled/throttled v2.2.4+incompatible h1:aVKdoH/qT5Mo1Lm/678OkX2pFg7aRpHlTn1tfgaSKxs=
+github.com/throttled/throttled v2.2.4+incompatible/go.mod h1:0BjlrEGQmvxps+HuXLsyRdqpSRvJpq0PNIsOtqP9Nos=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tyler-smith/go-bip39 v0.0.0-20180716170310-95c66720ed7a h1:F21jMjYNPHd0O+0xzq6C9isWiLu9H+L1MU0I/1AJ4+Y=
 github.com/tyler-smith/go-bip39 v0.0.0-20180716170310-95c66720ed7a/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/throttled/throttled"
+	"github.com/throttled/throttled/store/memstore"
+)
+
+// RateLimiter rate limits the number of requests a
+// user from a single IP address can make
+func RateLimiter() func(http.Handler) http.Handler {
+	store, err := memstore.New(65536)
+	if err != nil {
+		log.Fatal(err)
+	}
+	quota := throttled.RateQuota{throttled.PerMin(5), 5}
+	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	httpRateLimiter := throttled.HTTPRateLimiter{
+		RateLimiter: rateLimiter,
+		VaryBy: &throttled.VaryBy{
+			RemoteAddr: true,
+			Path:       true,
+		},
+	}
+
+	return httpRateLimiter.RateLimit
+}

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -15,7 +15,10 @@ func RateLimiter() func(http.Handler) http.Handler {
 	if err != nil {
 		log.Fatal(err)
 	}
-	quota := throttled.RateQuota{throttled.PerMin(5), 5}
+	quota := throttled.RateQuota{
+		MaxRate:  throttled.PerMin(5),
+		MaxBurst: 5,
+	}
 	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
5 requests per path per remote_addr across the whole app.

This is perhaps too aggressive, and we are still pretty exposed so we should probably revisit in the future

This add a new dep, [throttled](https://github.com/throttled/throttled)