### PR TITLE
workaround returned ttl of 0 when making transfers to disabled currencies

### DIFF
--- a/cmd/settlement/uphold.go
+++ b/cmd/settlement/uphold.go
@@ -13,7 +13,6 @@ import (
 	"github.com/brave-intl/bat-go/cmd"
 	"github.com/brave-intl/bat-go/settlement"
 	appctx "github.com/brave-intl/bat-go/utils/context"
-	errorutils "github.com/brave-intl/bat-go/utils/errors"
 	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/brave-intl/bat-go/utils/wallet/provider/uphold"
 	"github.com/spf13/cobra"
@@ -163,14 +162,9 @@ func UpholdUpload(
 
 		err = settlement.SubmitPreparedTransaction(settlementWallet, settlementTransaction)
 		if err != nil {
-			if errorutils.IsErrInvalidDestination(err) {
-				logger.Info().Err(err).Msg("invalid destination, skipping")
-				// This is a final failure so we do not need to unset allFinalized
-			} else {
-				logger.Error().Err(err).Msg("unanticipated error")
-				allFinalized = false
-				continue
-			}
+			logger.Error().Err(err).Msg("unanticipated error")
+			allFinalized = false
+			continue
 		}
 
 		var out []byte

--- a/cmd/vault/sign_settlement.go
+++ b/cmd/vault/sign_settlement.go
@@ -76,6 +76,11 @@ func init() {
 	signSettlementBuilder.Flag().Float64("jpyrate", 0.0,
 		"jpyrate to use for paypal payouts").
 		Bind("jpyrate")
+
+	signSettlementBuilder.Flag().String("config", "config.yaml",
+		"the default path to a configuration file").
+		Bind("config").
+		Env("CONFIG")
 }
 
 // SignSettlement runs the signing of a settlement

--- a/settlement/settlement.go
+++ b/settlement/settlement.go
@@ -241,10 +241,17 @@ func SubmitPreparedTransaction(settlementWallet *uphold.Wallet, settlement *Tran
 	// post the settlement to uphold but do not confirm it
 	submitInfo, err := settlementWallet.SubmitTransaction(settlement.SignedTx, false)
 	if errorutils.IsErrInvalidDestination(err) {
+		fmt.Printf("invalid destination, skipping\n")
 		settlement.Status = "failed"
-		return err
+		return nil
 	} else if err != nil {
 		return err
+	}
+
+	if time.Now().UTC().Equal(settlement.ValidUntil) || time.Now().UTC().After(settlement.ValidUntil) {
+		fmt.Printf("quote returned is invalid, skipping\n")
+		settlement.Status = "failed"
+		return nil
 	}
 
 	fmt.Printf("transaction for channel %s submitted, new quote acquired\n", settlement.Channel)


### PR DESCRIPTION
### Summary

When making transfers to Uphold cards denominated in currencies they have disabled purchasing for seemingly valid quotes are returned, however they have a TTL of 0 meaning they cannot be confirmed. This PR works around this oddity and treats quotes that are immediately invalid as a permanent failure. It also includes a missing flag definition for the vault signing command.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
