### PR TITLE
add x request id to middleware and clients

### DIFF
--- a/bin/grant-server/main.go
+++ b/bin/grant-server/main.go
@@ -70,6 +70,7 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	r.Use(chiware.Timeout(60 * time.Second))
 	r.Use(middleware.BearerToken)
 	r.Use(middleware.RateLimiter)
+	r.Use(middleware.RequestIDTransfer)
 	if logger != nil {
 		// Also handles panic recovery
 		r.Use(hlog.NewHandler(*logger))

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496
 	github.com/btcsuite/btcutil v0.0.0-20190316010144-3ac1210f4b38
+	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect
 	github.com/containerd/containerd v1.2.9 // indirect
 	github.com/dhui/dktest v0.3.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/ethereum/go-ethereum v1.7.2
 	github.com/frankban/quicktest v1.4.2 // indirect
+	github.com/getsentry/raven-go v0.2.0 // indirect
 	github.com/getsentry/sentry-go v0.5.1
 	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gocarina/gocsv v0.0.0-20191214001331-e6697589f2e0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCS
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/btcsuite/btcutil v0.0.0-20190316010144-3ac1210f4b38 h1:GbQHMJ2u/geMPV1tbN7i7zARSoPAPuXWa44V0KYvJXU=
 github.com/btcsuite/btcutil v0.0.0-20190316010144-3ac1210f4b38/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
+github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 h1:JLaf/iINcLyjwbtTsCJjc6rtlASgHeIJPrB6QmwURnA=
+github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -109,6 +111,8 @@ github.com/frankban/quicktest v1.4.2/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsouza/fake-gcs-server v1.7.0/go.mod h1:5XIRs4YvwNbNoz+1JF8j6KLAyDh7RHGAyAK3EP2EsNk=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
+github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
+github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/getsentry/sentry-go v0.5.1 h1:MIPe7ScHADsrK2vznqmhksIUFxq7m0JfTh+ZIMkI+VQ=
 github.com/getsentry/sentry-go v0.5.1/go.mod h1:B8H7x8TYDPkeWPRzGpIiFO97LZP6rL8A3hEt8lUItMw=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=

--- a/middleware/request_id.go
+++ b/middleware/request_id.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"context"
+	"crypto/sha256"
+	"net/http"
+
+	"github.com/brave-intl/bat-go/utils/requestutils"
+	uuid "github.com/satori/go.uuid"
+	"github.com/shengdoushi/base58"
+)
+
+// RequestIDTransfer transfers the request id from header to context
+func RequestIDTransfer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := r.Header.Get(requestutils.RequestIDHeaderKey)
+		if reqID == "" {
+			// generate one if one does not yet exist
+			bytes := sha256.Sum256(uuid.NewV4().Bytes())
+			reqID = base58.Encode(bytes[:], base58.BitcoinAlphabet)[:16]
+		}
+		w.Header().Set(requestutils.RequestIDHeaderKey, reqID)
+		ctx := context.WithValue(r.Context(), requestutils.RequestID, reqID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/utils/clients/client.go
+++ b/utils/clients/client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/brave-intl/bat-go/utils/closers"
 	"github.com/brave-intl/bat-go/utils/handlers"
+	"github.com/brave-intl/bat-go/utils/requestutils"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
 )
@@ -103,7 +104,7 @@ func (c *SimpleHTTPClient) NewRequest(
 		req.Header.Add("content-type", "application/json")
 	}
 
-	handlers.TransferRequestID(ctx, req)
+	requestutils.SetRequestID(ctx, req)
 	logOut(ctx, "request", *req.URL, 0, req.Header, body)
 
 	req.Header.Set("authorization", "Bearer "+c.AuthToken)

--- a/utils/clients/client.go
+++ b/utils/clients/client.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/brave-intl/bat-go/utils/closers"
-	"github.com/brave-intl/bat-go/utils/handlers"
+	"github.com/brave-intl/bat-go/utils/errors"
 	"github.com/brave-intl/bat-go/utils/requestutils"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog/log"
@@ -42,7 +42,7 @@ func New(serverURL string, authToken string) (*SimpleHTTPClient, error) {
 	}, nil
 }
 
-func (c *SimpleHTTPClient) newRequest(
+func (c *SimpleHTTPClient) request(
 	method string,
 	resolvedURL string,
 	buf io.Reader,
@@ -62,13 +62,13 @@ func (c *SimpleHTTPClient) newRequest(
 	return req, nil
 }
 
-// NewRequest creaates a request, JSON encoding the body passed
-func (c *SimpleHTTPClient) NewRequest(
+// newRequest creaates a request, JSON encoding the body passed
+func (c *SimpleHTTPClient) newRequest(
 	ctx context.Context,
 	method,
 	path string,
 	body interface{},
-) (*http.Request, error) {
+) (*http.Request, int, error) {
 	var buf io.ReadWriter
 	resolvedURL := c.BaseURL.ResolveReference(&url.URL{Path: path})
 
@@ -76,40 +76,46 @@ func (c *SimpleHTTPClient) NewRequest(
 		buf = new(bytes.Buffer)
 		err := json.NewEncoder(buf).Encode(body)
 		if err != nil {
-			return nil, NewHTTPError(err, ErrUnableToEncodeBody, 0, nil)
+			return nil, 0, errors.Wrap(err, ErrUnableToEncodeBody)
 		}
 	}
 
-	req, err := c.newRequest(method, resolvedURL.String(), buf)
+	req, err := c.request(method, resolvedURL.String(), buf)
 	if err != nil {
 		status := 0
-		message := "request"
 		switch err.(type) {
 		case url.EscapeError:
 			status = http.StatusBadRequest
-			message = "request: unable to escape url"
+			err = errors.Wrap(err, ErrUnableToEscapeURL)
 		case url.InvalidHostError:
 			status = http.StatusBadRequest
-			message = "request: invalid host"
+			err = errors.Wrap(err, ErrInvalidHost)
 		}
-		return nil, handlers.AppError{
-			Cause:   err,
-			Code:    status,
-			Message: message,
-		}
+		return nil, status, err
 	}
 
 	req.Header.Set("accept", "application/json")
 	if body != nil {
 		req.Header.Add("content-type", "application/json")
 	}
-
 	requestutils.SetRequestID(ctx, req)
-	logOut(ctx, "request", *req.URL, 0, req.Header, body)
-
 	req.Header.Set("authorization", "Bearer "+c.AuthToken)
+	return req, 0, nil
+}
 
-	return req, nil
+// NewRequest wraps the new request with a particular error type
+func (c *SimpleHTTPClient) NewRequest(
+	ctx context.Context,
+	method,
+	path string,
+	body interface{},
+) (*http.Request, error) {
+	req, status, err := c.newRequest(ctx, method, path, body)
+	if err != nil {
+		return nil, NewHTTPError(err, "request", status, body)
+	}
+	logOut(ctx, "request", *req.URL, 0, req.Header, body)
+	return req, err
 }
 
 // Do the specified http request, decoding the JSON result into v
@@ -135,19 +141,19 @@ func (c *SimpleHTTPClient) do(
 		if v != nil {
 			err = json.NewDecoder(resp.Body).Decode(v)
 			if err != nil {
-				return resp, NewHTTPError(err, ErrUnableToDecode, resp.StatusCode, v)
+				return resp, errors.Wrap(err, ErrUnableToDecode)
 			}
 		}
 		return resp, nil
 	}
-	return resp, NewHTTPError(err, ErrProtocolError, resp.StatusCode, v)
+	return resp, errors.Wrap(err, ErrProtocolError)
 }
 
 // Do the specified http request, decoding the JSON result into v
 func (c *SimpleHTTPClient) Do(ctx context.Context, req *http.Request, v interface{}) (*http.Response, error) {
 	resp, err := c.do(ctx, req, v)
 	if err != nil {
-		return resp, err
+		return resp, NewHTTPError(err, "response", resp.StatusCode, v)
 	}
 	logOut(ctx, "response", *req.URL, resp.StatusCode, resp.Header, v)
 	return resp, nil

--- a/utils/context/wrap.go
+++ b/utils/context/wrap.go
@@ -1,6 +1,8 @@
 package context
 
-import "context"
+import (
+	"context"
+)
 
 // wrapper allows for wrapping the values of a context with the cancellation of a new one
 // approach from https://github.com/posener/ctxutil

--- a/utils/handlers/handlers.go
+++ b/utils/handlers/handlers.go
@@ -97,7 +97,7 @@ func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				scope.SetTags(map[string]string{
 					"reqID": requestutils.GetRequestID(r.Context()),
 				})
-				sentry.CaptureException(e)
+				sentry.CaptureMessage(e.Error())
 			})
 		}
 

--- a/utils/handlers/handlers.go
+++ b/utils/handlers/handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,14 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
+)
+
+type requestID string
+
+var (
+	requestIDHeaderKey = "x-request-id"
+	// RequestID holds the type for request ids
+	RequestID = requestID(requestIDHeaderKey)
 )
 
 // AppError is error type for json HTTP responses
@@ -89,9 +98,16 @@ type AppHandler func(http.ResponseWriter, *http.Request) *AppError
 // ServeHTTP responds via the passed handler and handles returned errors
 func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "application/json")
+	reqID := r.Header.Get(requestIDHeaderKey)
+	w.Header().Set(requestIDHeaderKey, reqID)
+	ctx := context.WithValue(r.Context(), RequestID, reqID)
+	r = r.WithContext(ctx)
 
 	if e := fn(w, r); e != nil {
 		if e.Code >= 500 && e.Code <= 599 {
+			info := map[string]string{
+				"reqID": reqID,
+			}
 			if e.Cause != nil {
 				sentry.CaptureException(fmt.Errorf("%s: %w", e.Message, e.Cause))
 			} else {
@@ -110,5 +126,13 @@ func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		e.ServeHTTP(w, r)
+	}
+}
+
+// TransferRequestID transfers a request id from a context to a request header
+func TransferRequestID(ctx context.Context, r *http.Request) {
+	reqID, ok := ctx.Value(RequestID).(string)
+	if ok && len(reqID) != 0 {
+		r.Header.Set(requestIDHeaderKey, reqID)
 	}
 }

--- a/utils/handlers/handlers.go
+++ b/utils/handlers/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/brave-intl/bat-go/utils/requestutils"
 	"github.com/getsentry/sentry-go"
 	"github.com/rs/zerolog"
 )
@@ -92,14 +93,12 @@ func (fn AppHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if e := fn(w, r); e != nil {
 		if e.Code >= 500 && e.Code <= 599 {
-			info := map[string]string{
-				"reqID": r.Header.Get(""),
-			}
-			if e.Cause != nil {
-				sentry.CaptureException(fmt.Errorf("%s: %w", e.Message, e.Cause))
-			} else {
-				sentry.CaptureMessage(e.Message)
-			}
+			sentry.WithScope(func(scope *sentry.Scope) {
+				scope.SetTags(map[string]string{
+					"reqID": requestutils.GetRequestID(r.Context()),
+				})
+				sentry.CaptureException(e)
+			})
 		}
 
 		l := zerolog.Ctx(r.Context())

--- a/utils/requestutils/requestutils.go
+++ b/utils/requestutils/requestutils.go
@@ -1,15 +1,25 @@
 package requestutils
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/brave-intl/bat-go/utils/closers"
 	errorutils "github.com/brave-intl/bat-go/utils/errors"
 )
 
-var payloadLimit10MB = int64(1024 * 1024 * 10)
+type requestID string
+
+var (
+	payloadLimit10MB = int64(1024 * 1024 * 10)
+	// RequestIDHeaderKey is the request header key
+	RequestIDHeaderKey = "x-request-id"
+	// RequestID holds the type for request ids
+	RequestID = requestID(RequestIDHeaderKey)
+)
 
 // ReadWithLimit reads an io reader with a limit and closes
 func ReadWithLimit(body io.Reader, limit int64) ([]byte, error) {
@@ -37,4 +47,17 @@ func ReadJSON(body io.Reader, intr interface{}) error {
 		return errorutils.Wrap(err, "error unmarshalling body")
 	}
 	return nil
+}
+
+// SetRequestID transfers a request id from a context to a request header
+func SetRequestID(ctx context.Context, r *http.Request) {
+	r.Header.Set(RequestIDHeaderKey, GetRequestID(ctx))
+}
+
+// GetRequestID gets the request id
+func GetRequestID(ctx context.Context) string {
+	if reqID, ok := ctx.Value(RequestID).(string); ok {
+		return reqID
+	}
+	return ""
 }


### PR DESCRIPTION
It would be useful to be able to track a request from end to end, and through requests as a client
added a middleware and used in client request code, logging where appropriate