### PR TITLE
Token Drain Status Polling Endpoint

### DIFF
--- a/cmd/serve/grant.go
+++ b/cmd/serve/grant.go
@@ -166,6 +166,14 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 	}
 
 	r.Mount("/v1/suggestions", sRouter)
+
+	sV2Router, err := promotion.SuggestionsV2Router(promotionService)
+	if err != nil {
+		logger.Panic().Err(err).Msg("failed to initialize the suggestions router")
+	}
+
+	r.Mount("/v2/suggestions", sV2Router)
+
 	// temporarily house batloss events in promotion to avoid widespread conflicts later
 	r.Mount("/v1/wallets", promotion.WalletEventRouter(promotionService))
 

--- a/datastore/grantserver/postgres.go
+++ b/datastore/grantserver/postgres.go
@@ -23,7 +23,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-const currentMigrationVersion = 23
+const currentMigrationVersion = 24
 
 var (
 	// dbInstanceClassToMaxConn -  https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Managing.html

--- a/migrations/0024_drain_poll.down.sql
+++ b/migrations/0024_drain_poll.down.sql
@@ -1,0 +1,2 @@
+drop table drain_poll;
+drop table claim_drain_poll;

--- a/migrations/0024_drain_poll.down.sql
+++ b/migrations/0024_drain_poll.down.sql
@@ -1,2 +1,7 @@
-drop table drain_poll;
-drop table claim_drain_poll;
+drop index batch_id_idx;
+--- completed indicates this claim_drain job is drained and complete
+alter table claim_drain drop column completed;
+--- completed_at indicates the time at which this claim_drain job was completed
+alter table claim_drain drop column completed_at;
+--- batch_id is the draining batch that this claim drain job belongs to
+alter table claim_drain drop column batch_id;

--- a/migrations/0024_drain_poll.up.sql
+++ b/migrations/0024_drain_poll.up.sql
@@ -1,18 +1,8 @@
---- drain poll table holds the identifier handed out by
---- /v2/suggestions/claim which will track the progress of
---- the various drain jobs.  Of all the tokens passed in
---- they are segregated by promotion id, and turned into
---- drain jobs.
-create table drain_poll (
-    id uuid primary key not null default uuid_generate_v4(),
-    status varchar(32) not null default 'pending'
-);
-
---- claim drain poll table is the linkage between
---- the claim_drain table and the drain_poll table
-create table claim_drain_poll (
-    drain_poll_id uuid not null,
-    claim_drain_id uuid not null,
-    complete boolean not null default false,
-    primary key (drain_poll_id, claim_drain_id)
-);
+--- completed indicates this claim_drain job is drained and complete
+alter table claim_drain add column completed boolean not null default false;
+--- completed_at indicates the time at which this claim_drain job was completed
+alter table claim_drain add column completed_at timestamp;
+--- batch_id is the draining batch that this claim drain job belongs to
+alter table claim_drain add column batch_id uuid default null;
+--- create an index on the batch_id for easy lookup
+create index batch_id_idx on claim_drain(batch_id);

--- a/migrations/0024_drain_poll.up.sql
+++ b/migrations/0024_drain_poll.up.sql
@@ -1,0 +1,18 @@
+--- drain poll table holds the identifier handed out by
+--- /v2/suggestions/claim which will track the progress of
+--- the various drain jobs.  Of all the tokens passed in
+--- they are segregated by promotion id, and turned into
+--- drain jobs.
+create table drain_poll (
+    id uuid primary key not null default uuid_generate_v4(),
+    status varchar(32) not null default 'pending'
+);
+
+--- claim drain poll table is the linkage between
+--- the claim_drain table and the drain_poll table
+create table claim_drain_poll (
+    drain_poll_id uuid not null,
+    claim_drain_id uuid not null,
+    complete boolean not null default false,
+    primary key (drain_poll_id, claim_drain_id)
+);

--- a/promotion/controllers.go
+++ b/promotion/controllers.go
@@ -58,7 +58,29 @@ func Router(service *Service) chi.Router {
 	r.Method("POST", "/reportclobberedclaims", middleware.InstrumentHandler("ReportClobberedClaims", PostReportClobberedClaims(service, 1)))
 	r.Method("POST", "/{promotionId}", middleware.HTTPSignedOnly(service)(middleware.InstrumentHandler("ClaimPromotion", ClaimPromotion(service))))
 	r.Method("GET", "/{promotionId}/claims/{claimId}", middleware.InstrumentHandler("GetClaim", GetClaim(service)))
+	r.Method("GET", "/drain/{drainId}", middleware.InstrumentHandler("GetDrainPoll", GetDrainPoll(service)))
 	return r
+}
+
+// SuggestionsV2Router for suggestions endpoints
+func SuggestionsV2Router(service *Service) (chi.Router, error) {
+	r := chi.NewRouter()
+	var (
+		enableLinkingDraining bool
+		err                   error
+	)
+	// make sure that we only enable the DrainJob if we have linking/draining enabled
+	if os.Getenv("ENABLE_LINKING_DRAINING") != "" {
+		enableLinkingDraining, err = strconv.ParseBool(os.Getenv("ENABLE_LINKING_DRAINING"))
+		if err != nil {
+			return nil, fmt.Errorf("invalid enable_linking_draining flag: %w", err)
+		}
+	}
+
+	if enableLinkingDraining {
+		r.Method("POST", "/claim", middleware.HTTPSignedOnly(service)(middleware.InstrumentHandler("DrainSuggestionV2", DrainSuggestionV2(service))))
+	}
+	return r, nil
 }
 
 // SuggestionsRouter for suggestions endpoints
@@ -268,6 +290,51 @@ func ClaimPromotion(service *Service) handlers.AppHandler {
 	})
 }
 
+// DrainPollResponse - structure for a drain poll response
+type DrainPollResponse struct {
+	ID     *uuid.UUID `json:"drainId"`
+	Status string     `json:"status"`
+}
+
+// GetDrainPoll is the handler for checking on a particular claim's status
+func GetDrainPoll(service *Service) handlers.AppHandler {
+	return handlers.AppHandler(func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		var drainID = new(inputs.ID)
+		if err := inputs.DecodeAndValidateString(context.Background(), drainID, chi.URLParam(r, "drainId")); err != nil {
+			return handlers.ValidationError(
+				"Error validating request url parameter",
+				map[string]interface{}{
+					"drainId": err.Error(),
+				},
+			)
+		}
+
+		var resp = &DrainPollResponse{}
+
+		drainPoll, err := service.Datastore.GetDrainPoll(drainID.UUID())
+		if err != nil {
+			return handlers.WrapError(err, "Error getting drain poll by id", http.StatusBadRequest)
+		}
+
+		if drainPoll == nil {
+			return &handlers.AppError{
+				Message: "Drain Job does not exist",
+				Code:    http.StatusNotFound,
+				Data:    map[string]interface{}{},
+			}
+		}
+
+		resp.ID = drainPoll.ID
+		resp.Status = drainPoll.Status
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+		return nil
+	})
+}
+
 // GetClaimResponse includes signed credentials and a batch proof showing they were signed by the public key
 type GetClaimResponse struct {
 	SignedCreds jsonutils.JSONStringArray `json:"signedCreds"`
@@ -408,6 +475,67 @@ func MakeSuggestion(service *Service) handlers.AppHandler {
 	})
 }
 
+// DrainSuggestionV2Request includes the ID of the verified wallet attempting to drain suggestions
+// and returns the drain_poll uuid so the client can poll for status updates on this draining
+type DrainSuggestionV2Request struct {
+	WalletID    uuid.UUID           `json:"paymentId" valid:"-"`
+	Credentials []CredentialBinding `json:"credentials"`
+}
+
+// DrainSuggestionV2Response - the response structure of the token draining endpoint v2
+type DrainSuggestionV2Response struct {
+	DrainID *uuid.UUID `json:"drainId"`
+}
+
+// DrainSuggestionV2 is the handler for draining ad suggestions for a verified wallet
+func DrainSuggestionV2(service *Service) handlers.AppHandler {
+	return handlers.AppHandler(func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		var (
+			req  DrainSuggestionV2Request
+			resp = DrainSuggestionV2Response{}
+		)
+		err := requestutils.ReadJSON(r.Body, &req)
+		if err != nil {
+			return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
+		}
+
+		_, err = govalidator.ValidateStruct(req)
+		if err != nil {
+			return handlers.WrapValidationError(err)
+		}
+
+		logging.AddWalletIDToContext(r.Context(), req.WalletID)
+
+		keyID, err := middleware.GetKeyID(r.Context())
+		if err != nil {
+			return handlers.WrapError(err, "Error looking up http signature info", http.StatusBadRequest)
+		}
+		if req.WalletID.String() != keyID {
+			return handlers.ValidationError("request",
+				map[string]string{"paymentId": "paymentId must match signature"})
+		}
+
+		resp.DrainID, err = service.Drain(r.Context(), req.Credentials, req.WalletID)
+		if err != nil {
+			switch err.(type) {
+			case govalidator.Error:
+				return handlers.WrapValidationError(err)
+			case govalidator.Errors:
+				return handlers.WrapValidationError(err)
+			default:
+				// FIXME not all remaining errors should be mapped to 400
+				return handlers.WrapError(err, "Error draining", http.StatusBadRequest)
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+		return nil
+	})
+}
+
 // DrainSuggestionRequest includes the ID of the verified wallet attempting to drain suggestions
 type DrainSuggestionRequest struct {
 	WalletID    uuid.UUID           `json:"paymentId" valid:"-"`
@@ -439,7 +567,7 @@ func DrainSuggestion(service *Service) handlers.AppHandler {
 				map[string]string{"paymentId": "paymentId must match signature"})
 		}
 
-		err = service.Drain(r.Context(), req.Credentials, req.WalletID)
+		_, err = service.Drain(r.Context(), req.Credentials, req.WalletID)
 		if err != nil {
 			switch err.(type) {
 			case govalidator.Error:

--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -78,7 +78,7 @@ func (suite *ControllersTestSuite) TearDownTest() {
 }
 
 func (suite *ControllersTestSuite) CleanDB() {
-	tables := []string{"claim_creds", "claims", "wallets", "issuers", "promotions"}
+	tables := []string{"claim_drain", "claim_creds", "claims", "wallets", "issuers", "promotions"}
 
 	pg, _, err := NewPostgres()
 	suite.Require().NoError(err, "Failed to get postgres conn")
@@ -1573,23 +1573,10 @@ func (suite *ControllersTestSuite) TestSuggestionDrainV2() {
 
 	suite.Require().True(drainPoll.Status == "unknown")
 
-	err = removeClaimDrainFixtures(pg.RawDB(), delayedID)
-	suite.Require().NoError(err, "failed to fixture claim_drain")
-	err = removeClaimDrainFixtures(pg.RawDB(), pendingID)
-	suite.Require().NoError(err, "failed to fixture claim_drain")
-	err = removeClaimDrainFixtures(pg.RawDB(), inprogressID)
-	suite.Require().NoError(err, "failed to fixture claim_drain")
-	err = removeClaimDrainFixtures(pg.RawDB(), inprogressID)
-	suite.Require().NoError(err, "failed to fixture claim_drain")
 }
 
 func claimDrainFixtures(db *sqlx.DB, batchID, walletID uuid.UUID, completed, erred bool) error {
 	_, err := db.Exec(`INSERT INTO claim_drain (batch_id, credentials, completed, erred, wallet_id, total) values ($1, '[{"t":123}]', $2, $3, $4, $5);`, batchID, completed, erred, walletID, 1)
-	return err
-}
-
-func removeClaimDrainFixtures(db *sqlx.DB, batchID uuid.UUID) error {
-	_, err := db.Exec(`delete from claim_drain where batch_id=$1;`, batchID)
 	return err
 }
 

--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -1572,10 +1572,24 @@ func (suite *ControllersTestSuite) TestSuggestionDrainV2() {
 	suite.Require().NoError(err, "Failed to get drain poll response")
 
 	suite.Require().True(drainPoll.Status == "unknown")
+
+	err = removeClaimDrainFixtures(pg.RawDB(), delayedID)
+	suite.Require().NoError(err, "failed to fixture claim_drain")
+	err = removeClaimDrainFixtures(pg.RawDB(), pendingID)
+	suite.Require().NoError(err, "failed to fixture claim_drain")
+	err = removeClaimDrainFixtures(pg.RawDB(), inprogressID)
+	suite.Require().NoError(err, "failed to fixture claim_drain")
+	err = removeClaimDrainFixtures(pg.RawDB(), inprogressID)
+	suite.Require().NoError(err, "failed to fixture claim_drain")
 }
 
 func claimDrainFixtures(db *sqlx.DB, batchID, walletID uuid.UUID, completed, erred bool) error {
 	_, err := db.Exec(`INSERT INTO claim_drain (batch_id, credentials, completed, erred, wallet_id, total) values ($1, '[{"t":123}]', $2, $3, $4, $5);`, batchID, completed, erred, walletID, 1)
+	return err
+}
+
+func removeClaimDrainFixtures(db *sqlx.DB, batchID uuid.UUID) error {
+	_, err := db.Exec(`delete from claim_drain where batch_id=$1;`, batchID)
 	return err
 }
 

--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -663,6 +663,12 @@ group by
 
 	err = pg.RawDB().Get(drainPoll, statement, drainID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &DrainPoll{
+				ID:     drainID,
+				Status: "unknown",
+			}, nil
+		}
 		return nil, err
 	}
 
@@ -673,17 +679,17 @@ group by
 		}, nil
 	}
 
-	if drainPoll.Pending {
-		return &DrainPoll{
-			ID:     drainID,
-			Status: "pending",
-		}, nil
-	}
-
 	if drainPoll.Delayed {
 		return &DrainPoll{
 			ID:     drainID,
 			Status: "delayed",
+		}, nil
+	}
+
+	if drainPoll.Pending {
+		return &DrainPoll{
+			ID:     drainID,
+			Status: "pending",
 		}, nil
 	}
 

--- a/promotion/datastore_test.go
+++ b/promotion/datastore_test.go
@@ -785,7 +785,10 @@ func (suite *PostgresTestSuite) TestDrainClaim() {
 	suite.Assert().Equal(false, claim.Drained)
 
 	credentials := []cbr.CredentialRedemption{}
-	err = pg.DrainClaim(claim, credentials, wallet, total)
+
+	drainID := uuid.NewV4()
+
+	err = pg.DrainClaim(&drainID, claim, credentials, wallet, total)
 	suite.Require().NoError(err, "Drain claim should succeed")
 
 	claim, err = pg.GetClaimByWalletAndPromotion(wallet, promotion)

--- a/promotion/drain.go
+++ b/promotion/drain.go
@@ -28,21 +28,23 @@ import (
 var errMissingTransferPromotion = errors.New("missing configuration: BraveTransferPromotionID")
 
 // Drain ad suggestions into verified wallet
-func (service *Service) Drain(ctx context.Context, credentials []CredentialBinding, walletID uuid.UUID) error {
+func (service *Service) Drain(ctx context.Context, credentials []CredentialBinding, walletID uuid.UUID) (*uuid.UUID, error) {
+	var pollID *uuid.UUID
+
 	wallet, err := service.wallet.Datastore.GetWallet(ctx, walletID)
 	if err != nil || wallet == nil {
-		return fmt.Errorf("error getting wallet: %w", err)
+		return nil, fmt.Errorf("error getting wallet: %w", err)
 	}
 
 	// A verified wallet will have a payout address
 	if wallet.UserDepositDestination == "" {
-		return errors.New("Wallet is not verified")
+		return nil, errors.New("Wallet is not verified")
 	}
 
 	// Iterate through each credential and assemble list of funding sources
 	_, _, fundingSources, promotions, err := service.GetCredentialRedemptions(ctx, credentials)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var (
 		depositProvider string
@@ -60,12 +62,12 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 		// is this from wallet reputable as an iOS device?
 		isFromOnPlatform, err := service.reputationClient.IsWalletOnPlatform(ctx, walletID, "ios")
 		if err != nil {
-			return fmt.Errorf("invalid device: %w", err)
+			return nil, fmt.Errorf("invalid device: %w", err)
 		}
 
 		if !isFromOnPlatform {
 			// wallet is not reputable, decline
-			return fmt.Errorf("unable to drain to wallet: invalid device")
+			return nil, fmt.Errorf("unable to drain to wallet: invalid device")
 		}
 
 		// these drained claims commit to mint
@@ -76,13 +78,19 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 
 		walletID, err := uuid.FromString(wallet.ID)
 		if err != nil {
-			return fmt.Errorf("invalid wallet id: %w", err)
+			return nil, fmt.Errorf("invalid wallet id: %w", err)
 		}
 
 		err = service.Datastore.EnqueueMintDrainJob(ctx, walletID, promotionIDs...)
 		if err != nil {
-			return fmt.Errorf("error adding mint drain: %w", err)
+			return nil, fmt.Errorf("error adding mint drain: %w", err)
 		}
+	}
+
+	// create a drain_poll tracking number which will be returned to client
+	pollID, err = service.Datastore.CreateDrainPoll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error adding mint drain: %w", err)
 	}
 
 	for k, v := range fundingSources {
@@ -94,30 +102,32 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 		// except in the case the promotion is for ios and deposit provider is a brave wallet
 		if v.Type != "ads" &&
 			depositProvider != "brave" && strings.ToLower(promotion.Platform) != "ios" {
-			return errors.New("Only ads suggestions can be drained")
+			return nil, errors.New("Only ads suggestions can be drained")
 		}
 
 		claim, err := service.Datastore.GetClaimByWalletAndPromotion(wallet, promotion)
 		if err != nil || claim == nil {
-			return fmt.Errorf("error finding claim for wallet: %w", err)
+			return nil, fmt.Errorf("error finding claim for wallet: %w", err)
 		}
 
 		suggestionsExpected, err := claim.SuggestionsNeeded(promotion)
 		if err != nil {
-			return fmt.Errorf("error calculating expected number of suggestions: %w", err)
+			return nil, fmt.Errorf("error calculating expected number of suggestions: %w", err)
 		}
 
 		amountExpected := decimal.New(int64(suggestionsExpected), 0).Mul(promotion.CredentialValue())
 		if v.Amount.GreaterThan(amountExpected) {
-			return errors.New("Cannot claim more funds than were earned")
+			return nil, errors.New("Cannot claim more funds than were earned")
 		}
 
 		// Skip already drained promotions for idempotency
 		if !claim.Drained {
+			// insert claim drain poll linkage so we can assert the state of this drain attempt
+
 			// Mark corresponding claim as drained
-			err := service.Datastore.DrainClaim(claim, v.Credentials, wallet, v.Amount)
+			err := service.Datastore.DrainClaim(pollID, claim, v.Credentials, wallet, v.Amount)
 			if err != nil {
-				return fmt.Errorf("error draining claim: %w", err)
+				return nil, fmt.Errorf("error draining claim: %w", err)
 			}
 
 			// the original request context will be cancelled as soon as the dialer closes the connection.
@@ -166,7 +176,13 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 			}
 		}()
 	}
-	return nil
+	return pollID, nil
+}
+
+// DrainPoll - Response structure for the DrainPoll
+type DrainPoll struct {
+	ID     *uuid.UUID `db:"id"`
+	Status string     `db:"status"`
 }
 
 // DrainWorker attempts to work on a drain job by redeeming the credentials and transferring funds

--- a/promotion/instrumented_datastore.go
+++ b/promotion/instrumented_datastore.go
@@ -87,20 +87,6 @@ func (_d DatastoreWithPrometheus) CreateClaim(promotionID uuid.UUID, walletID st
 	return _d.base.CreateClaim(promotionID, walletID, value, bonus, legacy)
 }
 
-// CreateDrainPoll implements Datastore
-func (_d DatastoreWithPrometheus) CreateDrainPoll(ctx context.Context) (up1 *uuid.UUID, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "CreateDrainPoll", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.CreateDrainPoll(ctx)
-}
-
 // CreatePromotion implements Datastore
 func (_d DatastoreWithPrometheus) CreatePromotion(promotionType string, numGrants int, value decimal.Decimal, platform string) (pp1 *Promotion, err error) {
 	_since := time.Now()

--- a/promotion/instrumented_datastore.go
+++ b/promotion/instrumented_datastore.go
@@ -87,6 +87,20 @@ func (_d DatastoreWithPrometheus) CreateClaim(promotionID uuid.UUID, walletID st
 	return _d.base.CreateClaim(promotionID, walletID, value, bonus, legacy)
 }
 
+// CreateDrainPoll implements Datastore
+func (_d DatastoreWithPrometheus) CreateDrainPoll(ctx context.Context) (up1 *uuid.UUID, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "CreateDrainPoll", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.CreateDrainPoll(ctx)
+}
+
 // CreatePromotion implements Datastore
 func (_d DatastoreWithPrometheus) CreatePromotion(promotionType string, numGrants int, value decimal.Decimal, platform string) (pp1 *Promotion, err error) {
 	_since := time.Now()
@@ -130,7 +144,7 @@ func (_d DatastoreWithPrometheus) DeactivatePromotion(promotion *Promotion) (err
 }
 
 // DrainClaim implements Datastore
-func (_d DatastoreWithPrometheus) DrainClaim(claim *Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal) (err error) {
+func (_d DatastoreWithPrometheus) DrainClaim(drainID *uuid.UUID, claim *Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal) (err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -140,7 +154,7 @@ func (_d DatastoreWithPrometheus) DrainClaim(claim *Claim, credentials []cbr.Cre
 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "DrainClaim", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.DrainClaim(claim, credentials, wallet, total)
+	return _d.base.DrainClaim(drainID, claim, credentials, wallet, total)
 }
 
 // EnqueueMintDrainJob implements Datastore
@@ -225,6 +239,20 @@ func (_d DatastoreWithPrometheus) GetClaimSummary(walletID uuid.UUID, grantType 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetClaimSummary", result).Observe(time.Since(_since).Seconds())
 	}()
 	return _d.base.GetClaimSummary(walletID, grantType)
+}
+
+// GetDrainPoll implements Datastore
+func (_d DatastoreWithPrometheus) GetDrainPoll(drainID *uuid.UUID) (dp1 *DrainPoll, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetDrainPoll", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.GetDrainPoll(drainID)
 }
 
 // GetIssuer implements Datastore

--- a/promotion/instrumented_read_only_datastore.go
+++ b/promotion/instrumented_read_only_datastore.go
@@ -111,6 +111,20 @@ func (_d ReadOnlyDatastoreWithPrometheus) GetClaimSummary(walletID uuid.UUID, gr
 	return _d.base.GetClaimSummary(walletID, grantType)
 }
 
+// GetDrainPoll implements ReadOnlyDatastore
+func (_d ReadOnlyDatastoreWithPrometheus) GetDrainPoll(drainID *uuid.UUID) (dp1 *DrainPoll, err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		readonlydatastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetDrainPoll", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.GetDrainPoll(drainID)
+}
+
 // GetIssuer implements ReadOnlyDatastore
 func (_d ReadOnlyDatastoreWithPrometheus) GetIssuer(promotionID uuid.UUID, cohort string) (ip1 *Issuer, err error) {
 	_since := time.Now()


### PR DESCRIPTION
### Summary

This PR enables a caller (client) to receive a drain id from submission of tokens, and provides the ability to query a new get drain poll endpoint to look up the status of the draining request.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
