### PR TITLE
ignore subsequent metric checks

### DIFF
--- a/grant/service.go
+++ b/grant/service.go
@@ -111,6 +111,7 @@ func InitService(datastore Datastore, roDatastore ReadOnlyDatastore) (*Service, 
 
 		prometheus.MustRegister(claimedGrantsCounter)
 		prometheus.MustRegister(redeemedGrantsCounter)
+		registerGrantInstrumentation = false
 	}
 
 	return gs, nil


### PR DESCRIPTION
this pr is useful when generating multiple service objects so that the prometheus.mustregister method does not run twice and panic