### PR TITLE
Don't set secret key when don't need to

### DIFF
--- a/payment/datastore.go
+++ b/payment/datastore.go
@@ -173,7 +173,7 @@ func (pg *Postgres) CreateOrder(totalPrice decimal.Decimal, merchantID string, s
 		nstmt, _ := tx.PrepareNamed(`
 			INSERT INTO order_items (order_id, sku, quantity, price, currency, subtotal, location, description)
 			VALUES (:order_id, :sku, :quantity, :price, :currency, :subtotal, :location, :description)
-			RETURNING id, order_id, sku, created_at, updated_at, currency, quantity, price, location, description
+			RETURNING id, order_id, sku, created_at, updated_at, currency, quantity, price, location, description, (quantity * price) as subtotal
 		`)
 		err = nstmt.Get(&orderItems[i], orderItems[i])
 
@@ -206,7 +206,7 @@ func (pg *Postgres) GetOrder(orderID uuid.UUID) (*Order, error) {
 
 	foundOrderItems := []OrderItem{}
 	statement = `
-		SELECT id, order_id, sku, created_at, updated_at, currency, quantity, price, location, description
+		SELECT id, order_id, sku, created_at, updated_at, currency, quantity, price, (quantity * price) as subtotal, location, description
 		FROM order_items WHERE order_id = $1`
 	err = pg.DB.Select(&foundOrderItems, statement, orderID)
 

--- a/payment/order.go
+++ b/payment/order.go
@@ -34,7 +34,7 @@ type OrderItem struct {
 	Currency    string               `json:"currency" db:"currency"`
 	Quantity    int                  `json:"quantity" db:"quantity"`
 	Price       decimal.Decimal      `json:"price" db:"price"`
-	Subtotal    decimal.Decimal      `json:"subtotal"`
+	Subtotal    decimal.Decimal      `json:"subtotal" db:"subtotal"`
 	Location    datastore.NullString `json:"location" db:"location"`
 	Description datastore.NullString `json:"description" db:"description"`
 }


### PR DESCRIPTION
We were setting and reading the encrypted secret key from our database during the initial read

Also I removed most of the `select *` code we have in our payment service ☺️ 