### PR TITLE
Sentry Recommends defer-ing Flush right after Init

### DIFF
--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -147,6 +147,5 @@ func (pg *Postgres) RollbackTx(tx *sqlx.Tx) {
 	err := tx.Rollback()
 	if err != nil && err != sql.ErrTxDone {
 		sentry.CaptureMessage(err.Error())
-		sentry.Flush(time.Second * 2)
 	}
 }

--- a/promotion/claim.go
+++ b/promotion/claim.go
@@ -131,7 +131,6 @@ func (service *Service) ClaimPromotionForWallet(
 		err = service.balanceClient.InvalidateBalance(ctx, walletID)
 		if err != nil {
 			sentry.CaptureException(err)
-			sentry.Flush(time.Second * 2)
 		}
 	}
 
@@ -148,7 +147,6 @@ func (service *Service) ClaimPromotionForWallet(
 		_, err := service.RunNextClaimJob(ctx)
 		if err != nil {
 			sentry.CaptureException(err)
-			sentry.Flush(time.Second * 2)
 		}
 	}()
 

--- a/promotion/drain.go
+++ b/promotion/drain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/brave-intl/bat-go/utils/altcurrency"
 	"github.com/brave-intl/bat-go/utils/clients/cbr"
@@ -78,7 +77,6 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 				_, err := service.RunNextDrainJob(ctx)
 				if err != nil {
 					sentry.CaptureException(err)
-					sentry.Flush(time.Second * 2)
 				}
 			}()
 		}

--- a/utils/clients/reputation/proxy.go
+++ b/utils/clients/reputation/proxy.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"time"
 
 	"github.com/getsentry/sentry-go"
 	log "github.com/sirupsen/logrus"
@@ -18,7 +17,6 @@ func ProxyRouter(
 	proxyURL, err := url.Parse(reputationServer)
 	if err != nil {
 		sentry.CaptureException(err)
-		sentry.Flush(time.Second * 2)
 		log.Panic(err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)


### PR DESCRIPTION
https://godoc.org/github.com/getsentry/sentry-go#Flush

```
Flush should be called before terminating the program to avoid unintentionally dropping events.

Do not call Flush indiscriminately after every call to CaptureEvent, CaptureException or CaptureMessage.
```