### PR TITLE
pushed ads expiration back and allowed legacy claimed to continue claiming

### DIFF
--- a/promotion/claim.go
+++ b/promotion/claim.go
@@ -86,7 +86,7 @@ func (service *Service) ClaimPromotionForWallet(
 	if promotion == nil {
 		return nil, errors.New("promotion did not exist")
 	}
-	if !promotion.Active || promotion.ExpiresAt.Before(time.Now()) || promotion.CreatedAt.Before(time.Now().AddDate(0, -3, 0)) {
+	if !promotion.Claimable() {
 		return nil, &handlers.AppError{
 			Message: "promotion is no longer active",
 			Code:    http.StatusGone,

--- a/promotion/promotion.go
+++ b/promotion/promotion.go
@@ -91,7 +91,7 @@ func (promotion *Promotion) Claimable() bool {
 	if promotion.Expired() {
 		return false
 	}
-	// always allow previously claimed grants to go through
+	// otherwise allow previously claimed grants to go through
 	if promotion.LegacyClaimed {
 		return true
 	}

--- a/promotion/promotion.go
+++ b/promotion/promotion.go
@@ -87,22 +87,24 @@ func (promotion *Promotion) Claimable() bool {
 	if !promotion.Active {
 		return false
 	}
+	// always refuse expired promotions
+	if promotion.Expired() {
+		return false
+	}
 	// always allow previously claimed grants to go through
 	if promotion.LegacyClaimed {
 		return true
 	}
-	if promotion.Type == "ads" {
-		// give ads more time
-		if promotion.ExpiresAt.Before(time.Now()) || promotion.CreatedAt.Before(time.Now().AddDate(-1, 0, 0)) {
-			return false
-		}
-	} else {
-		// everyone else gets 3 months
-		if promotion.ExpiresAt.Before(time.Now()) || promotion.CreatedAt.Before(time.Now().AddDate(0, -3, 0)) {
-			return false
-		}
+	// expire grants created 3 months ago
+	if promotion.CreatedAt.Before(time.Now().AddDate(0, -3, 0)) {
+		return false
 	}
 	return true
+}
+
+// Expired check if now is after the expires_at time
+func (promotion *Promotion) Expired() bool {
+	return promotion.ExpiresAt.Before(time.Now())
 }
 
 // GetAvailablePromotions first tries to look up the wallet and then retrieves available promotions

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -40,7 +40,6 @@ type Assertion struct {
 
 func (suite *PromotionTestSuite) TestPromotionClaimable() {
 	now := time.Now()
-	// nowPlus := now.Add(time.Minute)
 	monthsAgo3 := now.AddDate(0, -3, 0)
 	scenarios := []Assertion{{
 		Claimable: false,

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -60,7 +60,7 @@ func (suite *PromotionTestSuite) TestPromotionClaimable() {
 	}, {
 		Claimable: true,
 		Promotion: Promotion{
-			Active:        true, // fails because not active
+			Active:        true,
 			LegacyClaimed: true,
 			CreatedAt:     monthsAgo3.Add(time.Minute),
 			ExpiresAt:     now.Add(time.Minute),
@@ -68,7 +68,7 @@ func (suite *PromotionTestSuite) TestPromotionClaimable() {
 	}, {
 		Claimable: false,
 		Promotion: Promotion{
-			Active:        true, // fails because not active
+			Active:        true,
 			LegacyClaimed: true,
 			CreatedAt:     monthsAgo3,
 			ExpiresAt:     now,
@@ -76,7 +76,7 @@ func (suite *PromotionTestSuite) TestPromotionClaimable() {
 	}, {
 		Claimable: true,
 		Promotion: Promotion{
-			Active:        true, // fails because not active
+			Active:        true,
 			LegacyClaimed: false,
 			CreatedAt:     monthsAgo3.Add(time.Minute),
 			ExpiresAt:     now.Add(time.Minute),

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -12,41 +12,15 @@ type PromotionTestSuite struct {
 }
 
 func (suite *PromotionTestSuite) SetupSuite() {
-	// pg, _, err := NewPostgres()
-	// suite.Require().NoError(err, "Failed to get postgres conn")
-
-	// m, err := pg.NewMigrate()
-	// suite.Require().NoError(err, "Failed to create migrate instance")
-
-	// ver, dirty, _ := m.Version()
-	// if dirty {
-	// 	suite.Require().NoError(m.Force(int(ver)))
-	// }
-	// if ver > 0 {
-	// 	suite.Require().NoError(m.Down(), "Failed to migrate down cleanly")
-	// }
-
-	// suite.Require().NoError(pg.Migrate(), "Failed to fully migrate")
 }
 
 func (suite *PromotionTestSuite) SetupTest() {
-	suite.CleanDB()
 }
 
 func (suite *PromotionTestSuite) TearDownTest() {
-	suite.CleanDB()
 }
 
 func (suite *PromotionTestSuite) CleanDB() {
-	// tables := []string{"claim_creds", "claims", "wallets", "issuers", "promotions"}
-
-	// pg, _, err := NewPostgres()
-	// suite.Require().NoError(err, "Failed to get postgres conn")
-
-	// for _, table := range tables {
-	// 	_, err = pg.RawDB().Exec("delete from " + table)
-	// 	suite.Require().NoError(err, "Failed to get clean table")
-	// }
 }
 
 func TestPromotionTestSuite(t *testing.T) {

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -1,0 +1,118 @@
+package promotion
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type PromotionTestSuite struct {
+	suite.Suite
+}
+
+func (suite *PromotionTestSuite) SetupSuite() {
+	// pg, _, err := NewPostgres()
+	// suite.Require().NoError(err, "Failed to get postgres conn")
+
+	// m, err := pg.NewMigrate()
+	// suite.Require().NoError(err, "Failed to create migrate instance")
+
+	// ver, dirty, _ := m.Version()
+	// if dirty {
+	// 	suite.Require().NoError(m.Force(int(ver)))
+	// }
+	// if ver > 0 {
+	// 	suite.Require().NoError(m.Down(), "Failed to migrate down cleanly")
+	// }
+
+	// suite.Require().NoError(pg.Migrate(), "Failed to fully migrate")
+}
+
+func (suite *PromotionTestSuite) SetupTest() {
+	suite.CleanDB()
+}
+
+func (suite *PromotionTestSuite) TearDownTest() {
+	suite.CleanDB()
+}
+
+func (suite *PromotionTestSuite) CleanDB() {
+	// tables := []string{"claim_creds", "claims", "wallets", "issuers", "promotions"}
+
+	// pg, _, err := NewPostgres()
+	// suite.Require().NoError(err, "Failed to get postgres conn")
+
+	// for _, table := range tables {
+	// 	_, err = pg.RawDB().Exec("delete from " + table)
+	// 	suite.Require().NoError(err, "Failed to get clean table")
+	// }
+}
+
+func TestPromotionTestSuite(t *testing.T) {
+	suite.Run(t, new(PromotionTestSuite))
+}
+
+func (suite *PromotionTestSuite) TestPromotionExpired() {
+	p := Promotion{
+		ExpiresAt: time.Now(),
+	}
+	suite.Require().True(p.Expired())
+	p.ExpiresAt = p.ExpiresAt.AddDate(0, 0, 1)
+	suite.Require().False(p.Expired())
+}
+
+type Assertion struct {
+	Claimable bool
+	Promotion Promotion
+}
+
+func (suite *PromotionTestSuite) TestPromotionClaimable() {
+	now := time.Now()
+	// nowPlus := now.Add(time.Minute)
+	monthsAgo3 := now.AddDate(0, -3, 0)
+	scenarios := []Assertion{{
+		Claimable: false,
+		Promotion: Promotion{
+			Active:        false, // fails because not active
+			LegacyClaimed: false,
+			CreatedAt:     monthsAgo3.Add(time.Minute),
+			ExpiresAt:     now.Add(time.Minute),
+		},
+	}, {
+		Claimable: true,
+		Promotion: Promotion{
+			Active:        true,
+			LegacyClaimed: false,
+			CreatedAt:     monthsAgo3.Add(time.Minute),
+			ExpiresAt:     now.Add(time.Minute),
+		},
+	}, {
+		Claimable: true,
+		Promotion: Promotion{
+			Active:        true, // fails because not active
+			LegacyClaimed: true,
+			CreatedAt:     monthsAgo3.Add(time.Minute),
+			ExpiresAt:     now.Add(time.Minute),
+		},
+	}, {
+		Claimable: false,
+		Promotion: Promotion{
+			Active:        true, // fails because not active
+			LegacyClaimed: true,
+			CreatedAt:     monthsAgo3,
+			ExpiresAt:     now,
+		},
+	}, {
+		Claimable: true,
+		Promotion: Promotion{
+			Active:        true, // fails because not active
+			LegacyClaimed: false,
+			CreatedAt:     monthsAgo3.Add(time.Minute),
+			ExpiresAt:     now.Add(time.Minute),
+		},
+	}}
+	for _, s := range scenarios {
+		suite.Require().Equal(s.Claimable, s.Promotion.Claimable())
+	}
+}

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -20,9 +20,6 @@ func (suite *PromotionTestSuite) SetupTest() {
 func (suite *PromotionTestSuite) TearDownTest() {
 }
 
-func (suite *PromotionTestSuite) CleanDB() {
-}
-
 func TestPromotionTestSuite(t *testing.T) {
 	suite.Run(t, new(PromotionTestSuite))
 }


### PR DESCRIPTION
### Summary

allow claims
- never if `Active = false`
- always if `LegacyClaimed = true`
- allow ads claims up to… a year? - or better to only check expires at
- allow non ads claims up to 3 months (current)

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
