### PR TITLE
Read Wallet Env Vars in Grant Bin

### DIFF
--- a/bin/grant-server/main.go
+++ b/bin/grant-server/main.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/asaskevich/govalidator"
+	// re-using viper bind-env for wallet env variables
+	_ "github.com/brave-intl/bat-go/cmd/wallets"
 	"github.com/brave-intl/bat-go/grant"
 	"github.com/brave-intl/bat-go/middleware"
 	"github.com/brave-intl/bat-go/payment"

--- a/promotion/service_test.go
+++ b/promotion/service_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/brave-intl/bat-go/cmd"
+	// re-using viper bind-env for wallet env variables
+	_ "github.com/brave-intl/bat-go/cmd/wallets"
 	"github.com/brave-intl/bat-go/utils/inputs"
+	"github.com/brave-intl/bat-go/wallet"
 	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/suite"
 )
@@ -61,7 +63,7 @@ func TestServiceTestSuite(t *testing.T) {
 func (suite *ServiceTestSuite) createService() (*Service, context.Context) {
 	ctx := context.Background()
 	r := chi.NewRouter()
-	r, ctx, walletService := cmd.SetupWalletService(ctx, r)
+	r, ctx, walletService := wallet.SetupService(ctx, r)
 	promotionDB, promotionRODB, err := NewPostgres()
 	suite.Require().NoError(err, "unable connect to promotion db")
 	s, err := InitService(


### PR DESCRIPTION


### Summary

Fix to allow viper bind env to be run in grants binary, as we were no longer importing the cmd/wallets package.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

Validate that the /v3/wallets endpoints are visible.
