### PR TITLE
Dev refresh compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,9 @@ docker-dev:
 	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))
 	VAULT_TOKEN=$(VAULT_TOKEN) docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm dev /bin/bash
 
-docker-cory-dev:
+docker-refresh-dev:
 	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))
-	VAULT_TOKEN=$(VAULT_TOKEN) docker-compose -f docker-compose.yml -f docker-compose.cory.yml up -d cory
+	VAULT_TOKEN=$(VAULT_TOKEN) docker-compose -f docker-compose.yml -f docker-compose.dev-refresh.yml up -d dev-refresh
 
 mac:
 	GOOS=darwin GOARCH=amd64 make bins

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ docker-dev:
 	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))
 	VAULT_TOKEN=$(VAULT_TOKEN) docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm dev /bin/bash
 
+docker-cory-dev:
+	$(eval VAULT_TOKEN = $(shell docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 ))
+	VAULT_TOKEN=$(VAULT_TOKEN) docker-compose -f docker-compose.yml -f docker-compose.cory.yml up -d cory
+
 mac:
 	GOOS=darwin GOARCH=amd64 make bins
 

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ test:
 
 format:
 	gofmt -s -w ./
+
 format-lint:
 	make format && make lint
 lint:

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Once you are in the Docker container you can run the web server via `go run bin/
 If you want to run tests you can do so via the command `go test --tags=integration -v`
 For example in `promotion` you can run specific tests by running a command similar to `go test --tags=integration -run TestControllersTestSuite/TestCreateOrder`.
 
+### Rapid Iteration dev Environment
+
+On occasion it is desirable to re-run the development environment at will quickly.  To this
+end you can run `make docker-refresh-dev` which will spin up the bat-go services including a
+container named `grant-refresh-dev`.  If you want to recompile this service you merely need to
+perform a `docker restart grant-refresh-dev` and it will recompile and run the service.
+
+A particularly interesting use case is marrying this with utilities such as `fswatch` to watch
+for file changes.  There is an example below which will restart this `grant-refresh-dev` container
+on any file change in the source directory:
+
+```bash
+fswatch . | xargs -I {} sh -c '$(docker ps -f "name=grant-refresh-dev" --format "docker restart {{.ID}}")'
+```
 
 ## Building a prod image using docker
 

--- a/docker-compose.cory.yml
+++ b/docker-compose.cory.yml
@@ -1,0 +1,46 @@
+version: "3.4"
+
+services:
+  cory:
+    container_name: grant-cory
+    image: golang:1.13.4
+    ports:
+      - "3334:3333"
+    command: "go run bin/grant-server/main.go"
+    volumes:
+      - .:/src
+      - ./test/secrets:/etc/kafka/secrets
+    working_dir: /src
+    depends_on:
+      - kafka
+      - postgres
+      - challenge-bypass
+    networks:
+      - grant
+    environment:
+      - ENV=local
+      - DEBUG=1
+      - BAT_SETTLEMENT_ADDRESS
+      - CHALLENGE_BYPASS_SERVER=http://challenge-bypass:2416
+      - CHALLENGE_BYPASS_TOKEN
+      - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
+      - "DATABASE_URL=postgres://grants:password@postgres/grants?sslmode=disable"
+      - DONOR_WALLET_CARD_ID
+      - DONOR_WALLET_PRIVATE_KEY
+      - DONOR_WALLET_PUBLIC_KEY
+      - GRANT_SIGNATOR_PUBLIC_KEY
+      - GRANT_WALLET_CARD_ID
+      - GRANT_WALLET_PRIVATE_KEY
+      - GRANT_WALLET_PUBLIC_KEY
+      - KAFKA_BROKERS=kafka:19092
+      - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
+      - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem
+      - KAFKA_SSL_KEY_LOCATION=/etc/kafka/secrets/consumer.client.key
+      - KAFKA_SSL_KEY_PASSWORD=confluent
+      - KAFKA_REQUIRED_ACKS=1
+      - "LEDGER_SERVER=https://ledger-staging.mercury.basicattentiontoken.org"
+      - "BALANCE_SERVER=https://balance-staging.mercury.basicattentiontoken.org"
+      - TOKEN_LIST
+      - UPHOLD_ACCESS_TOKEN
+      - "RATIOS_SERVER=https://ratios-staging.mercury.basicattentiontoken.org"
+      - RATIOS_ACCESS_TOKEN

--- a/docker-compose.dev-refresh.yml
+++ b/docker-compose.dev-refresh.yml
@@ -10,7 +10,7 @@ services:
     container_name: grant-dev-refresh
     image: golang:1.13.4
     ports:
-      - "3334:3333"
+      - "3335:3333"
     command: "go run bin/grant-server/main.go"
     volumes:
       - .:/src

--- a/docker-compose.dev-refresh.yml
+++ b/docker-compose.dev-refresh.yml
@@ -1,8 +1,13 @@
 version: "3.4"
 
 services:
-  cory:
-    container_name: grant-cory
+  # dev-refresh service will start up a grant server bound to host port 3334
+  # which allows one to do `docker restart grant-dev-refresh` when the user
+  # wants to "restart" the service running new code.  This is especially helpful
+  # when you hook it up to `fswatch` type utilities, causing a re-run of `go run`
+  # every time a file changes.
+  dev-refresh:
+    container_name: grant-dev-refresh
     image: golang:1.13.4
     ports:
       - "3334:3333"


### PR DESCRIPTION
a docker container named grant-dev-refresh service will start up a grant server bound to host port 3334 which allows one to do `docker restart grant-dev-refresh` when the user wants to "restart" the service running new code.  This is especially helpful when you hook it up to `fswatch` type utilities, causing a re-run of `go run` every time a file changes.
