### PR TITLE
re-enable legacy promotion (re)claim

### DIFF
--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -360,10 +360,6 @@ func (pg *Postgres) ClaimForWallet(promotion *Promotion, issuer *Issuer, wallet 
 		_ = tx.Rollback()
 		panic("impossible number of claims")
 	} else if len(claims) == 1 {
-		if os.Getenv("ENV") != "local" {
-			_ = tx.Rollback()
-			return nil, errors.New("legacy promotion is not available to claim")
-		}
 		legacyClaimExists = true
 	}
 


### PR DESCRIPTION
It was originally disabled in https://github.com/brave-intl/bat-go/pull/239

Then changed when normal claims were re-enabled https://github.com/brave-intl/bat-go/pull/242