### PR TITLE
update status code to cause error when ios linking limit is exceeded

### DIFF
--- a/wallet/service.go
+++ b/wallet/service.go
@@ -282,7 +282,9 @@ func (service *Service) LinkBraveWallet(ctx context.Context, from, to uuid.UUID)
 	if err := service.Datastore.LinkWallet(ctx, from.String(), to.String(), providerLinkingID, nil, "brave"); err != nil {
 		status := http.StatusInternalServerError
 		if err == ErrTooManyCardsLinked {
-			status = http.StatusConflict
+			// we are not allowing draining to wallets that exceed the linking limits
+			// this will cause an error in the client prior to attempting draining
+			status = http.StatusTeapot
 		}
 		return handlers.WrapError(err, "unable to link wallets", status)
 	}


### PR DESCRIPTION
### Summary

In the event an iOS device attempts to link to a desktop wallet that will make the desktop wallet exceed it's linking limit we want to return a failure before the client attempts to transfer vg.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

