### PR TITLE
Setup Context for Rewards Server prior to Logger Creation

### DIFF
--- a/cmd/rewards/rest_run.go
+++ b/cmd/rewards/rest_run.go
@@ -35,7 +35,6 @@ func RestRun(command *cobra.Command, args []string) {
 	}
 
 	// add our command line params to context
-	ctx = context.WithValue(ctx, appctx.EnvironmentCTXKey, viper.Get("environment"))
 	ctx = context.WithValue(ctx, appctx.RatiosServerCTXKey, viper.Get("ratios-service"))
 	ctx = context.WithValue(ctx, appctx.RatiosAccessTokenCTXKey, viper.Get("ratios-token"))
 	ctx = context.WithValue(ctx, appctx.BaseCurrencyCTXKey, viper.Get("base-currency"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,8 +45,9 @@ func Must(err error) {
 
 // Execute - the main entrypoint for all subcommands in bat-go
 func Execute() {
-	// setup context with logging
+	// setup context with logging, but first we need to setup the environment
 	var logger *zerolog.Logger
+	ctx = context.WithValue(ctx, appctx.EnvironmentCTXKey, viper.Get("environment"))
 	ctx, logger = logging.SetupLogger(ctx)
 	// setup ratios service values
 	ctx = context.WithValue(ctx, appctx.RatiosServerCTXKey, viper.Get("ratios-service"))
@@ -67,8 +68,8 @@ func init() {
 	Must(viper.BindPFlag("pprof-enabled", RootCmd.PersistentFlags().Lookup("pprof-enabled")))
 	Must(viper.BindEnv("pprof-enabled", "PPROF_ENABLED"))
 
-	// env - defaults to development
-	RootCmd.PersistentFlags().StringVarP(&env, "environment", "e", "development",
+	// env - defaults to local
+	RootCmd.PersistentFlags().StringVarP(&env, "environment", "e", "local",
 		"the default environment")
 	Must(viper.BindPFlag("environment", RootCmd.PersistentFlags().Lookup("environment")))
 	Must(viper.BindEnv("environment", "ENV"))


### PR DESCRIPTION
### Summary

The logging in api.rewards was defaulting to 'local' style logging for all environments.  This corrects the issue by setting up the context with 'environment' prior to creation of the logger. 

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

Watch logs in a non-local environment to make sure they are correctly formatted as json.
