### PR TITLE
Disconnect Custodial Wallet API Stub

### DIFF
--- a/wallet/controllers_v3.go
+++ b/wallet/controllers_v3.go
@@ -701,9 +701,9 @@ func DisconnectCustodianLinkV3(s *Service) func(w http.ResponseWriter, r *http.R
 
 		// get custodian name
 		if err := inputs.DecodeAndValidateString(ctx, custodian, chi.URLParam(r, "custodian")); err != nil {
-			logger.Warn().Str("paymentID", err.Error()).Msg("failed to decode and validate custodian from url")
+			logger.Warn().Str("custodian", err.Error()).Msg("failed to decode and validate custodian from url")
 			return handlers.ValidationError(
-				"error validating paymentID url parameter",
+				"error validating custodian url parameter",
 				map[string]interface{}{
 					"custodian": err.Error(),
 				},
@@ -718,9 +718,9 @@ func DisconnectCustodianLinkV3(s *Service) func(w http.ResponseWriter, r *http.R
 		signatureID, err := middleware.GetKeyID(r.Context())
 		if err != nil {
 			return handlers.ValidationError(
-				"error validating paymentID url parameter",
+				"error validating http signature, does not match paymentID url parameter",
 				map[string]interface{}{
-					"paymentID": err.Error(),
+					"signature": err.Error(),
 				},
 			)
 		}

--- a/wallet/controllers_v3.go
+++ b/wallet/controllers_v3.go
@@ -671,3 +671,75 @@ func GetLinkingInfoV3(s *Service) func(w http.ResponseWriter, r *http.Request) *
 		return handlers.RenderContent(ctx, info, w, http.StatusOK)
 	}
 }
+
+// DisconnectCustodianLinkV3 - produces an http handler for the service s which handles disconnect
+// state for a deposit account linking
+func DisconnectCustodianLinkV3(s *Service) func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		var (
+			ctx       = r.Context()
+			id        = new(inputs.ID)
+			custodian = new(CustodianName)
+		)
+		// get logger from context
+		logger, err := appctx.GetLogger(ctx)
+		if err != nil {
+			// no logger, setup
+			ctx, logger = logging.SetupLogger(ctx)
+		}
+
+		// get payment id
+		if err := inputs.DecodeAndValidateString(ctx, id, chi.URLParam(r, "paymentID")); err != nil {
+			logger.Warn().Str("paymentID", err.Error()).Msg("failed to decode and validate paymentID from url")
+			return handlers.ValidationError(
+				"error validating paymentID url parameter",
+				map[string]interface{}{
+					"paymentID": err.Error(),
+				},
+			)
+		}
+
+		// get custodian name
+		if err := inputs.DecodeAndValidateString(ctx, custodian, chi.URLParam(r, "custodian")); err != nil {
+			logger.Warn().Str("paymentID", err.Error()).Msg("failed to decode and validate custodian from url")
+			return handlers.ValidationError(
+				"error validating paymentID url parameter",
+				map[string]interface{}{
+					"custodian": err.Error(),
+				},
+			)
+		}
+
+		sublogger := logger.With().
+			Str("custodian", custodian.String()).
+			Str("paymentID", id.String()).Logger()
+
+		// validate payment id matches what was in the http signature
+		signatureID, err := middleware.GetKeyID(r.Context())
+		if err != nil {
+			return handlers.ValidationError(
+				"error validating paymentID url parameter",
+				map[string]interface{}{
+					"paymentID": err.Error(),
+				},
+			)
+		}
+
+		if id.String() != signatureID {
+			return handlers.ValidationError(
+				"paymentId from URL does not match paymentId in http signature",
+				map[string]interface{}{
+					"paymentID": "does not match http signature id",
+				},
+			)
+		}
+
+		err = s.DisconnectCustodianLink(ctx, custodian.String(), *id.UUID())
+		if err != nil {
+			sublogger.Error().Err(err).Msg("failed to disconnect custodian link")
+			return handlers.WrapError(err, "failed to disconnect custodian link", http.StatusInternalServerError)
+		}
+
+		return handlers.RenderContent(ctx, nil, w, http.StatusOK)
+	}
+}

--- a/wallet/controllers_v3_test.go
+++ b/wallet/controllers_v3_test.go
@@ -512,9 +512,6 @@ func TestDisconnectCustodianLinkV3(t *testing.T) {
 	router.ServeHTTP(w, r)
 
 	if resp := w.Result(); resp.StatusCode != http.StatusOK {
-		t.Logf("%+v\n", resp)
-		body, err := ioutil.ReadAll(resp.Body)
-		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
 }

--- a/wallet/inputs.go
+++ b/wallet/inputs.go
@@ -32,6 +32,31 @@ var (
 	ErrMissingLinkingInfo = errors.New("missing linking information")
 )
 
+// CustodianName - input validation for custodian name
+type CustodianName string
+
+// String - implement the stringer interface for this input
+func (cn *CustodianName) String() string {
+	return string(*cn)
+}
+
+// Validate - implement the validatable interface for this input
+func (cn *CustodianName) Validate(ctx context.Context) error {
+	if string(*cn) != "uphold" && string(*cn) != "bitflyer" && string(*cn) != "brave" && string(*cn) != "gemini" {
+		return fmt.Errorf("validate custodian name not in (uphold, bitflyer, brave, gemini)")
+	}
+	return nil
+}
+
+// Decode - implement the decodable interface for this input
+func (cn *CustodianName) Decode(ctx context.Context, v []byte) error {
+	*cn = CustodianName(string(v))
+	if *cn == "" {
+		return fmt.Errorf("failed to decode custodian name, cannot be empty")
+	}
+	return nil
+}
+
 // UpholdCreationRequest - the structure for a brave provider wallet creation request
 type UpholdCreationRequest struct {
 	SignedCreationRequest string `json:"signedCreationRequest"`

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -338,6 +338,9 @@ func SetupService(ctx context.Context, r *chi.Mux) (*chi.Mux, context.Context, *
 				"LinkBraveDepositAccount", LinkBraveDepositAccountV3(s))).ServeHTTP)
 			r.Post("/gemini/{paymentID}/claim", middleware.HTTPSignedOnly(s)(middleware.InstrumentHandlerFunc(
 				"LinkGeminiDepositAccount", LinkGeminiDepositAccountV3(s))).ServeHTTP)
+			// disconnect verified custodial wallet
+			r.Delete("/{custodian}/{paymentID}/claim", middleware.HTTPSignedOnly(s)(middleware.InstrumentHandlerFunc(
+				"DisconnectCustodianLinkV3", DisconnectCustodianLinkV3(s))).ServeHTTP)
 		}
 		// support only APIs to assist in linking limit issues
 		/*
@@ -412,5 +415,11 @@ func (service *Service) LinkBraveWallet(ctx context.Context, from, to uuid.UUID)
 		return handlers.WrapError(err, "unable to link wallets", status)
 	}
 
+	return nil
+}
+
+// DisconnectCustodianLink - removes the link to the custodian wallet that is active
+func (service *Service) DisconnectCustodianLink(ctx context.Context, custodian string, walletID uuid.UUID) error {
+	// TODO: hook up Datastore to effect the disconnect
 	return nil
 }


### PR DESCRIPTION
### Summary

Phase 1 of #712, just the API interface, not hooked up to datastore.  This PR includes an API endpoint in the wallets service which will allow for disconnecting of custodian wallets.

### Type of change ( select one )

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

