### PR TITLE
copy metrics for grant and rewards serve to own port

### DIFF
--- a/cmd/serve/grant.go
+++ b/cmd/serve/grant.go
@@ -352,6 +352,14 @@ func GrantServer(
 		}
 	}
 
+	go func() {
+		err := http.ListenAndServe(":9090", middleware.Metrics())
+		if err != nil {
+			sentry.CaptureException(err)
+			logger.Panic().Err(err).Msg("metrics HTTP server start failed!")
+		}
+	}()
+
 	srv := http.Server{
 		Addr:         ":3333",
 		Handler:      chi.ServerBaseContext(ctx, r),


### PR DESCRIPTION
### Summary

This PR serves a copy of the metrics handler for grant and rewards serve on it's own dedicated http.Server / port (9090). This is part 1 of 2, once we deploy this and change our configured scraping port we can commence part 2 which involves removing the metrics handler served on the primary API port.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:
```
root@8a2bc5757110:/src# curl localhost:3333/v1/promotions
{"promotions":[]}

root@8a2bc5757110:/src# curl -s localhost:9090/metrics | grep api
# HELP api_requests_total Number of requests per handler.
# TYPE api_requests_total counter
api_requests_total{code="200",handler="GetAvailablePromotions",method="get"} 1
# HELP client_api_requests_total A counter for requests from the wrapped client.
# TYPE client_api_requests_total counter
client_api_requests_total{code="200",method="get",service="uphold"} 2

root@8a2bc5757110:/src# curl -s localhost:3333/metrics | grep api
# HELP api_requests_total Number of requests per handler.
# TYPE api_requests_total counter
api_requests_total{code="200",handler="GetAvailablePromotions",method="get"} 1
# HELP client_api_requests_total A counter for requests from the wrapped client.
# TYPE client_api_requests_total counter
client_api_requests_total{code="200",method="get",service="uphold"} 3
```