### PR TITLE
Add description/location to order and items

### DIFF
--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -17,7 +17,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-const currentMigrationVersion = 10
+const currentMigrationVersion = 11
 
 var (
 	// dbInstanceClassToMaxConn -  https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html

--- a/migrations/0011_add_properties_to_order.down.sql
+++ b/migrations/0011_add_properties_to_order.down.sql
@@ -1,0 +1,6 @@
+alter table order_items
+drop location,
+drop description;
+
+alter table orders
+drop location;

--- a/migrations/0011_add_properties_to_order.up.sql
+++ b/migrations/0011_add_properties_to_order.up.sql
@@ -1,0 +1,6 @@
+alter table order_items
+add location text,
+add description text;
+
+alter table orders
+add location text;

--- a/payment/order.go
+++ b/payment/order.go
@@ -1,62 +1,41 @@
 package payment
 
 import (
-	"database/sql"
-	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/brave-intl/bat-go/utils/datastore"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
 	macaroon "gopkg.in/macaroon.v2"
 )
 
-// NullString is a type that lets ya get a null field from the database
-type NullString struct {
-	sql.NullString
-}
-
-// MarshalJSON for NullString
-func (ns *NullString) MarshalJSON() ([]byte, error) {
-	if !ns.Valid {
-		return []byte("null"), nil
-	}
-	return json.Marshal(ns.String)
-}
-
-// UnmarshalJSON unmarshalls NullString
-func (ns *NullString) UnmarshalJSON(data []byte) error {
-	ns.String = strings.Trim(string(data), `"`)
-	ns.Valid = true
-	return nil
-}
-
 // Order includes information about a particular order
 type Order struct {
-	ID         uuid.UUID       `json:"id" db:"id"`
-	CreatedAt  time.Time       `json:"createdAt" db:"created_at"`
-	Currency   string          `json:"currency" db:"currency"`
-	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
-	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
-	MerchantID string          `json:"merchantId" db:"merchant_id"`
-	Location   NullString      `json:"location" db:"location"`
-	Status     string          `json:"status" db:"status"`
-	Items      []OrderItem     `json:"items"`
+	ID         uuid.UUID            `json:"id" db:"id"`
+	CreatedAt  time.Time            `json:"createdAt" db:"created_at"`
+	Currency   string               `json:"currency" db:"currency"`
+	UpdatedAt  time.Time            `json:"updatedAt" db:"updated_at"`
+	TotalPrice decimal.Decimal      `json:"totalPrice" db:"total_price"`
+	MerchantID string               `json:"merchantId" db:"merchant_id"`
+	Location   datastore.NullString `json:"location" db:"location"`
+	Status     string               `json:"status" db:"status"`
+	Items      []OrderItem          `json:"items"`
 }
 
 // OrderItem includes information about a particular order item
 type OrderItem struct {
-	ID          uuid.UUID       `json:"id" db:"id"`
-	OrderID     uuid.UUID       `json:"orderId" db:"order_id"`
-	CreatedAt   *time.Time      `json:"createdAt" db:"created_at"`
-	UpdatedAt   *time.Time      `json:"updatedAt" db:"updated_at"`
-	Currency    string          `json:"currency" db:"currency"`
-	Quantity    int             `json:"quantity" db:"quantity"`
-	Price       decimal.Decimal `json:"price" db:"price"`
-	Subtotal    decimal.Decimal `json:"subtotal"`
-	Location    NullString      `json:"location" db:"location"`
-	Description NullString      `json:"description" db:"description"`
+	ID          uuid.UUID            `json:"id" db:"id"`
+	OrderID     uuid.UUID            `json:"orderId" db:"order_id"`
+	CreatedAt   *time.Time           `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time           `json:"updatedAt" db:"updated_at"`
+	Currency    string               `json:"currency" db:"currency"`
+	Quantity    int                  `json:"quantity" db:"quantity"`
+	Price       decimal.Decimal      `json:"price" db:"price"`
+	Subtotal    decimal.Decimal      `json:"subtotal"`
+	Location    datastore.NullString `json:"location" db:"location"`
+	Description datastore.NullString `json:"description" db:"description"`
 }
 
 // CreateOrderItemFromMacaroon creates an order item from a macaroon

--- a/payment/order.go
+++ b/payment/order.go
@@ -1,7 +1,6 @@
 package payment
 
 import (
-	"database/sql"
 	"strconv"
 	"strings"
 	"time"
@@ -19,7 +18,7 @@ type Order struct {
 	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
 	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
 	MerchantID string          `json:"merchantId" db:"merchant_id"`
-	Location   sql.NullString  `json:"location" db:"location"`
+	Location   string          `json:"location" db:"location"`
 	Status     string          `json:"status" db:"status"`
 	Items      []OrderItem     `json:"items"`
 }

--- a/payment/order_test.go
+++ b/payment/order_test.go
@@ -32,6 +32,6 @@ func (suite *OrderTestSuite) TestCreateOrderItemFromMacaroon() {
 	suite.Assert().Equal("BAT", orderItem.Currency)
 	suite.Assert().Equal("5c846da1-83cd-4e15-98dd-8e147a56b6fa", orderItem.ID.String())
 	suite.Assert().Equal("2", orderItem.Price.String())
-	suite.Assert().Equal("coffee coffee coffee", orderItem.Description)
-	suite.Assert().Equal("https://brave.com", orderItem.Location)
+	suite.Assert().Equal("coffee coffee coffee", orderItem.Description.String)
+	suite.Assert().Equal("https://brave.com", orderItem.Location.String)
 }

--- a/payment/order_test.go
+++ b/payment/order_test.go
@@ -1,0 +1,37 @@
+package payment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type OrderTestSuite struct {
+	suite.Suite
+}
+
+func TestOrderTestSuite(t *testing.T) {
+	suite.Run(t, new(OrderTestSuite))
+}
+
+func (suite *OrderTestSuite) TestCreateOrderItemFromMacaroon() {
+	sku := "MDAxZmxvY2F0aW9uIGh0dHBzOi8vYnJhdmUuY29tCjAwMWFpZGVudGlmaWVyIGlkZW50aWZpZXIKMDAyYmNpZCBleHBpcnkgPSAzMDIwLTAzLTA1VDEzOjIwOjI3LTA2OjAwCjAwMTdjaWQgY3VycmVuY3kgPSBCQVQKMDAzMmNpZCBpZCA9IDVjODQ2ZGExLTgzY2QtNGUxNS05OGRkLThlMTQ3YTU2YjZmYQowMDJiY2lkIGRlc2NyaXB0aW9uID0gY29mZmVlIGNvZmZlZSBjb2ZmZWUKMDAxNWNpZCBwcmljZSA9IDIuMDAKMDAyZnNpZ25hdHVyZSBBejw7oGlCuSe61soF1nJsWVQeJwRucj5jZwtUc2y4Ugo"
+	// identifier: identifier
+	// rootKey: secret
+	// location: brave.com
+	// caveats:
+	//     id = 5c846da1-83cd-4e15-98dd-8e147a56b6fa
+	//     currency = BAT
+	//     price = 2.00
+	//     description = coffee coffee coffee
+	//     expiry = 2020-04-01
+
+	orderItem, err := CreateOrderItemFromMacaroon(sku, 1)
+	suite.NoError(err)
+
+	suite.Assert().Equal("BAT", orderItem.Currency)
+	suite.Assert().Equal("5c846da1-83cd-4e15-98dd-8e147a56b6fa", orderItem.ID.String())
+	suite.Assert().Equal("2", orderItem.Price.String())
+	suite.Assert().Equal("coffee coffee coffee", orderItem.Description)
+	suite.Assert().Equal("https://brave.com", orderItem.Location)
+}

--- a/payment/service.go
+++ b/payment/service.go
@@ -264,9 +264,9 @@ func (s *Service) CreateOrderFromRequest(req CreateOrderRequest) (*Order, error)
 		totalPrice = totalPrice.Add(orderItem.Subtotal)
 
 		if location == "" {
-			location = orderItem.Location
+			location = orderItem.Location.String
 		}
-		if location != orderItem.Location {
+		if location != orderItem.Location.String {
 			return nil, errors.New("all order items must be from the same location")
 		}
 		if currency == "" {

--- a/payment/service.go
+++ b/payment/service.go
@@ -254,14 +254,21 @@ func (s *Service) CreateOrderFromRequest(req CreateOrderRequest) (*Order, error)
 	totalPrice := decimal.New(0, 0)
 	orderItems := []OrderItem{}
 	var currency string
+	var location string
 
 	for i := 0; i < len(req.Items); i++ {
-		orderItem, err := createOrderItemFromMacaroon(req.Items[i].SKU, req.Items[i].Quantity)
+		orderItem, err := CreateOrderItemFromMacaroon(req.Items[i].SKU, req.Items[i].Quantity)
 		if err != nil {
 			return nil, err
 		}
 		totalPrice = totalPrice.Add(orderItem.Subtotal)
 
+		if location == "" {
+			location = orderItem.Location
+		}
+		if location != orderItem.Location {
+			return nil, errors.New("all order items must be from the same location")
+		}
 		if currency == "" {
 			currency = orderItem.Currency
 		}
@@ -271,7 +278,7 @@ func (s *Service) CreateOrderFromRequest(req CreateOrderRequest) (*Order, error)
 		orderItems = append(orderItems, *orderItem)
 	}
 
-	order, err := s.datastore.CreateOrder(totalPrice, "brave.com", "pending", currency, orderItems)
+	order, err := s.datastore.CreateOrder(totalPrice, "brave.com", "pending", currency, location, orderItems)
 
 	return order, err
 }

--- a/promotion/order.go
+++ b/promotion/order.go
@@ -1,6 +1,7 @@
 package promotion
 
 import (
+	"database/sql"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -18,20 +19,23 @@ type Order struct {
 	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
 	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
 	MerchantID string          `json:"merchantId" db:"merchant_id"`
+	Location   sql.NullString  `json:"location" db:"location"`
 	Status     string          `json:"status" db:"status"`
 	Items      []OrderItem     `json:"items"`
 }
 
 // OrderItem includes information about a particular order item
 type OrderItem struct {
-	ID        uuid.UUID       `json:"id" db:"id"`
-	OrderID   uuid.UUID       `json:"order_id" db:"order_id"`
-	CreatedAt *time.Time      `json:"createdAt" db:"created_at"`
-	UpdatedAt *time.Time      `json:"updatedAt" db:"updated_at"`
-	Currency  string          `json:"currency" db:"currency"`
-	Quantity  int             `json:"quantity" db:"quantity"`
-	Price     decimal.Decimal `json:"price" db:"price"`
-	Subtotal  decimal.Decimal `json:"subtotal"`
+	ID          uuid.UUID       `json:"id" db:"id"`
+	OrderID     uuid.UUID       `json:"orderId" db:"order_id"`
+	CreatedAt   *time.Time      `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time      `json:"updatedAt" db:"updated_at"`
+	Currency    string          `json:"currency" db:"currency"`
+	Quantity    int             `json:"quantity" db:"quantity"`
+	Price       decimal.Decimal `json:"price" db:"price"`
+	Subtotal    decimal.Decimal `json:"subtotal"`
+	Location    string          `json:"location" db:"location"`
+	Description string          `json:"description" db:"description"`
 }
 
 // IsPaid returns true if the order is paid

--- a/promotion/order.go
+++ b/promotion/order.go
@@ -1,7 +1,6 @@
 package promotion
 
 import (
-	"database/sql"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -19,7 +18,7 @@ type Order struct {
 	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
 	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
 	MerchantID string          `json:"merchantId" db:"merchant_id"`
-	Location   sql.NullString  `json:"location" db:"location"`
+	Location   *string         `json:"location" db:"location"`
 	Status     string          `json:"status" db:"status"`
 	Items      []OrderItem     `json:"items"`
 }
@@ -34,7 +33,7 @@ type OrderItem struct {
 	Quantity    int             `json:"quantity" db:"quantity"`
 	Price       decimal.Decimal `json:"price" db:"price"`
 	Subtotal    decimal.Decimal `json:"subtotal"`
-	Location    string          `json:"location" db:"location"`
+	Location    *string         `json:"location" db:"location"`
 	Description string          `json:"description" db:"description"`
 }
 

--- a/promotion/order.go
+++ b/promotion/order.go
@@ -1,6 +1,9 @@
 package promotion
 
 import (
+	"database/sql"
+	"encoding/json"
+	"strings"
 	"time"
 
 	uuid "github.com/satori/go.uuid"
@@ -10,6 +13,26 @@ import (
 // Delete this file once the issue is completed
 // https://github.com/brave-intl/bat-go/issues/263
 
+// NullString is a type that lets ya get a null field from the database
+type NullString struct {
+	sql.NullString
+}
+
+// MarshalJSON for NullString
+func (ns *NullString) MarshalJSON() ([]byte, error) {
+	if !ns.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(ns.String)
+}
+
+// UnmarshalJSON unmarshalls NullString
+func (ns *NullString) UnmarshalJSON(data []byte) error {
+	ns.String = strings.Trim(string(data), `"`)
+	ns.Valid = true
+	return nil
+}
+
 // Order includes information about a particular order
 type Order struct {
 	ID         uuid.UUID       `json:"id" db:"id"`
@@ -18,7 +41,7 @@ type Order struct {
 	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
 	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
 	MerchantID string          `json:"merchantId" db:"merchant_id"`
-	Location   *string         `json:"location" db:"location"`
+	Location   NullString      `json:"location" db:"location"`
 	Status     string          `json:"status" db:"status"`
 	Items      []OrderItem     `json:"items"`
 }
@@ -33,8 +56,8 @@ type OrderItem struct {
 	Quantity    int             `json:"quantity" db:"quantity"`
 	Price       decimal.Decimal `json:"price" db:"price"`
 	Subtotal    decimal.Decimal `json:"subtotal"`
-	Location    *string         `json:"location" db:"location"`
-	Description string          `json:"description" db:"description"`
+	Location    NullString      `json:"location" db:"location"`
+	Description NullString      `json:"description" db:"description"`
 }
 
 // IsPaid returns true if the order is paid

--- a/promotion/order.go
+++ b/promotion/order.go
@@ -1,11 +1,9 @@
 package promotion
 
 import (
-	"database/sql"
-	"encoding/json"
-	"strings"
 	"time"
 
+	"github.com/brave-intl/bat-go/utils/datastore"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
 )
@@ -13,51 +11,31 @@ import (
 // Delete this file once the issue is completed
 // https://github.com/brave-intl/bat-go/issues/263
 
-// NullString is a type that lets ya get a null field from the database
-type NullString struct {
-	sql.NullString
-}
-
-// MarshalJSON for NullString
-func (ns *NullString) MarshalJSON() ([]byte, error) {
-	if !ns.Valid {
-		return []byte("null"), nil
-	}
-	return json.Marshal(ns.String)
-}
-
-// UnmarshalJSON unmarshalls NullString
-func (ns *NullString) UnmarshalJSON(data []byte) error {
-	ns.String = strings.Trim(string(data), `"`)
-	ns.Valid = true
-	return nil
-}
-
 // Order includes information about a particular order
 type Order struct {
-	ID         uuid.UUID       `json:"id" db:"id"`
-	CreatedAt  time.Time       `json:"createdAt" db:"created_at"`
-	Currency   string          `json:"currency" db:"currency"`
-	UpdatedAt  time.Time       `json:"updatedAt" db:"updated_at"`
-	TotalPrice decimal.Decimal `json:"totalPrice" db:"total_price"`
-	MerchantID string          `json:"merchantId" db:"merchant_id"`
-	Location   NullString      `json:"location" db:"location"`
-	Status     string          `json:"status" db:"status"`
-	Items      []OrderItem     `json:"items"`
+	ID         uuid.UUID            `json:"id" db:"id"`
+	CreatedAt  time.Time            `json:"createdAt" db:"created_at"`
+	Currency   string               `json:"currency" db:"currency"`
+	UpdatedAt  time.Time            `json:"updatedAt" db:"updated_at"`
+	TotalPrice decimal.Decimal      `json:"totalPrice" db:"total_price"`
+	MerchantID string               `json:"merchantId" db:"merchant_id"`
+	Location   datastore.NullString `json:"location" db:"location"`
+	Status     string               `json:"status" db:"status"`
+	Items      []OrderItem          `json:"items"`
 }
 
 // OrderItem includes information about a particular order item
 type OrderItem struct {
-	ID          uuid.UUID       `json:"id" db:"id"`
-	OrderID     uuid.UUID       `json:"orderId" db:"order_id"`
-	CreatedAt   *time.Time      `json:"createdAt" db:"created_at"`
-	UpdatedAt   *time.Time      `json:"updatedAt" db:"updated_at"`
-	Currency    string          `json:"currency" db:"currency"`
-	Quantity    int             `json:"quantity" db:"quantity"`
-	Price       decimal.Decimal `json:"price" db:"price"`
-	Subtotal    decimal.Decimal `json:"subtotal"`
-	Location    NullString      `json:"location" db:"location"`
-	Description NullString      `json:"description" db:"description"`
+	ID          uuid.UUID            `json:"id" db:"id"`
+	OrderID     uuid.UUID            `json:"orderId" db:"order_id"`
+	CreatedAt   *time.Time           `json:"createdAt" db:"created_at"`
+	UpdatedAt   *time.Time           `json:"updatedAt" db:"updated_at"`
+	Currency    string               `json:"currency" db:"currency"`
+	Quantity    int                  `json:"quantity" db:"quantity"`
+	Price       decimal.Decimal      `json:"price" db:"price"`
+	Subtotal    decimal.Decimal      `json:"subtotal"`
+	Location    datastore.NullString `json:"location" db:"location"`
+	Description datastore.NullString `json:"description" db:"description"`
 }
 
 // IsPaid returns true if the order is paid

--- a/utils/datastore/models.go
+++ b/utils/datastore/models.go
@@ -23,5 +23,8 @@ func (ns *NullString) MarshalJSON() ([]byte, error) {
 func (ns *NullString) UnmarshalJSON(data []byte) error {
 	ns.String = strings.Trim(string(data), `"`)
 	ns.Valid = true
+	if len(data) == 0 {
+		ns.Valid = false
+	}
 	return nil
 }

--- a/utils/datastore/models.go
+++ b/utils/datastore/models.go
@@ -1,0 +1,27 @@
+package datastore
+
+import (
+	"database/sql"
+	"encoding/json"
+	"strings"
+)
+
+// NullString is a type that lets ya get a null field from the database
+type NullString struct {
+	sql.NullString
+}
+
+// MarshalJSON for NullString
+func (ns *NullString) MarshalJSON() ([]byte, error) {
+	if !ns.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(ns.String)
+}
+
+// UnmarshalJSON unmarshalls NullString
+func (ns *NullString) UnmarshalJSON(data []byte) error {
+	ns.String = strings.Trim(string(data), `"`)
+	ns.Valid = true
+	return nil
+}


### PR DESCRIPTION
## Add description/location to order and items

All locations in the order item should be from the same place. Orders should have the ability to report the location of the order items. Items should have a description. 