### PR TITLE
re-enable CI integration tests by restoring TEST_TAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docker-test:
 	COMMIT=$(GIT_COMMIT) VERSION=$(GIT_VERSION) BUILD_TIME=$(BUILD_TIME) docker-compose \
 		-f docker-compose.yml -f docker-compose.dev.yml up -d vault
 	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))
-	VAULT_TOKEN=$(VAULT_TOKEN) PKG=$(TEST_PKG) RUN=$(TEST_RUN) docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm web make test
+	VAULT_TOKEN=$(VAULT_TOKEN) PKG=$(TEST_PKG) RUN=$(TEST_RUN) docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm dev make test
 
 docker-dev:
 	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ else
 endif
 
 TEST_PKG?=./...
-TEST_FLAGS= $(TEST_PKG)
+TEST_FLAGS= --tags=$(TEST_TAGS) $(TEST_PKG)
 ifdef TEST_RUN
-	TEST_FLAGS = $(TEST_PKG) --run=$(TEST_RUN)
+	TEST_FLAGS = --tags=$(TEST_TAGS) $(TEST_PKG) --run=$(TEST_RUN)
 endif
 
 .PHONY: all bins docker test lint clean

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "3.4"
 
 services:
-  web:
+  dev:
     volumes:
       - ".:/src"
     environment:


### PR DESCRIPTION
restore `TEST_TAGS` which were dropped in https://github.com/brave-intl/bat-go/pull/171 - now integration tests will run as part of CI again