### PR TITLE
better handle case where destination is invalid and unknown errors during submit

### DIFF
--- a/cmd/settlement/uphold.go
+++ b/cmd/settlement/uphold.go
@@ -166,11 +166,11 @@ func UpholdUpload(
 			if errorutils.IsErrInvalidDestination(err) {
 				logger.Info().Err(err).Msg("invalid destination, skipping")
 				// This is a final failure so we do not need to unset allFinalized
+			} else {
+				logger.Error().Err(err).Msg("unanticipated error")
+				allFinalized = false
 				continue
 			}
-			logger.Error().Err(err).Msg("unanticipated error")
-			allFinalized = false
-			continue
 		}
 
 		var out []byte

--- a/settlement/settlement.go
+++ b/settlement/settlement.go
@@ -297,7 +297,7 @@ func ConfirmPreparedTransaction(settlementWallet *uphold.Wallet, settlement *Tra
 			return nil
 		}
 		if settlement.IsFailed() {
-			fmt.Printf("already failed, skipping submit for channel %s\n", settlement.Channel)
+			fmt.Printf("already failed, skipping confirm for channel %s\n", settlement.Channel)
 			return nil
 		}
 


### PR DESCRIPTION
### Summary

Workaround for spurious 502s we're seeing on the Uphold API. There are two problems at play here. One is that we should have an explicit failed state for transfers that cannot continue - e.g. for transfers to an invalid destination, currently we retry these during each run which adds unnecessary load. The second is that we consider unknown errors on the submit endpoint to be as dangerous as those on the confirm endpoint. Since an unhandled return for submit can never result in a duplicate transfer we can safely attempt to submit other transfers.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
