### PR TITLE
Check if ENABLE_LINKING_DRAINING is empty string

### DIFF
--- a/promotion/controllers.go
+++ b/promotion/controllers.go
@@ -66,9 +66,16 @@ func SuggestionsRouter(service *Service) (chi.Router, error) {
 	r := chi.NewRouter()
 	r.Method("POST", "/", middleware.InstrumentHandler("MakeSuggestion", MakeSuggestion(service)))
 
-	enableLinkingDraining, err := strconv.ParseBool(os.Getenv("ENABLE_LINKING_DRAINING"))
-	if err != nil {
-		return nil, fmt.Errorf("invalid enable_linking_draining flag: %w", err)
+	var (
+		enableLinkingDraining bool
+		err                   error
+	)
+	// make sure that we only enable the DrainJob if we have linking/draining enabled
+	if os.Getenv("ENABLE_LINKING_DRAINING") != "" {
+		enableLinkingDraining, err = strconv.ParseBool(os.Getenv("ENABLE_LINKING_DRAINING"))
+		if err != nil {
+			return nil, fmt.Errorf("invalid enable_linking_draining flag: %w", err)
+		}
 	}
 
 	if enableLinkingDraining {

--- a/promotion/service.go
+++ b/promotion/service.go
@@ -389,10 +389,14 @@ func InitService(
 		},
 	}
 
+	var enableLinkingDraining bool
 	// make sure that we only enable the DrainJob if we have linking/draining enabled
-	enableLinkingDraining, err := strconv.ParseBool(os.Getenv("ENABLE_LINKING_DRAINING"))
-	if err != nil {
-		return nil, fmt.Errorf("invalid enable_linking_draining flag: %w", err)
+	if os.Getenv("ENABLE_LINKING_DRAINING") != "" {
+		enableLinkingDraining, err = strconv.ParseBool(os.Getenv("ENABLE_LINKING_DRAINING"))
+		if err != nil {
+			// there was an error parsing the environment variable
+			return nil, fmt.Errorf("invalid enable_linking_draining flag: %w", err)
+		}
 	}
 
 	if enableLinkingDraining {


### PR DESCRIPTION
### Summary

ParseBool does not recognize the empty string as a synonym of "false", so check to see if the env variable is empty prior to parsing as bool

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

