### PR TITLE
Store card id and feature flag to enable linking/draining

### DIFF
--- a/bin/grant-server/main.go
+++ b/bin/grant-server/main.go
@@ -122,7 +122,13 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	r.Mount("/v1/grants", controllers.GrantsRouter(grantService))
 	r.Mount("/v1/promotions", promotion.Router(promotionService))
 	r.Mount("/v2/promotions", promotion.RouterV2(promotionService))
-	r.Mount("/v1/suggestions", promotion.SuggestionsRouter(promotionService))
+
+	sRouter, err := promotion.SuggestionsRouter(promotionService)
+	if err != nil {
+		log.Panic().Err(err).Msg("failed to initialize the suggestions router")
+	}
+
+	r.Mount("/v1/suggestions", sRouter)
 	// temporarily house batloss events in promotion to avoid widespread conflicts later
 	r.Mount("/v1/wallets", promotion.WalletEventRouter(promotionService))
 

--- a/cmd/wallets.go
+++ b/cmd/wallets.go
@@ -22,7 +22,6 @@ var (
 	}
 	db                        string
 	walletsFeatureFlag        bool
-	walletsInMigrationFlag    bool
 	enableLinkingDrainingFlag bool
 	roDB                      string
 )
@@ -46,12 +45,6 @@ func init() {
 		"the feature flag enabling the wallets feature")
 	must(viper.BindPFlag("wallets-feature-flag", walletsCmd.PersistentFlags().Lookup("wallets-feature-flag")))
 	must(viper.BindEnv("wallets-feature-flag", "FEATURE_WALLET"))
-
-	// walletsInMigrationFlag - enable the wallet endpoints through this in migration flag
-	walletsCmd.PersistentFlags().BoolVarP(&walletsInMigrationFlag, "wallets-in-migration-flag", "", false,
-		"the in-migration flag disabling the wallets link feature")
-	must(viper.BindPFlag("wallets-in-migration-flag", walletsCmd.PersistentFlags().Lookup("wallets-in-migration-flag")))
-	must(viper.BindEnv("wallets-in-migration-flag", "WALLETS_IN_MIGRATION"))
 
 	// ENABLE_LINKING_DRAINING - enable ability to link wallets and drain wallets
 	walletsCmd.PersistentFlags().BoolVarP(&enableLinkingDrainingFlag, "enable-linking-draining-flag", "", false,

--- a/cmd/wallets.go
+++ b/cmd/wallets.go
@@ -20,10 +20,10 @@ var (
 		Short: "provides REST api services",
 		Run:   WalletRestRun,
 	}
-	db                        string
-	walletsFeatureFlag        bool
-	enableLinkingDrainingFlag bool
-	roDB                      string
+	db                  string
+	walletsFeatureFlag  bool
+	enableLinkDrainFlag bool
+	roDB                string
 )
 
 func init() {
@@ -47,10 +47,10 @@ func init() {
 	must(viper.BindEnv("wallets-feature-flag", "FEATURE_WALLET"))
 
 	// ENABLE_LINKING_DRAINING - enable ability to link wallets and drain wallets
-	walletsCmd.PersistentFlags().BoolVarP(&enableLinkingDrainingFlag, "enable-linking-draining-flag", "", false,
+	walletsCmd.PersistentFlags().BoolVarP(&enableLinkDrainFlag, "enable-link-drain-flag", "", false,
 		"the in-migration flag disabling the wallets link feature")
-	must(viper.BindPFlag("enable-linking-draining-flag", walletsCmd.PersistentFlags().Lookup("enable-linking-draining-flag")))
-	must(viper.BindEnv("enable-linking-draining-flag", "ENABLE_LINKING_DRAINING"))
+	must(viper.BindPFlag("enable-link-drain-flag", walletsCmd.PersistentFlags().Lookup("enable-link-drain-flag")))
+	must(viper.BindEnv("enable-link-drain-flag", "ENABLE_LINKING_DRAINING"))
 
 	// ro-datastore - the writable datastore
 	walletsCmd.PersistentFlags().StringVarP(&roDB, "ro-datastore", "", "",

--- a/cmd/wallets.go
+++ b/cmd/wallets.go
@@ -20,10 +20,11 @@ var (
 		Short: "provides REST api services",
 		Run:   WalletRestRun,
 	}
-	db                     string
-	walletsFeatureFlag     bool
-	walletsInMigrationFlag bool
-	roDB                   string
+	db                        string
+	walletsFeatureFlag        bool
+	walletsInMigrationFlag    bool
+	enableLinkingDrainingFlag bool
+	roDB                      string
 )
 
 func init() {
@@ -51,6 +52,12 @@ func init() {
 		"the in-migration flag disabling the wallets link feature")
 	must(viper.BindPFlag("wallets-in-migration-flag", walletsCmd.PersistentFlags().Lookup("wallets-in-migration-flag")))
 	must(viper.BindEnv("wallets-in-migration-flag", "WALLETS_IN_MIGRATION"))
+
+	// ENABLE_LINKING_DRAINING - enable ability to link wallets and drain wallets
+	walletsCmd.PersistentFlags().BoolVarP(&enableLinkingDrainingFlag, "enable-linking-draining-flag", "", false,
+		"the in-migration flag disabling the wallets link feature")
+	must(viper.BindPFlag("enable-linking-draining-flag", walletsCmd.PersistentFlags().Lookup("enable-linking-draining-flag")))
+	must(viper.BindEnv("enable-linking-draining-flag", "ENABLE_LINKING_DRAINING"))
 
 	// ro-datastore - the writable datastore
 	walletsCmd.PersistentFlags().StringVarP(&roDB, "ro-datastore", "", "",

--- a/cmd/wallets_rest_run.go
+++ b/cmd/wallets_rest_run.go
@@ -58,7 +58,7 @@ func SetupWalletService(ctx context.Context, r *chi.Mux) (*chi.Mux, context.Cont
 				"CreateBraveWallet", wallet.CreateBraveWalletV3))
 
 			// if wallets are being migrated we do not want to over claim, we might go over the limit
-			if !viper.GetBool("wallets-in-migration-flag") && viper.GetBool("enable-linking-draining-flag") {
+			if viper.GetBool("enable-linking-draining-flag") {
 				// create wallet claim routes for our wallet providers
 				r.Post("/uphold/{paymentID}/claim", middleware.InstrumentHandlerFunc(
 					"LinkUpholdDepositAccount", wallet.LinkUpholdDepositAccountV3(s)))

--- a/cmd/wallets_rest_run.go
+++ b/cmd/wallets_rest_run.go
@@ -58,7 +58,7 @@ func SetupWalletService(ctx context.Context, r *chi.Mux) (*chi.Mux, context.Cont
 				"CreateBraveWallet", wallet.CreateBraveWalletV3))
 
 			// if wallets are being migrated we do not want to over claim, we might go over the limit
-			if !viper.GetBool("wallets-in-migration-flag") {
+			if !viper.GetBool("wallets-in-migration-flag") && viper.GetBool("enable-linking-draining-flag") {
 				// create wallet claim routes for our wallet providers
 				r.Post("/uphold/{paymentID}/claim", middleware.InstrumentHandlerFunc(
 					"LinkUpholdDepositAccount", wallet.LinkUpholdDepositAccountV3(s)))

--- a/cmd/wallets_rest_run.go
+++ b/cmd/wallets_rest_run.go
@@ -58,7 +58,7 @@ func SetupWalletService(ctx context.Context, r *chi.Mux) (*chi.Mux, context.Cont
 				"CreateBraveWallet", wallet.CreateBraveWalletV3))
 
 			// if wallets are being migrated we do not want to over claim, we might go over the limit
-			if viper.GetBool("enable-linking-draining-flag") {
+			if viper.GetBool("enable-link-drain-flag") {
 				// create wallet claim routes for our wallet providers
 				r.Post("/uphold/{paymentID}/claim", middleware.InstrumentHandlerFunc(
 					"LinkUpholdDepositAccount", wallet.LinkUpholdDepositAccountV3(s)))

--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -18,7 +18,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-const currentMigrationVersion = 18
+const currentMigrationVersion = 19
 
 var (
 	// dbInstanceClassToMaxConn -  https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html

--- a/docker-compose.dev-refresh.yml
+++ b/docker-compose.dev-refresh.yml
@@ -25,6 +25,7 @@ services:
       - grant
     environment:
       - PPROF_ENABLED=true
+      - ENABLE_LINKING_DRAINING=true
       - ENV=local
       - DEBUG=1
       - BAT_SETTLEMENT_ADDRESS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
           BUILD_TIME: "${BUILD_TIME}"
     environment:
       - PPROF_ENABLED=true
+      - ENABLE_LINKING_DRAINING=true
       - ENV=local
       - DEBUG=1
       - BAT_SETTLEMENT_ADDRESS
@@ -70,6 +71,7 @@ services:
       - "6061:6061"
     environment:
       - PPROF_ENABLED=true
+      - ENABLE_LINKING_DRAINING=true
       - ENV=local
       - PKG
       - RUN

--- a/migrations/0019_wallet_card_id.down.sql
+++ b/migrations/0019_wallet_card_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE wallets DROP COLUMN card_id;

--- a/migrations/0019_wallet_card_id.down.sql
+++ b/migrations/0019_wallet_card_id.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE wallets DROP COLUMN user_deposit_card_id;
+ALTER TABLE wallets DROP COLUMN user_deposit_destination;

--- a/migrations/0019_wallet_card_id.down.sql
+++ b/migrations/0019_wallet_card_id.down.sql
@@ -1,1 +1,1 @@
-ALTER TABLE wallets DROP COLUMN card_id;
+ALTER TABLE wallets DROP COLUMN user_deposit_card_id;

--- a/migrations/0019_wallet_card_id.up.sql
+++ b/migrations/0019_wallet_card_id.up.sql
@@ -1,1 +1,2 @@
-ALTER TABLE wallets ADD COLUMN user_deposit_card_id text not null default '';
+ALTER TABLE wallets ADD COLUMN user_deposit_destination text not null default '';
+create index wallet_user_deposit_destination_idx on wallets(user_deposit_destination);

--- a/migrations/0019_wallet_card_id.up.sql
+++ b/migrations/0019_wallet_card_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE wallets ADD COLUMN user_deposit_card_id text not null default '';

--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -1293,7 +1293,7 @@ func (suite *ControllersTestSuite) TestSuggestionDrain() {
 	err = s.Sign(privKey, crypto.Hash(0), req)
 	suite.Require().NoError(err)
 
-	info.UserDepositCardID = w.ProviderID
+	info.UserDepositDestination = w.ProviderID
 
 	err = walletDB.UpsertWallet(&info)
 	suite.Require().NoError(err, "Failed to insert wallet")

--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -1284,6 +1284,7 @@ func (suite *ControllersTestSuite) TestSuggestionDrain() {
 
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
 	suite.Require().Equal(http.StatusBadRequest, rr.Code, "Wallet without payout address should fail")
 
 	req, err = http.NewRequest("POST", "/suggestion/drain", bytes.NewBuffer(body))
@@ -1292,8 +1293,7 @@ func (suite *ControllersTestSuite) TestSuggestionDrain() {
 	err = s.Sign(privKey, crypto.Hash(0), req)
 	suite.Require().NoError(err)
 
-	anonymousAddress := uuid.Must(uuid.FromString(w.ProviderID))
-	info.AnonymousAddress = &anonymousAddress
+	info.UserDepositCardID = w.ProviderID
 
 	err = walletDB.UpsertWallet(&info)
 	suite.Require().NoError(err, "Failed to insert wallet")

--- a/utils/wallet/wallet.go
+++ b/utils/wallet/wallet.go
@@ -22,6 +22,7 @@ type Info struct {
 	ProviderLinkingID          *uuid.UUID               `json:"providerLinkingId" valid:"-" db:"provider_linking_id"`
 	AnonymousAddress           *uuid.UUID               `json:"anonymousAddress" valid:"-" db:"anonymous_address"`
 	UserDepositAccountProvider *string                  `json:"userDepositAccountProvider" valid:"in(uphold)" db:"user_deposit_account_provider"`
+	UserDepositCardID          string                   `json:"userDepositCardId" db:"user_deposit_card_id"`
 }
 
 // TransactionInfo contains information about a transaction like the denomination, amount in probi,

--- a/utils/wallet/wallet.go
+++ b/utils/wallet/wallet.go
@@ -22,7 +22,7 @@ type Info struct {
 	ProviderLinkingID          *uuid.UUID               `json:"providerLinkingId" valid:"-" db:"provider_linking_id"`
 	AnonymousAddress           *uuid.UUID               `json:"anonymousAddress" valid:"-" db:"anonymous_address"`
 	UserDepositAccountProvider *string                  `json:"userDepositAccountProvider" valid:"in(uphold)" db:"user_deposit_account_provider"`
-	UserDepositCardID          string                   `json:"userDepositCardId" db:"user_deposit_card_id"`
+	UserDepositDestination     string                   `json:"userDepositCardId" db:"user_deposit_destination"`
 }
 
 // TransactionInfo contains information about a transaction like the denomination, amount in probi,

--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -267,8 +267,8 @@ func (pg *Postgres) TxLinkWalletInfo(
 			UPDATE wallets
 			SET
 				provider_linking_id = $2,
-				user_deposit_account_provider = $3
-				user_deposit_card_id = $4,
+				user_deposit_account_provider = $3,
+				user_deposit_card_id = $4
 			WHERE id = $1;`
 		r, sqlErr = tx.Exec(
 			statement,
@@ -283,7 +283,7 @@ func (pg *Postgres) TxLinkWalletInfo(
 			SET
 					provider_linking_id = $2,
 					anonymous_address = $3,
-					user_deposit_account_provider = $4
+					user_deposit_account_provider = $4,
 					user_deposit_card_id = $5
 			WHERE id = $1;`
 		r, sqlErr = tx.Exec(

--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -132,7 +132,8 @@ func (pg *Postgres) UpsertWallet(wallet *wallet.Info) error {
 		provider_id = $3,
 		provider_linking_id = $5,
 		anonymous_address = $6,
-		user_deposit_account_provider = $7
+		user_deposit_account_provider = $7,
+		user_deposit_card_id = $8
 	returning *`
 	_, err := pg.RawDB().Exec(statement, wallet.ID, wallet.Provider, wallet.ProviderID, wallet.PublicKey, wallet.ProviderLinkingID, wallet.AnonymousAddress, wallet.UserDepositAccountProvider, wallet.UserDepositCardID)
 	if err != nil {

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -142,7 +142,7 @@ func (service *Service) LinkWallet(
 			return handlers.WrapError(errors.New("wallets do not match"), "unable to match wallets", http.StatusForbidden)
 		}
 	} else {
-		// tx.Destination will be stored as "ProviderID"
+		// tx.Destination will be stored as wallet.UserDepositDestination in the wallet info upon linking
 		err := service.Datastore.LinkWallet(info.ID, tx.Destination, providerLinkingID, anonymousAddress, depositProvider)
 		if err != nil {
 			status := http.StatusInternalServerError

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -142,11 +142,8 @@ func (service *Service) LinkWallet(
 			return handlers.WrapError(errors.New("wallets do not match"), "unable to match wallets", http.StatusForbidden)
 		}
 	} else {
-		destination := info.ProviderID
-		if info.ProviderID == "" {
-			destination = tx.Destination
-		}
-		err := service.Datastore.LinkWallet(info.ID, destination, providerLinkingID, anonymousAddress, depositProvider)
+		// tx.Destination will be stored as "ProviderID"
+		err := service.Datastore.LinkWallet(info.ID, tx.Destination, providerLinkingID, anonymousAddress, depositProvider)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if err == ErrTooManyCardsLinked {


### PR DESCRIPTION
### Summary

1. Adds a flag "ENABLE_LINKING_DRAINING" which when set to false will disable linking of wallets and draining of grants.
2. Stores the card id (tx.destination) as provider_id in the database
3. Draining will transfer to provider_id (tx.destination) instead of anon address.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:


