### PR TITLE
One Claim Drain Entry per API Call

### DIFF
--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -875,11 +875,15 @@ func (pg *Postgres) DrainClaims(claims []*Claim, credentials []cbr.CredentialRed
 	}
 	defer pg.RollbackTx(tx)
 
+	var claimIDs []interface{}
+
 	for _, claim := range claims {
-		_, err = tx.Exec(`update claims set drained = true where id = $1 and not drained`, claim.ID)
-		if err != nil {
-			return err
-		}
+		claimIDs = append(claimIDs, claim.ID)
+	}
+
+	_, err = tx.Exec(`update claims set drained = true where id in ($1::uuid[]) and not drained`, claimIDs)
+	if err != nil {
+		return err
 	}
 
 	statement := `

--- a/promotion/instrumented_datastore.go
+++ b/promotion/instrumented_datastore.go
@@ -143,6 +143,20 @@ func (_d DatastoreWithPrometheus) DrainClaim(claim *Claim, credentials []cbr.Cre
 	return _d.base.DrainClaim(claim, credentials, wallet, total)
 }
 
+// DrainClaims implements Datastore
+func (_d DatastoreWithPrometheus) DrainClaims(claim []*Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal) (err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "DrainClaims", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.DrainClaims(claim, credentials, wallet, total)
+}
+
 // GetAvailablePromotions implements Datastore
 func (_d DatastoreWithPrometheus) GetAvailablePromotions(platform string) (pa1 []Promotion, err error) {
 	_since := time.Now()

--- a/wallet/controllers_v3.go
+++ b/wallet/controllers_v3.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -392,17 +391,6 @@ func GetUpholdWalletBalanceV3(w http.ResponseWriter, r *http.Request) *handlers.
 
 // LinkBraveDepositAccountV3 - produces an http handler for the service s which handles deposit account linking of brave wallets
 func LinkBraveDepositAccountV3(s *Service) func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-		return &handlers.AppError{
-			Cause:   fmt.Errorf("Internal Error"),
-			Message: "Internal Error",
-			Code:    http.StatusInternalServerError,
-		}
-	}
-}
-
-// LinkBraveDepositAccountV4 - produces an http handler for the service s which handles deposit account linking of brave wallets
-func LinkBraveDepositAccountV4(s *Service) func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 		var (
 			ctx = r.Context()

--- a/wallet/controllers_v3_test.go
+++ b/wallet/controllers_v3_test.go
@@ -45,7 +45,7 @@ type result struct{}
 func (r result) LastInsertId() (int64, error) { return 1, nil }
 func (r result) RowsAffected() (int64, error) { return 1, nil }
 
-func TestLinkBraveWalletV4(t *testing.T) {
+func TestLinkBraveWalletV3(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	var (
@@ -73,7 +73,7 @@ func TestLinkBraveWalletV4(t *testing.T) {
 				}`),
 		)
 		mockReputation = mockreputation.NewMockClient(mockCtrl)
-		handler        = wallet.LinkBraveDepositAccountV4(&wallet.Service{
+		handler        = wallet.LinkBraveDepositAccountV3(&wallet.Service{
 			Datastore: datastore,
 		})
 		w = httptest.NewRecorder()


### PR DESCRIPTION
### Summary

reduce the number of claim drain queue entries to one per api call

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
