### PR TITLE
Claim creds conflict

### DIFF
--- a/promotion/claim.go
+++ b/promotion/claim.go
@@ -81,7 +81,7 @@ func blindCredsEq(a, b []string) bool {
 	return true
 }
 
-var ErrClaimedDifferentBlindCreds = errors.New("blinded credentials do not match what was already claimed")
+var errClaimedDifferentBlindCreds = errors.New("blinded credentials do not match what was already claimed")
 
 // ClaimPromotionForWallet attempts to claim the promotion on behalf of a wallet and returning the ClaimID
 // It kicks off asynchronous signing of the credentials on success
@@ -123,7 +123,7 @@ func (service *Service) ClaimPromotionForWallet(
 
 	// if blinded creds do not match prior attempt, return error
 	if claim != nil && claim.Redeemed && !blindCredsEq([]string(claimCreds.BlindedCreds), blindedCreds) {
-		return nil, ErrClaimedDifferentBlindCreds
+		return nil, errClaimedDifferentBlindCreds
 	}
 	// This is skipped for legacy migration path as they passed a reputation check when originally claiming
 	if claim == nil || !claim.LegacyClaimed {

--- a/promotion/claim.go
+++ b/promotion/claim.go
@@ -56,26 +56,12 @@ func blindCredsEq(a, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
+	// a and b must have same values in same order
 	for _, v := range a {
-		var found bool
 		for _, vv := range b {
-			if v == vv {
-				found = true
+			if v != vv {
+				return false
 			}
-		}
-		if !found {
-			return false
-		}
-	}
-	for _, v := range b {
-		var found bool
-		for _, vv := range b {
-			if v == vv {
-				found = true
-			}
-		}
-		if !found {
-			return false
 		}
 	}
 	return true

--- a/promotion/claim_test.go
+++ b/promotion/claim_test.go
@@ -50,8 +50,8 @@ func TestBlindCredsEq(t *testing.T) {
 		b = []string{"b", "a", "c"}
 		c = []string{"d", "b", "c", "a"}
 	)
-	if !blindCredsEq(a, b) {
-		t.Error("two creds should have been equal..")
+	if blindCredsEq(a, b) {
+		t.Error("two creds must retain the same ordering..")
 	}
 	if blindCredsEq(a, c) {
 		t.Error("two creds should have not been equal..")

--- a/promotion/claim_test.go
+++ b/promotion/claim_test.go
@@ -44,6 +44,20 @@ func TestSuggestionsNeeded(t *testing.T) {
 	}
 }
 
+func TestBlindCredsEq(t *testing.T) {
+	var (
+		a = []string{"a", "b", "c"}
+		b = []string{"b", "a", "c"}
+		c = []string{"d", "b", "c", "a"}
+	)
+	if !blindCredsEq(a, b) {
+		t.Error("two creds should have been equal..")
+	}
+	if blindCredsEq(a, c) {
+		t.Error("two creds should have not been equal..")
+	}
+}
+
 func TestClaimPromotion(t *testing.T) {
 	// t.Fatal("not implemented")
 }

--- a/promotion/controllers.go
+++ b/promotion/controllers.go
@@ -215,8 +215,15 @@ func ClaimPromotion(service *Service) handlers.AppHandler {
 		claimID, err := service.ClaimPromotionForWallet(r.Context(), promotionID.UUID(), req.WalletID, req.BlindedCreds)
 
 		if err != nil {
-			var target *errorutils.ErrorBundle
-			status := http.StatusBadRequest
+			var (
+				target *errorutils.ErrorBundle
+				status = http.StatusBadRequest
+			)
+
+			if errors.Is(err, ErrClaimedDifferentBlindCreds) {
+				status = http.StatusConflict
+			}
+
 			if errors.As(err, &target) {
 				err = target
 				response, ok := target.Data().(clients.HTTPState)

--- a/promotion/controllers.go
+++ b/promotion/controllers.go
@@ -220,7 +220,7 @@ func ClaimPromotion(service *Service) handlers.AppHandler {
 				status = http.StatusBadRequest
 			)
 
-			if errors.Is(err, ErrClaimedDifferentBlindCreds) {
+			if errors.Is(err, errClaimedDifferentBlindCreds) {
 				status = http.StatusConflict
 			}
 


### PR DESCRIPTION
If wallet/grant combination already has a claim, and the claim credentials do not match the original attempt, respond with a conflict to the caller.