### PR TITLE
Correct KYC Flow for Linking Wallets

### DIFF
--- a/wallet/controllers_v3.go
+++ b/wallet/controllers_v3.go
@@ -215,29 +215,6 @@ func LinkUpholdDepositAccountV3(s *Service) func(w http.ResponseWriter, r *http.
 			PubKey:  httpsignature.Ed25519PubKey([]byte(publicKey)),
 		}
 
-		// we need to verify the transaction and use the destination from the transaction
-		if wallet.ProviderID == "" {
-			// parse the signedlinkingreationrequest to get the provider id
-			txInfo, err := uwallet.VerifyTransaction(cuw.SignedLinkingRequest)
-			if err != nil {
-				logger.Warn().Err(err).Msg("failed to transaction validation for uphold")
-				return handlers.WrapError(
-					errors.New("unable to create uphold wallet"),
-					"failed transaction validation for uphold", http.StatusBadRequest)
-			}
-			logger.Debug().Msg("able to verify transaction")
-
-			// get the card id from the submitted destination
-			wallet.ProviderID = txInfo.Destination
-			upholdProvider := "uphold"
-			wallet.UserDepositAccountProvider = &upholdProvider
-			wallet.AnonymousAddress = &aa
-
-			// updated wallet info for uphold wallet
-			uwallet.Info = *wallet
-		}
-
-		// AnonCard Linking
 		err = s.LinkWallet(r.Context(), uwallet, cuw.SignedLinkingRequest, &aa)
 		if err != nil {
 			return handlers.WrapError(err, "error linking wallet", http.StatusBadRequest)

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -105,7 +105,7 @@ func (service *Service) LinkWallet(
 	)
 
 	// verify that the user is kyc from uphold. (for all wallet provider cases)
-	if uID, ok, err := wallet.IsUserKYC(ctx); err != nil {
+	if uID, ok, err := wallet.IsUserKYC(ctx, transaction); err != nil {
 		// there was an error
 		return handlers.WrapError(err,
 			"wallet could not be kyc checked",
@@ -145,6 +145,7 @@ func (service *Service) LinkWallet(
 		}
 		// get the original transaction probi amount
 		probi = tx.Probi
+		info.ProviderID = tx.Destination
 		depositProvider = "uphold"
 	}
 


### PR DESCRIPTION
### Summary

This makes sure the KYC flow is the same for various wallet providers by using the signed transaction "Destination" instead of using the ProviderID on record in the uphold wallet provider case.