### PR TITLE
Metrics Bleed across Subcommands

### DIFF
--- a/payment/controllers_test.go
+++ b/payment/controllers_test.go
@@ -408,7 +408,7 @@ func (suite *ControllersTestSuite) TestAnonymousCardE2E() {
 		},
 	}
 
-	err = service.InitKafka()
+	err = service.InitKafka(context.Background())
 	suite.Require().NoError(err, "Failed to initialize kafka")
 
 	log.Printf("!!! time to startup kafka: %+v\n", time.Now().Sub(start))

--- a/payment/service.go
+++ b/payment/service.go
@@ -59,18 +59,6 @@ func (s *Service) Jobs() []srv.Job {
 	return s.jobs
 }
 
-// InitCodecs used for Avro encoding / decoding
-func (s *Service) InitCodecs() error {
-	s.codecs = make(map[string]*goavro.Codec)
-
-	voteEventCodec, err := goavro.NewCodec(string(voteSchema))
-	s.codecs["vote"] = voteEventCodec
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // InitKafka by creating a kafka writer and creating local copies of codecs
 func (s *Service) InitKafka(ctx context.Context) error {
 
@@ -83,9 +71,12 @@ func (s *Service) InitKafka(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize kafka: %w", err)
 	}
 
-	err = s.InitCodecs()
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"vote": voteSchema,
+	})
+
 	if err != nil {
-		return fmt.Errorf("failed to initialize kafka: %w", err)
+		return fmt.Errorf("failed to generate codecs kafka: %w", err)
 	}
 	return nil
 }

--- a/payment/service.go
+++ b/payment/service.go
@@ -9,7 +9,6 @@ import (
 
 	"errors"
 
-	appctx "github.com/brave-intl/bat-go/utils/context"
 	"github.com/brave-intl/bat-go/utils/logging"
 	srv "github.com/brave-intl/bat-go/utils/service"
 	"github.com/brave-intl/bat-go/utils/wallet/provider/uphold"
@@ -36,22 +35,6 @@ var (
 		Help: "Date when the kafka certificate expires.",
 	})
 )
-
-func init() {
-	// put environment on context before logger setup
-	ctx := context.WithValue(context.Background(), appctx.EnvironmentCTXKey, os.Getenv("ENV"))
-	_, logger := logging.SetupLogger(ctx)
-	var err error
-	// gracefully try to register collectors for prom, no need to panic
-	err = prometheus.Register(kafkaCertNotBefore)
-	if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		logger.Warn().Err(err).Msg("already registered kafkaCertNotBefore collector")
-	}
-	err = prometheus.Register(kafkaCertNotAfter)
-	if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		logger.Warn().Err(err).Msg("already registered kafkaCertNotAfter collector")
-	}
-}
 
 // Service contains datastore
 type Service struct {
@@ -101,6 +84,17 @@ func (s *Service) InitCodecs() error {
 func (s *Service) InitKafka() error {
 
 	_, logger := logging.SetupLogger(context.Background())
+
+	var err error
+	// gracefully try to register collectors for prom, no need to panic
+	err = prometheus.Register(kafkaCertNotBefore)
+	if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		logger.Warn().Err(err).Msg("already registered kafkaCertNotBefore collector")
+	}
+	err = prometheus.Register(kafkaCertNotAfter)
+	if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		logger.Warn().Err(err).Msg("already registered kafkaCertNotAfter collector")
+	}
 
 	dialer, x509Cert, err := kafkautils.TLSDialer()
 	if err != nil {

--- a/payment/vote_test.go
+++ b/payment/vote_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/brave-intl/bat-go/datastore/grantserver"
 	"github.com/brave-intl/bat-go/utils/clients/cbr"
+	kafkautils "github.com/brave-intl/bat-go/utils/kafka"
 )
 
 type BytesContains []byte
@@ -47,9 +48,13 @@ func TestVoteAnonCard(t *testing.T) {
 		}
 		oldGenerateCredentialRedemptions = generateCredentialRedemptions
 		db, mock, _                      = sqlmock.New()
+		err                              error
 	)
 	// avro codecs
-	if err := s.InitCodecs(); err != nil {
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"vote": voteSchema,
+	})
+	if err != nil {
 		t.Error("failed to initialize avro codecs for test: ", err)
 	}
 	s.Datastore = Datastore(
@@ -77,7 +82,7 @@ func TestVoteAnonCard(t *testing.T) {
 		generateCredentialRedemptions = oldGenerateCredentialRedemptions
 	}()
 
-	err := s.Vote(
+	err = s.Vote(
 		context.Background(), []CredentialBinding{}, voteText)
 	if err != nil {
 		t.Error("encountered an error in Vote call: ", err.Error())
@@ -97,9 +102,13 @@ func TestVoteUnknownSKU(t *testing.T) {
 			}, nil
 		}
 		oldGenerateCredentialRedemptions = generateCredentialRedemptions
+		err                              error
 	)
 	// avro codecs
-	if err := s.InitCodecs(); err != nil {
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"vote": voteSchema,
+	})
+	if err != nil {
 		t.Error("failed to initialize avro codecs for test: ", err)
 	}
 	voteText := base64.StdEncoding.EncodeToString([]byte(`{"channel":"brave.com", "type":"auto-contribute"}`))
@@ -109,7 +118,7 @@ func TestVoteUnknownSKU(t *testing.T) {
 		generateCredentialRedemptions = oldGenerateCredentialRedemptions
 	}()
 
-	err := s.Vote(
+	err = s.Vote(
 		context.Background(), []CredentialBinding{}, voteText)
 	if err == nil {
 		t.Error("should have encountered an error in Vote call: ")
@@ -132,9 +141,13 @@ func TestVoteUnknownBadMerch(t *testing.T) {
 			}, nil
 		}
 		oldGenerateCredentialRedemptions = generateCredentialRedemptions
+		err                              error
 	)
 	// avro codecs
-	if err := s.InitCodecs(); err != nil {
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"vote": voteSchema,
+	})
+	if err != nil {
 		t.Error("failed to initialize avro codecs for test: ", err)
 	}
 	voteText := base64.StdEncoding.EncodeToString([]byte(`{"channel":"brave.com", "type":"auto-contribute"}`))
@@ -144,7 +157,7 @@ func TestVoteUnknownBadMerch(t *testing.T) {
 		generateCredentialRedemptions = oldGenerateCredentialRedemptions
 	}()
 
-	err := s.Vote(
+	err = s.Vote(
 		context.Background(), []CredentialBinding{}, voteText)
 	if err == nil {
 		t.Error("should have encountered an error in Vote call: ")
@@ -171,9 +184,13 @@ func TestVoteGoodAndBadSKU(t *testing.T) {
 			}, nil
 		}
 		oldGenerateCredentialRedemptions = generateCredentialRedemptions
+		err                              error
 	)
 	// avro codecs
-	if err := s.InitCodecs(); err != nil {
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"vote": voteSchema,
+	})
+	if err != nil {
 		t.Error("failed to initialize avro codecs for test: ", err)
 	}
 	voteText := base64.StdEncoding.EncodeToString([]byte(`{"channel":"brave.com", "type":"auto-contribute"}`))
@@ -183,7 +200,7 @@ func TestVoteGoodAndBadSKU(t *testing.T) {
 		generateCredentialRedemptions = oldGenerateCredentialRedemptions
 	}()
 
-	err := s.Vote(
+	err = s.Vote(
 		context.Background(), []CredentialBinding{}, voteText)
 	if err == nil {
 		t.Error("should have encountered an error in Vote call: ")

--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -577,7 +577,7 @@ func (suite *ControllersTestSuite) TestSuggest() {
 		reputationClient: mockReputation,
 	}
 
-	err = service.InitKafka()
+	err = service.InitKafka(context.Background())
 	suite.Require().NoError(err, "Failed to initialize kafka")
 
 	promotion, err := service.Datastore.CreatePromotion("ugp", 2, decimal.NewFromFloat(0.25), "")
@@ -1447,7 +1447,7 @@ func (suite *ControllersTestSuite) TestBraveFundsTransaction() {
 		reputationClient: mockReputation,
 	}
 
-	err = service.InitKafka()
+	err = service.InitKafka(context.Background())
 	suite.Require().NoError(err, "Failed to initialize kafka")
 
 	promotion, err := service.Datastore.CreatePromotion("ugp", 2, decimal.NewFromFloat(0.25), "")

--- a/promotion/service.go
+++ b/promotion/service.go
@@ -93,40 +93,6 @@ func SetSuggestionTopic(newTopic string) {
 	suggestionTopic = newTopic
 }
 
-func init() {
-
-	// register metrics with prometheus
-	err := prometheus.Register(countGrantsClaimedBatTotal)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		countGrantsClaimedBatTotal = ae.ExistingCollector.(*prometheus.CounterVec)
-	}
-
-	err = prometheus.Register(countGrantsClaimedTotal)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		countGrantsClaimedTotal = ae.ExistingCollector.(*prometheus.CounterVec)
-	}
-
-	err = prometheus.Register(countContributionsBatTotal)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		countContributionsBatTotal = ae.ExistingCollector.(*prometheus.CounterVec)
-	}
-
-	err = prometheus.Register(countContributionsTotal)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		countContributionsTotal = ae.ExistingCollector.(*prometheus.CounterVec)
-	}
-
-	err = prometheus.Register(kafkaCertNotAfter)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		kafkaCertNotAfter = ae.ExistingCollector.(prometheus.Gauge)
-	}
-
-	err = prometheus.Register(kafkaCertNotBefore)
-	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
-		kafkaCertNotBefore = ae.ExistingCollector.(prometheus.Gauge)
-	}
-}
-
 // Service contains datastore and challenge bypass client connections
 type Service struct {
 	wallet                  *wallet.Service
@@ -166,6 +132,16 @@ func (s *Service) InitCodecs() error {
 func (s *Service) InitKafka() error {
 
 	_, logger := logging.SetupLogger(context.Background())
+
+	err := prometheus.Register(kafkaCertNotAfter)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		kafkaCertNotAfter = ae.ExistingCollector.(prometheus.Gauge)
+	}
+
+	err = prometheus.Register(kafkaCertNotBefore)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		kafkaCertNotBefore = ae.ExistingCollector.(prometheus.Gauge)
+	}
 
 	dialer, x509Cert, err := kafkautils.TLSDialer()
 	if err != nil {
@@ -240,6 +216,28 @@ func InitService(
 	promotionRODB ReadOnlyDatastore,
 	walletService *wallet.Service,
 ) (*Service, error) {
+
+	// register metrics with prometheus
+	err := prometheus.Register(countGrantsClaimedBatTotal)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		countGrantsClaimedBatTotal = ae.ExistingCollector.(*prometheus.CounterVec)
+	}
+
+	err = prometheus.Register(countGrantsClaimedTotal)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		countGrantsClaimedTotal = ae.ExistingCollector.(*prometheus.CounterVec)
+	}
+
+	err = prometheus.Register(countContributionsBatTotal)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		countContributionsBatTotal = ae.ExistingCollector.(*prometheus.CounterVec)
+	}
+
+	err = prometheus.Register(countContributionsTotal)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		countContributionsTotal = ae.ExistingCollector.(*prometheus.CounterVec)
+	}
+
 	cbClient, err := cbr.New()
 	if err != nil {
 		return nil, err

--- a/promotion/service.go
+++ b/promotion/service.go
@@ -99,18 +99,6 @@ func (s *Service) Jobs() []srv.Job {
 	return s.jobs
 }
 
-// InitCodecs used for Avro encoding / decoding
-func (s *Service) InitCodecs() error {
-	s.codecs = make(map[string]*goavro.Codec)
-
-	suggestionEventCodec, err := goavro.NewCodec(string(suggestionEventSchema))
-	s.codecs["suggestion"] = suggestionEventCodec
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // InitKafka by creating a kafka writer and creating local copies of codecs
 func (s *Service) InitKafka(ctx context.Context) error {
 
@@ -123,9 +111,12 @@ func (s *Service) InitKafka(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize kafka: %w", err)
 	}
 
-	err = s.InitCodecs()
+	s.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"suggestion": suggestionEventSchema,
+	})
+
 	if err != nil {
-		return fmt.Errorf("failed to initialize kafka: %w", err)
+		return fmt.Errorf("failed to generate codecs kafka: %w", err)
 	}
 	return nil
 }

--- a/promotion/suggestions_test.go
+++ b/promotion/suggestions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	kafkautils "github.com/brave-intl/bat-go/utils/kafka"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,8 +53,15 @@ func TestUnmarshalText(t *testing.T) {
 }
 
 func TestTryUpgradeSuggestionEvent(t *testing.T) {
-	var service Service
-	err := service.InitCodecs()
+	var (
+		service Service
+		err     error
+	)
+
+	service.codecs, err = kafkautils.GenerateCodecs(map[string]string{
+		"suggestion": suggestionEventSchema,
+	})
+
 	assert.NoError(t, err, "Failed to initialize codecs")
 
 	suggestion := `{"id":"d6e6f7f2-8975-4105-8fef-2ad89e299add","type":"oneoff-tip","channel":"3zsistemi.si","totalAmount":"10","funding":[{"type":"ugp","amount":"10","cohort":"control","promotion":"1d54793b-e8e7-4e96-890f-a1836cab9533"}]}`

--- a/utils/context/keys.go
+++ b/utils/context/keys.go
@@ -43,6 +43,10 @@ const (
 	CommitCTXKey CTXKey = "commit"
 	// BuildTimeCTXKey - context key for the build time of code
 	BuildTimeCTXKey CTXKey = "build_time"
+	// Kafka509CertCTXKey - context key for the build time of code
+	Kafka509CertCTXKey CTXKey = "kafka_x509_cert"
+	// KafkaBrokersCTXKey - context key for the build time of code
+	KafkaBrokersCTXKey CTXKey = "kafka_brokers"
 )
 
 var (

--- a/utils/kafka/dialer.go
+++ b/utils/kafka/dialer.go
@@ -7,11 +7,13 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/linkedin/goavro"
 	kafka "github.com/segmentio/kafka-go"
 
 	appctx "github.com/brave-intl/bat-go/utils/context"
@@ -155,4 +157,19 @@ func InitKafkaWriter(ctx context.Context, topic string) (*kafka.Writer, *kafka.D
 	})
 
 	return kafkaWriter, dialer, nil
+}
+
+// GenerateCodecs - create a map of codec name to the avro codec
+func GenerateCodecs(codecs map[string]string) (map[string]*goavro.Codec, error) {
+	var (
+		res = make(map[string]*goavro.Codec)
+		err error
+	)
+	for k, v := range codecs {
+		res[k], err = goavro.NewCodec(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate codec: %w", err)
+		}
+	}
+	return res, nil
 }

--- a/utils/kafka/instrument.go
+++ b/utils/kafka/instrument.go
@@ -1,0 +1,57 @@
+package kafka
+
+import (
+	"context"
+	"crypto/x509"
+
+	appctx "github.com/brave-intl/bat-go/utils/context"
+	"github.com/brave-intl/bat-go/utils/logging"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// kafkaCertNotAfter checks when the kafka certificate becomes valid
+	kafkaCertNotBefore = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "kafka_cert_not_before",
+			Help: "Date when the kafka certificate becomes valid.",
+		},
+	)
+
+	// kafkaCertNotAfter checks when the kafka certificate expires
+	kafkaCertNotAfter = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "kafka_cert_not_after",
+			Help: "Date when the kafka certificate expires.",
+		},
+	)
+)
+
+// InstrumentKafka - setup instrumentation and metrics around our kafka connection
+func InstrumentKafka(ctx context.Context) {
+	_, logger := logging.SetupLogger(ctx)
+
+	cert, ok := ctx.Value(appctx.Kafka509CertCTXKey).(*x509.Certificate)
+	if !ok {
+		// no cert on context
+		logger.Info().Msg("no kafka cert on context, not initializing kafka instrumentation")
+		return
+	}
+
+	err := prometheus.Register(kafkaCertNotAfter)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		kafkaCertNotAfter = ae.ExistingCollector.(prometheus.Gauge)
+	}
+
+	err = prometheus.Register(kafkaCertNotBefore)
+	if ae, ok := err.(prometheus.AlreadyRegisteredError); ok {
+		kafkaCertNotBefore = ae.ExistingCollector.(prometheus.Gauge)
+	}
+
+	logger.Info().Msg("registered kafka cert not before and not after prom metrics")
+
+	kafkaCertNotBefore.Set(float64(cert.NotBefore.Unix()))
+	kafkaCertNotAfter.Set(float64(cert.NotAfter.Unix()))
+
+	logger.Info().Msg("set values for kafka cert not before and not after prom metrics")
+}


### PR DESCRIPTION
### Summary

move metrics out of init so they will not bleed into services for which not applicable.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

Validate that metrics not applicable for rewards sub-command are not present.
