### PR TITLE
Release 2020-05-08_1

### DIFF
--- a/bin/grant-server/main.go
+++ b/bin/grant-server/main.go
@@ -45,7 +45,12 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	govalidator.SetFieldsRequiredByDefault(true)
 
 	r := chi.NewRouter()
+
+	// chain should be:
+	// id / transfer -> ip -> heartbeat -> request logger / recovery -> token check -> rate limit
+	// -> instrumentation -> handler
 	r.Use(chiware.RequestID)
+	r.Use(middleware.RequestIDTransfer)
 
 	// NOTE: This uses standard fowarding headers, note that this puts implicit trust in the header values
 	// provided to us. In particular it uses the first element.
@@ -55,18 +60,18 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	r.Use(chiware.RealIP)
 
 	r.Use(chiware.Heartbeat("/"))
-	r.Use(chiware.Timeout(10 * time.Second))
-	r.Use(middleware.BearerToken)
-	r.Use(middleware.RateLimiter)
-	r.Use(middleware.RequestIDTransfer)
+	// log and recover here
 	if logger != nil {
 		// Also handles panic recovery
 		r.Use(hlog.NewHandler(*logger))
 		r.Use(hlog.UserAgentHandler("user_agent"))
 		r.Use(hlog.RequestIDHandler("req_id", "Request-Id"))
 		r.Use(middleware.RequestLogger(logger))
-		r.Use(chiware.Recoverer)
 	}
+	// now we have middlewares we want included in logging
+	r.Use(chiware.Timeout(10 * time.Second))
+	r.Use(middleware.BearerToken)
+	r.Use(middleware.RateLimiter(ctx))
 
 	roDB := os.Getenv("RO_DATABASE_URL")
 

--- a/middleware/rate_limiter.go
+++ b/middleware/rate_limiter.go
@@ -1,42 +1,51 @@
 package middleware
 
 import (
-	"log"
+	"context"
 	"net/http"
 
+	appctx "github.com/brave-intl/bat-go/utils/context"
+	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/throttled/throttled"
 	"github.com/throttled/throttled/store/memstore"
 )
 
 // RateLimiter rate limits the number of requests a
 // user from a single IP address can make
-func RateLimiter(next http.Handler) http.Handler {
-	store, err := memstore.New(65536)
+func RateLimiter(ctx context.Context) func(next http.Handler) http.Handler {
+	logger, err := appctx.GetLogger(ctx)
 	if err != nil {
-		log.Fatal(err)
-	}
-	quota := throttled.RateQuota{
-		MaxRate: throttled.PerMin(60),
-	}
-	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
-	if err != nil {
-		log.Fatal(err)
+		_, logger = logging.SetupLogger(ctx)
 	}
 
-	httpRateLimiter := throttled.HTTPRateLimiter{
-		RateLimiter: rateLimiter,
-		VaryBy: &throttled.VaryBy{
-			RemoteAddr: true,
-			Path:       true,
-			Method:     true,
-		},
-	}
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !isSimpleTokenInContext(r.Context()) {
-			httpRateLimiter.RateLimit(next).ServeHTTP(w, r)
-		} else {
-			// override rate limiting for authorized endpoints
-			next.ServeHTTP(w, r)
+	return func(next http.Handler) http.Handler {
+		store, err := memstore.New(65536)
+		if err != nil {
+			logger.Fatal().Err(err)
 		}
-	})
+		quota := throttled.RateQuota{
+			MaxRate: throttled.PerMin(60),
+		}
+		rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+		if err != nil {
+			logger.Fatal().Err(err)
+		}
+
+		httpRateLimiter := throttled.HTTPRateLimiter{
+			RateLimiter: rateLimiter,
+			VaryBy: &throttled.VaryBy{
+				RemoteAddr: true,
+				Path:       true,
+				Method:     true,
+			},
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !isSimpleTokenInContext(r.Context()) {
+				httpRateLimiter.RateLimit(next).ServeHTTP(w, r)
+			} else {
+				// override rate limiting for authorized endpoints
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
 }

--- a/payment/service.go
+++ b/payment/service.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"time"
 
 	"errors"
 
+	"github.com/brave-intl/bat-go/utils/logging"
 	srv "github.com/brave-intl/bat-go/utils/service"
 	"github.com/brave-intl/bat-go/wallet/provider/uphold"
 	wallet "github.com/brave-intl/bat-go/wallet/service"
@@ -40,12 +40,14 @@ var (
 )
 
 func init() {
+	_, logger := logging.SetupLogger(context.Background())
+
 	// gracefully try to register collectors for prom, no need to panic
 	if err := prometheus.Register(kafkaCertNotBefore); err != nil {
-		log.Printf("already registered kafkaCertNotBefore collector: %s\n", err)
+		logger.Warn().Err(err).Msg("already registered kafkaCertNotBefore collector")
 	}
 	if err := prometheus.Register(kafkaCertNotAfter); err != nil {
-		log.Printf("already registered kafkaCertNotBefore collector: %s\n", err)
+		logger.Warn().Err(err).Msg("already registered kafkaCertNotAfter collector")
 	}
 }
 
@@ -184,6 +186,9 @@ func (s *Service) InitCodecs() error {
 
 // InitKafka by creating a kafka writer and creating local copies of codecs
 func (s *Service) InitKafka() error {
+
+	_, logger := logging.SetupLogger(context.Background())
+
 	dialer, err := tlsDialer()
 	if err != nil {
 		return err
@@ -197,7 +202,7 @@ func (s *Service) InitKafka() error {
 		Topic:    voteTopic,
 		Balancer: &kafka.LeastBytes{},
 		Dialer:   dialer,
-		Logger:   kafka.LoggerFunc(log.Printf), // FIXME
+		Logger:   kafka.LoggerFunc(logger.Printf), // FIXME
 	})
 
 	s.kafkaWriter = kafkaWriter

--- a/payment/vote.go
+++ b/payment/vote.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -231,6 +230,11 @@ func (service *Service) RunNextVoteDrainJob(ctx context.Context) (bool, error) {
 func (service *Service) Vote(
 	ctx context.Context, credentials []CredentialBinding, voteText string) error {
 
+	logger, err := appctx.GetLogger(ctx)
+	if err != nil {
+		ctx, logger = logging.SetupLogger(ctx)
+	}
+
 	var vote Vote
 	// decode and validate the inputs
 	if err := inputs.DecodeAndValidate(ctx, &vote, []byte(voteText)); err != nil {
@@ -258,12 +262,12 @@ func (service *Service) Vote(
 			if merchantID != "brave.com" {
 				// validate that the merchantID is brave.com
 				// if not hard fail the request, and return an error stating the problem
-				log.Printf("merchantID is invalid in vote sku token - should be brave.com: %s\n", merchantID)
+				logger.Warn().Str("merchantID", merchantID).Msg("merchantID should be brave.com, vote invalid")
 				return fmt.Errorf("merchant id != brave.com: %w", ErrInvalidSKUTokenBadMerchant)
 			}
 
 			if sku != UserWalletVoteSKU && sku != AnonCardVoteSKU {
-				log.Printf("sku is invalid in sku token - should be either user-wallet or anonymous-card: %s\n", sku)
+				logger.Warn().Str("sku", sku).Msg("sku is invalid, should be user-wallet, or anonymous-card")
 				return fmt.Errorf("%s is an invalid sku: %w", sku, ErrInvalidSKUTokenSKU)
 			}
 
@@ -288,7 +292,7 @@ func (service *Service) Vote(
 			vote.FundingSource = "anonymous-card"
 		default:
 			// should not get here, doing validation above on each issuer name
-			log.Printf("sku is invalid in sku token - should be either user-wallet or anonymous-card: %s\n", sku)
+			logger.Warn().Str("sku", sku).Msg("sku is invalid, should be user-wallet, or anonymous-card")
 			return fmt.Errorf("%s is an invalid sku: %w", sku, ErrInvalidSKUTokenSKU)
 		}
 

--- a/promotion/service.go
+++ b/promotion/service.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"io/ioutil"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/brave-intl/bat-go/utils/clients/reputation"
 	errorutils "github.com/brave-intl/bat-go/utils/errors"
 	"github.com/brave-intl/bat-go/utils/httpsignature"
+	"github.com/brave-intl/bat-go/utils/logging"
 	srv "github.com/brave-intl/bat-go/utils/service"
 	w "github.com/brave-intl/bat-go/wallet"
 	"github.com/brave-intl/bat-go/wallet/provider/uphold"
@@ -244,6 +244,9 @@ func (s *Service) InitCodecs() error {
 
 // InitKafka by creating a kafka writer and creating local copies of codecs
 func (s *Service) InitKafka() error {
+
+	_, logger := logging.SetupLogger(context.Background())
+
 	dialer, err := tlsDialer()
 	if err != nil {
 		return err
@@ -257,7 +260,7 @@ func (s *Service) InitKafka() error {
 		Topic:    suggestionTopic,
 		Balancer: &kafka.LeastBytes{},
 		Dialer:   dialer,
-		Logger:   kafka.LoggerFunc(log.Printf), // FIXME
+		Logger:   kafka.LoggerFunc(logger.Printf), // FIXME
 	})
 
 	s.kafkaWriter = kafkaWriter

--- a/utils/handlers/healthcheck.go
+++ b/utils/handlers/healthcheck.go
@@ -38,10 +38,10 @@ func (hcr HealthCheckResponse) RenderJSON(ctx context.Context, w http.ResponseWr
 func HealthCheckHandler(version, buildTime, commit string) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			var ctx context.Context
-			logger, err := appctx.GetLogger(r.Context())
+			var ctx = r.Context()
+			logger, err := appctx.GetLogger(ctx)
 			if err != nil {
-				ctx, logger = logging.SetupLogger(r.Context())
+				ctx, logger = logging.SetupLogger(ctx)
 			}
 
 			hcr := HealthCheckResponse{

--- a/utils/handlers/healthcheck.go
+++ b/utils/handlers/healthcheck.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
+
+	appctx "github.com/brave-intl/bat-go/utils/context"
+	"github.com/brave-intl/bat-go/utils/logging"
 )
 
 // HealthCheckResponse - response structure for healthchecks
@@ -15,14 +18,18 @@ type HealthCheckResponse struct {
 }
 
 // RenderJSON - helper to render a HealthCheckResponse as Json to an http.ResponseWriter
-func (hcr HealthCheckResponse) RenderJSON(w http.ResponseWriter) error {
+func (hcr HealthCheckResponse) RenderJSON(ctx context.Context, w http.ResponseWriter) error {
+	logger, err := appctx.GetLogger(ctx)
+	if err != nil {
+		_, logger = logging.SetupLogger(ctx)
+	}
 	body, err := json.Marshal(hcr)
 	if err != nil {
 		return fmt.Errorf("failed to marshal response in render json: %w", err)
 	}
 	w.WriteHeader(200)
 	if _, err := w.Write(body); err != nil {
-		log.Printf("failed to write response to writer: %s", err)
+		logger.Error().Err(err).Msg("failed to write response to writer")
 	}
 	return nil
 }
@@ -31,15 +38,21 @@ func (hcr HealthCheckResponse) RenderJSON(w http.ResponseWriter) error {
 func HealthCheckHandler(version, buildTime, commit string) http.HandlerFunc {
 	return http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			var ctx context.Context
+			logger, err := appctx.GetLogger(r.Context())
+			if err != nil {
+				ctx, logger = logging.SetupLogger(r.Context())
+			}
+
 			hcr := HealthCheckResponse{
 				Commit:    commit,
 				BuildTime: buildTime,
 				Version:   version,
 			}
-			if err := hcr.RenderJSON(w); err != nil {
+			if err := hcr.RenderJSON(ctx, w); err != nil {
 				w.WriteHeader(500)
 				if _, err := w.Write([]byte("unhealthy")); err != nil {
-					log.Printf("failed to write response to writer: %s", err)
+					logger.Error().Err(err).Msg("failed to write response to writer")
 				}
 			}
 		})

--- a/utils/logging/logging.go
+++ b/utils/logging/logging.go
@@ -2,13 +2,34 @@ package logging
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
+	"time"
 
 	appctx "github.com/brave-intl/bat-go/utils/context"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/diode"
 	uuid "github.com/satori/go.uuid"
 )
+
+var (
+	// we are not promising to get every log message in the log
+	// anymore, when it comes down to it, we would rather the service
+	// runs than fails on log writing contention.  This will let us
+	// see how many logs we are dropping
+	droppedLogTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dropped_log_events_total",
+			Help: "A counter for the number of dropped log messages",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(droppedLogTotal)
+}
 
 // SetupLogger - helper to setup a logger and associate with context
 func SetupLogger(ctx context.Context) (context.Context, *zerolog.Logger) {
@@ -26,8 +47,17 @@ func SetupLogger(ctx context.Context) (context.Context, *zerolog.Logger) {
 		output = zerolog.ConsoleWriter{Out: os.Stdout}
 	}
 
+	// this log writer uses a ring buffer and drops messages that cannot be processed
+	// in a timely manner
+	wr := diode.NewWriter(output, 1000, time.Duration(10*time.Millisecond), func(missed int) {
+		// write to stderr the number of dropped log messages
+		fmt.Fprintf(os.Stderr, "logger dropped message count: %d", missed)
+		// add to our counter of lost log messages
+		droppedLogTotal.Add(float64(missed))
+	})
+
 	// always print out timestamp
-	l := zerolog.New(output).With().Timestamp().Logger()
+	l := zerolog.New(wr).With().Timestamp().Logger()
 
 	debug := os.Getenv("DEBUG")
 	if debug == "" || debug == "f" || debug == "n" || debug == "0" {


### PR DESCRIPTION
…r (#384)

updating payment/healthcheck/ratelimit to all use zerolog logger from context

updated payment service to use zerolog for kafka logger and in init functions

updates promotion service kafka client to use zerolog logger

move logging get out of every request, now only get logger once on initialization

adding instrumentation around number of dropped logs

re-arrange middlewares in grant server, removed extra recovery middleware

updates to request logger to not get logger from context twice