### PR TITLE
removing hard requirement for anon-address in api

### DIFF
--- a/middleware/request_logger.go
+++ b/middleware/request_logger.go
@@ -68,7 +68,7 @@ func RequestLogger(logger *zerolog.Logger) func(next http.Handler) http.Handler 
 
 				// Recover and record stack traces in case of a panic
 				if rec := recover(); rec != nil {
-					logger.Panic().Stack()
+					logger.Panic().Stack().Msg("panic")
 					// consolodate these: `http: proxy error: read tcp x.x.x.x:xxxx->x.x.x.x:xxxx: i/o timeout`
 					// any panic that has an ipaddress/port in it
 					m := string(ipPortRE.ReplaceAll(

--- a/wallet/controllers_v3.go
+++ b/wallet/controllers_v3.go
@@ -188,7 +188,11 @@ func LinkUpholdDepositAccountV3(s *Service) func(w http.ResponseWriter, r *http.
 			return handlers.WrapError(err, "unable to get or create wallets", http.StatusServiceUnavailable)
 		}
 
-		var aa = uuid.Must(uuid.FromString(cuw.AnonymousAddress))
+		var aa uuid.UUID
+
+		if cuw.AnonymousAddress != "" {
+			aa = uuid.Must(uuid.FromString(cuw.AnonymousAddress))
+		}
 
 		publicKey, err := hex.DecodeString(wallet.PublicKey)
 		if err != nil {

--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -179,7 +179,8 @@ func (pg *Postgres) txHasDestination(tx *sqlx.Tx, ID uuid.UUID) (bool, error) {
 	from
 		wallets
 	where
-		user_deposit_destination is not null and
+		user_deposit_destination is not null and 
+		user_deposit_destination != '' and
 		id = $1`
 	var result bool
 	err := tx.Get(&result, statement, ID)


### PR DESCRIPTION
### Summary

Anon Address is no longer required input from the API.  We are not removing the field completely, just no longer panic-ing if it is not in the request.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

Validate in development/staging that this attribute is no longer required.
