### PR TITLE
Fix location and amount for order item

### DIFF
--- a/payment/order.go
+++ b/payment/order.go
@@ -75,7 +75,7 @@ func CreateOrderItemFromMacaroon(sku string, quantity int) (*OrderItem, error) {
 				return nil, err
 			}
 			orderItem.ID = uuid
-		case "price":
+		case "price", "amount":
 			orderItem.Price, err = decimal.NewFromString(value)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Fix location and amount for order item

This adds a fix where on some legacy SKU tokens the price was specified in the field "amount". We will be able to remove this in the future, but for our initial MVP it's helpful to have this be included in the order item.

Another issue was that when inserting into the database the location was `null`. This was a result of the type being `NullString` 