### PR TITLE
fix ttl 0 handling as only LBA / XAU transfers are invalid, unauthorized

### DIFF
--- a/utils/errors/helpers.go
+++ b/utils/errors/helpers.go
@@ -53,3 +53,12 @@ func IsErrAlreadyExists(err error) bool {
 	te, ok := err.(alreadyExists)
 	return ok && te.AlreadyExistsError()
 }
+
+// IsErrForbidden is a helper method for determining if an error indicates the action is forbidden
+func IsErrForbidden(err error) bool {
+	type forbidden interface {
+		ForbiddenError() bool
+	}
+	te, ok := err.(forbidden)
+	return ok && te.ForbiddenError()
+}


### PR DESCRIPTION
### Summary
Fixes two settlement tooling issues:
1. There's more subtlety to the TTL 0 handling then originally expected as TTL 0 is expected when a quote is indefinitely valid ( e.g. in the case of BAT -> BAT transfers.
2. There's a new unauthorized error which can occur when confirming transactions.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
