### PR TITLE
Revert Provider ID Storage for "Brave" Provided Wallets

### DIFF
--- a/wallet/instrumented_datastore.go
+++ b/wallet/instrumented_datastore.go
@@ -98,7 +98,7 @@ func (_d DatastoreWithPrometheus) InsertWallet(wallet *walletutils.Info) (err er
 }
 
 // LinkWallet implements Datastore
-func (_d DatastoreWithPrometheus) LinkWallet(ID string, providerID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, depositProvider string) (err error) {
+func (_d DatastoreWithPrometheus) LinkWallet(ID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, depositProvider string) (err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -108,7 +108,7 @@ func (_d DatastoreWithPrometheus) LinkWallet(ID string, providerID string, provi
 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "LinkWallet", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.LinkWallet(ID, providerID, providerLinkingID, anonymousAddress, depositProvider)
+	return _d.base.LinkWallet(ID, providerLinkingID, anonymousAddress, depositProvider)
 }
 
 // Migrate implements Datastore
@@ -175,7 +175,7 @@ func (_d DatastoreWithPrometheus) RollbackTxAndHandle(tx *sqlx.Tx) (err error) {
 }
 
 // TxLinkWalletInfo implements Datastore
-func (_d DatastoreWithPrometheus) TxLinkWalletInfo(tx *sqlx.Tx, ID string, providerID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, pda string) (err error) {
+func (_d DatastoreWithPrometheus) TxLinkWalletInfo(tx *sqlx.Tx, ID string, providerLinkingID uuid.UUID, anonymousAddress *uuid.UUID, pda string) (err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -185,7 +185,7 @@ func (_d DatastoreWithPrometheus) TxLinkWalletInfo(tx *sqlx.Tx, ID string, provi
 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "TxLinkWalletInfo", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.TxLinkWalletInfo(tx, ID, providerID, providerLinkingID, anonymousAddress, pda)
+	return _d.base.TxLinkWalletInfo(tx, ID, providerLinkingID, anonymousAddress, pda)
 }
 
 // UpsertWallet implements Datastore

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -142,11 +142,7 @@ func (service *Service) LinkWallet(
 			return handlers.WrapError(errors.New("wallets do not match"), "unable to match wallets", http.StatusForbidden)
 		}
 	} else {
-		destination := info.ProviderID
-		if info.ProviderID == "" {
-			destination = tx.Destination
-		}
-		err := service.Datastore.LinkWallet(info.ID, destination, providerLinkingID, anonymousAddress, depositProvider)
+		err := service.Datastore.LinkWallet(info.ID, providerLinkingID, anonymousAddress, depositProvider)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if err == ErrTooManyCardsLinked {


### PR DESCRIPTION
### Summary

Removes provider id in linking flow for brave provided wallets.  Brave type wallets have no use for the provider id.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:
