### PR TITLE
No Linking While Migrating

### DIFF
--- a/cmd/wallets.go
+++ b/cmd/wallets.go
@@ -20,9 +20,10 @@ var (
 		Short: "provides REST api services",
 		Run:   WalletRestRun,
 	}
-	db                 string
-	walletsFeatureFlag bool
-	roDB               string
+	db                     string
+	walletsFeatureFlag     bool
+	walletsInMigrationFlag bool
+	roDB                   string
 )
 
 func init() {
@@ -44,6 +45,12 @@ func init() {
 		"the feature flag enabling the wallets feature")
 	must(viper.BindPFlag("wallets-feature-flag", walletsCmd.PersistentFlags().Lookup("wallets-feature-flag")))
 	must(viper.BindEnv("wallets-feature-flag", "FEATURE_WALLET"))
+
+	// walletsInMigrationFlag - enable the wallet endpoints through this in migration flag
+	walletsCmd.PersistentFlags().BoolVarP(&walletsInMigrationFlag, "wallets-in-migration-flag", "", false,
+		"the in-migration flag disabling the wallets link feature")
+	must(viper.BindPFlag("wallets-in-migration-flag", walletsCmd.PersistentFlags().Lookup("wallets-in-migration-flag")))
+	must(viper.BindEnv("wallets-in-migration-flag", "WALLETS_IN_MIGRATION"))
 
 	// ro-datastore - the writable datastore
 	walletsCmd.PersistentFlags().StringVarP(&roDB, "ro-datastore", "", "",

--- a/cmd/wallets_rest_run.go
+++ b/cmd/wallets_rest_run.go
@@ -57,9 +57,12 @@ func SetupWalletService(ctx context.Context, r *chi.Mux) (*chi.Mux, context.Cont
 			r.Post("/brave", middleware.InstrumentHandlerFunc(
 				"CreateBraveWallet", wallet.CreateBraveWalletV3))
 
-			// create wallet claim routes for our wallet providers
-			r.Post("/uphold/{paymentID}/claim", middleware.InstrumentHandlerFunc(
-				"LinkUpholdDepositAccount", wallet.LinkUpholdDepositAccountV3(s)))
+			// if wallets are being migrated we do not want to over claim, we might go over the limit
+			if !viper.GetBool("wallets-in-migration-flag") {
+				// create wallet claim routes for our wallet providers
+				r.Post("/uphold/{paymentID}/claim", middleware.InstrumentHandlerFunc(
+					"LinkUpholdDepositAccount", wallet.LinkUpholdDepositAccountV3(s)))
+			}
 
 			// get wallet routes
 			r.Get("/{paymentID}", middleware.InstrumentHandlerFunc(


### PR DESCRIPTION

### Summary

While migration is occurring it is possible that one might go over their linking limit if the wallet has not been migrated yet.  This PR adds a flag to disable the endpoint while migration is in progress.

### Type of change ( select one )

- [ ] Product feature
- [ x ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

When env variable is set the linking endpoint should 404.
