### PR TITLE
never update anon address on wallets

### DIFF
--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -38,7 +38,6 @@ func init() {
 // Datastore holds the interface for the wallet datastore
 type Datastore interface {
 	grantserver.Datastore
-	SetAnonymousAddress(ID string, anonymousAddress *uuid.UUID) error
 	TxLinkWalletInfo(tx *sqlx.Tx, ID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, pID, pda string) error
 	LinkWallet(ID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, pID, depositProvider string) error
 	// GetByProviderLinkingID gets the wallet by provider linking id
@@ -242,23 +241,6 @@ func (pg *Postgres) InsertWallet(wallet *walletutils.Info) error {
 	}
 
 	return nil
-}
-
-// SetAnonymousAddress sets the anon addresses of the provided wallets
-func (pg *Postgres) SetAnonymousAddress(ID string, anonymousAddress *uuid.UUID) error {
-	// do not update anonymous addresses
-	statement := `
-	UPDATE wallets
-	SET
-			anonymous_address = $2
-	WHERE id = $1 and (anonymous_address is null or anonymous_address = '')
-	`
-	_, err := pg.RawDB().Exec(
-		statement,
-		ID,
-		anonymousAddress,
-	)
-	return err
 }
 
 // TxLinkWalletInfo pass a tx to set the anonymous address

--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -1,7 +1,9 @@
 package wallet
 
 import (
+	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -169,6 +171,28 @@ func (pg *Postgres) GetWallet(ID uuid.UUID) (*wallet.Info, error) {
 	return nil, nil
 }
 
+// txGetWallet by ID
+func (pg *Postgres) txHasAnonymousAddress(tx *sqlx.Tx, ID uuid.UUID) (bool, error) {
+	statement := `
+	select
+		true
+	from
+		wallets
+	where
+		anonymous_address is not null and
+		id = $1`
+	var result bool
+	err := tx.Get(&result, statement, ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return result, nil
+}
+
 // GetWalletByPublicKey gets a wallet by a public key
 func (pg *Postgres) GetWalletByPublicKey(pk string) (*walletutils.Info, error) {
 	statement := `
@@ -222,11 +246,12 @@ func (pg *Postgres) InsertWallet(wallet *walletutils.Info) error {
 
 // SetAnonymousAddress sets the anon addresses of the provided wallets
 func (pg *Postgres) SetAnonymousAddress(ID string, anonymousAddress *uuid.UUID) error {
+	// do not update anonymous addresses
 	statement := `
 	UPDATE wallets
 	SET
 			anonymous_address = $2
-	WHERE id = $1
+	WHERE id = $1 and (anonymous_address is null or anonymous_address = '')
 	`
 	_, err := pg.RawDB().Exec(
 		statement,
@@ -244,24 +269,52 @@ func (pg *Postgres) TxLinkWalletInfo(
 	anonymousAddress *uuid.UUID,
 	providerID string,
 	userDepositAccountProvider string) error {
-	statement := `
-	UPDATE wallets
-	SET
-			provider_linking_id = $2,
-			anonymous_address = $3,
-			user_deposit_account_provider = $4,
-			provider_id = $5
-	WHERE id = $1;`
-	r, err := tx.Exec(
-		statement,
-		ID,
-		providerLinkingID,
-		anonymousAddress,
-		userDepositAccountProvider,
-		providerID,
+
+	var (
+		statement string
+		sqlErr    error
+		id        = uuid.Must(uuid.FromString(ID))
+		r         sql.Result
 	)
-	if err != nil {
-		return err
+
+	if ok, err := pg.txHasAnonymousAddress(tx, id); err != nil {
+		return fmt.Errorf("error trying to lookup anonymous address: %w", err)
+	} else if ok {
+		statement = `
+			UPDATE wallets
+			SET
+				provider_linking_id = $2,
+				user_deposit_account_provider = $3,
+				provider_id = $4
+			WHERE id = $1;`
+		r, sqlErr = tx.Exec(
+			statement,
+			ID,
+			providerLinkingID,
+			userDepositAccountProvider,
+			providerID,
+		)
+	} else {
+		statement = `
+			UPDATE wallets
+			SET
+					provider_linking_id = $2,
+					anonymous_address = $3,
+					user_deposit_account_provider = $4,
+					provider_id = $5
+			WHERE id = $1;`
+		r, sqlErr = tx.Exec(
+			statement,
+			ID,
+			providerLinkingID,
+			anonymousAddress,
+			userDepositAccountProvider,
+			providerID,
+		)
+	}
+
+	if sqlErr != nil {
+		return sqlErr
 	}
 	if r != nil {
 		count, _ := r.RowsAffected()
@@ -321,6 +374,7 @@ func (pg *Postgres) LinkWallet(ID string, providerLinkingID uuid.UUID, anonymous
 		})
 		return ErrTooManyCardsLinked
 	}
+
 	err = pg.TxLinkWalletInfo(tx, ID, providerLinkingID, anonymousAddress, pID, depositProvider)
 	if err != nil {
 		return errorutils.Wrap(err, "unable to set an anonymous address")

--- a/wallet/instrumented_datastore.go
+++ b/wallet/instrumented_datastore.go
@@ -174,20 +174,6 @@ func (_d DatastoreWithPrometheus) RollbackTxAndHandle(tx *sqlx.Tx) (err error) {
 	return _d.base.RollbackTxAndHandle(tx)
 }
 
-// SetAnonymousAddress implements Datastore
-func (_d DatastoreWithPrometheus) SetAnonymousAddress(ID string, anonymousAddress *uuid.UUID) (err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "SetAnonymousAddress", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.SetAnonymousAddress(ID, anonymousAddress)
-}
-
 // TxLinkWalletInfo implements Datastore
 func (_d DatastoreWithPrometheus) TxLinkWalletInfo(tx *sqlx.Tx, ID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, pID string, pda string) (err error) {
 	_since := time.Now()

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -154,12 +154,6 @@ func (service *Service) LinkWallet(
 		if !uuid.Equal(*info.ProviderLinkingID, providerLinkingID) {
 			return handlers.WrapError(errors.New("wallets do not match"), "unable to match wallets", http.StatusForbidden)
 		}
-		if anonymousAddress != nil && info.AnonymousAddress != nil && !uuid.Equal(*anonymousAddress, *info.AnonymousAddress) {
-			err := service.Datastore.SetAnonymousAddress(info.ID, anonymousAddress)
-			if err != nil {
-				return handlers.WrapError(err, "unable to set anonymous address", http.StatusInternalServerError)
-			}
-		}
 	} else {
 		err := service.Datastore.LinkWallet(info.ID, providerLinkingID, anonymousAddress, info.ProviderID, depositProvider)
 		if err != nil {


### PR DESCRIPTION
### Summary

This PR will not allow updates to Anonymous Addresses on wallets.  Based on add-wallet-endpoints feature branch.