### PR TITLE
Disconnect Wallet 500s Due to Disconnect on No Linkage 

### DIFF
--- a/wallet/datastore.go
+++ b/wallet/datastore.go
@@ -633,19 +633,13 @@ func (pg *Postgres) DisconnectCustodialWallet(ctx context.Context, walletID uuid
 			id=$1
 	`
 	// perform query
-	if r, err := tx.ExecContext(
+	if _, err := tx.ExecContext(
 		ctx,
 		stmt,
 		walletID,
 	); err != nil {
 		sublogger.Error().Err(err).Msg("failed to update wallet_custodian_id for wallet")
 		return err
-	} else if r != nil {
-		count, _ := r.RowsAffected()
-		if count < 1 {
-			sublogger.Error().Msg("at least one record should be updated for disconnecting a verified wallet")
-			return errors.New("should have updated at least one wallet with disconnected custodial")
-		}
 	}
 
 	// set disconnected on the custodian link
@@ -658,19 +652,13 @@ func (pg *Postgres) DisconnectCustodialWallet(ctx context.Context, walletID uuid
 			wallet_id=$1 and disconnected_at is null
 	`
 	// perform query
-	if r, err := tx.ExecContext(
+	if _, err := tx.ExecContext(
 		ctx,
 		stmt,
 		walletID,
 	); err != nil {
 		sublogger.Error().Err(err).Msg("failed to update wallet_custodian_id for wallet")
 		return err
-	} else if r != nil {
-		count, _ := r.RowsAffected()
-		if count < 1 {
-			sublogger.Error().Msg("at least one record should be updated for disconnecting a verified wallet")
-			return errors.New("should have updated at least one wallet with disconnected custodial")
-		}
 	}
 
 	// if the tx was created in this scope we will commit here


### PR DESCRIPTION

### Summary

remove error generation when no rows updated on wallet/wallet custodian tables on disconnect.  Instead of propogation of a 500 we will now return OK in the event we were unable to update the wallet information in the database.  The end goal of being disconnected still succeeded.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
