### PR TITLE
added tx rollback abstraction

### DIFF
--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/brave-intl/bat-go/utils/metrics"
+	"github.com/getsentry/raven-go"
 	migrate "github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/jmoiron/sqlx"
@@ -131,4 +132,12 @@ func NewPostgres(databaseURL string, performMigration bool, dbStatsPrefix ...str
 	}
 
 	return pg, nil
+}
+
+// RollbackTx rolls back a transaction (useful with defer)
+func (pg *Postgres) RollbackTx(tx *sqlx.Tx) {
+	err := tx.Rollback()
+	if err != nil {
+		raven.CaptureErrorAndWait(err, nil)
+	}
 }


### PR DESCRIPTION
rolling back a transaction should happen once, when the transaction is first created. 
otherwise we leave ourselves open to too many connections to the db if we forget to rollback and never commit.