### PR TITLE
added unique metrics table and used for active wallets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ GIT_VERSION := $(shell git describe --abbrev=8 --dirty --always --tags)
 VAULT_VERSION=0.10.1
 _BINS := $(wildcard bin/*)
 TEST_PKG?=./...
+TEST_FLAGS= $(TEST_PKG)
+ifdef TEST_RUN
+	TEST_FLAGS = $(TEST_PKG) --run=$(TEST_RUN)
+endif
 
 ifdef GOOS
 	BINS := $(_BINS:bin/%=target/$(GOOS)_$(GOARCH)/%)
@@ -76,7 +80,7 @@ download-vault:
 	cd target/settlement-tools && unzip -o vault_$(VAULT_VERSION)_$(GOOS)_$(GOARCH).zip vault && rm vault_$(VAULT_VERSION)_*
 
 test:
-	go test -v -p 1 --tags=$(TEST_TAGS) $(TEST_PKG) --run=$(TEST_RUN)
+	go test -v -p 1 --tags=$(TEST_TAGS) $(TEST_FLAGS)
 
 format:
 	gofmt -s -w ./

--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-const currentMigrationVersion = 9
+const currentMigrationVersion = 10
 
 var (
 	// dbInstanceClassToMaxConn -  https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - grant
   postgres:
     container_name: grant-postgres
-    image: postgres:10.4
+    image: mmclau14/postgres-extended:latest
     ports:
       - "3401:5432"
     environment:

--- a/migrations/0010_hll_active_users.down.sql
+++ b/migrations/0010_hll_active_users.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE if exists daily_unique_metrics;
+DROP EXTENSION IF EXISTS hll;

--- a/migrations/0010_hll_active_users.up.sql
+++ b/migrations/0010_hll_active_users.up.sql
@@ -1,0 +1,13 @@
+CREATE EXTENSION IF NOT EXISTS hll;
+
+-- Create the destination table
+CREATE TABLE IF NOT EXISTS daily_unique_metrics (
+  date          DATE NOT NULL,
+  activity_type TEXT NOT NULL,
+  wallets       HLL,
+  PRIMARY KEY   (date, activity_type)
+);
+
+ALTER TABLE daily_unique_metrics
+ADD CONSTRAINT check_activity_type
+CHECK(activity_type in ('active'));

--- a/promotion/controllers.go
+++ b/promotion/controllers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/brave-intl/bat-go/utils/requestutils"
 	"github.com/brave-intl/bat-go/utils/validators"
+	"github.com/getsentry/raven-go"
 	"github.com/go-chi/chi"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -154,6 +155,14 @@ func GetAvailablePromotions(service *Service) handlers.AppHandler {
 				"id": promotion.ID.String(),
 			}).Inc()
 		}
+
+		if walletID != nil {
+			err = service.CountActiveWallet(*walletID)
+			if err != nil {
+				raven.CaptureError(err, nil)
+			}
+		}
+
 		return nil
 	})
 }

--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -82,6 +82,8 @@ type Datastore interface {
 	CreateTransaction(orderID uuid.UUID, externalTransactionID string, status string, currency string, kind string, amount decimal.Decimal) (*Transaction, error)
 	// GetSumForTransactions gets a decimal sum of for transactions for an order
 	GetSumForTransactions(orderID uuid.UUID) (decimal.Decimal, error)
+	// CountActiveWallet counts an active user
+	CountActiveWallet(walletID uuid.UUID) error
 }
 
 // ReadOnlyDatastore includes all database methods that can be made with a read only db connection

--- a/promotion/metrics.go
+++ b/promotion/metrics.go
@@ -1,0 +1,34 @@
+package promotion
+
+import (
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+)
+
+// DailyUniqueMetricCounts holds a single metrics data
+type DailyUniqueMetricCounts struct {
+	Date         time.Time `db:"date"`
+	ActivityType string    `db:"activity_type"`
+	Wallets      int       `db:"wallets"`
+}
+
+// CountActiveWallet count the active user
+func (pg *Postgres) CountActiveWallet(walletID uuid.UUID) error {
+	statement := `
+	INSERT INTO daily_unique_metrics(date, activity_type, wallets)
+	VALUES (NOW()::DATE, $2, hll_add(hll_empty(), hll_hash_text($1)))
+	ON CONFLICT (date, activity_type)
+		DO UPDATE
+		SET
+			wallets = hll_add(daily_unique_metrics.wallets, hll_hash_text($1))
+		WHERE
+				daily_unique_metrics.date = NOW()::DATE
+		AND daily_unique_metrics.activity_type = $2`
+	_, err := pg.DB.Exec(
+		statement,
+		walletID.String(),
+		"active",
+	)
+	return err
+}

--- a/promotion/metrics_test.go
+++ b/promotion/metrics_test.go
@@ -1,0 +1,85 @@
+package promotion
+
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/suite"
+)
+
+type MetricsTestSuite struct {
+	suite.Suite
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
+
+func (suite *MetricsTestSuite) SetupSuite() {
+	pg, err := NewPostgres("", false)
+	suite.Require().NoError(err, "Failed to get postgres conn")
+
+	m, err := pg.NewMigrate()
+	suite.Require().NoError(err, "Failed to create migrate instance")
+
+	ver, dirty, _ := m.Version()
+	if dirty {
+		suite.Require().NoError(m.Force(int(ver)))
+	}
+	if ver > 0 {
+		suite.Require().NoError(m.Down(), "Failed to migrate down cleanly")
+	}
+
+	suite.Require().NoError(pg.Migrate(), "Failed to fully migrate")
+
+	enableSuggestionJob = true
+}
+
+func (suite *MetricsTestSuite) SetupTest() {
+	suite.clearDb()
+}
+
+func (suite *MetricsTestSuite) TearDownTest() {
+	suite.clearDb()
+}
+
+func (suite *MetricsTestSuite) clearDb() {
+	tables := []string{"claim_creds", "claims", "wallets", "issuers", "promotions", "daily_unique_metrics"}
+
+	pg, err := NewPostgres("", false)
+	suite.Require().NoError(err, "Failed to get postgres conn")
+
+	for _, table := range tables {
+		_, err = pg.DB.Exec("delete from " + table)
+		suite.Require().NoError(err, "Failed to get clean table")
+	}
+}
+
+func (suite *MetricsTestSuite) TestCountActiveWallet() {
+	pg, err := NewPostgres("", false)
+	suite.Require().NoError(err, "Failed to get postgres conn")
+
+	var ids []uuid.UUID
+	for i := 0; i < 4; i++ {
+		id := uuid.NewV4()
+		err := pg.CountActiveWallet(id)
+		suite.Require().NoError(err, "inserting should not fail")
+		ids = append(ids, id)
+	}
+
+	for i := 0; i < len(ids); i++ {
+		err := pg.CountActiveWallet(ids[i])
+		suite.Require().NoError(err, "inserting should not fail")
+	}
+
+	var dailyUniques []DailyUniqueMetricCounts
+	err = pg.DB.Select(&dailyUniques, `
+	SELECT
+		date,
+		activity_type,
+		hll_cardinality(wallets) as wallets
+	FROM daily_unique_metrics`)
+	suite.Assert().NoError(err)
+	suite.Assert().Equal(1, len(dailyUniques), "only one activity was recorded")
+	suite.Assert().Equal(4, dailyUniques[0].Wallets, "user has been seen")
+}

--- a/promotion/service.go
+++ b/promotion/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/linkedin/goavro"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	uuid "github.com/satori/go.uuid"
 	kafka "github.com/segmentio/kafka-go"
 	"golang.org/x/crypto/ed25519"
 )
@@ -364,4 +365,9 @@ func (service *Service) RunNextSuggestionJob(ctx context.Context) (bool, error) 
 // RunNextDrainJob takes the next drain job and completes it
 func (service *Service) RunNextDrainJob(ctx context.Context) (bool, error) {
 	return service.datastore.RunNextDrainJob(ctx, service)
+}
+
+// CountActiveWallet counts an active user
+func (service *Service) CountActiveWallet(paymentID uuid.UUID) error {
+	return service.datastore.CountActiveWallet(paymentID)
 }


### PR DESCRIPTION
fixup #206 
need to measure daily active users, best way to do this currently is to measure wallets since wallets are hit once on browser startup to check for available promotions.
hll allows us to keep a space conscious approximation of our daily active users while keeping anonymity