### PR TITLE
(1) Include a JSON parser called payout_json_conversion_tool which

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@
 
 # Project specific ignores
 .env
+.prod_env
+.gemini_prod_env
+.gemini_sandbox_env
+.bitflyer_prod_env
+pub.asc
+settlement/vault
+settlement/vault-data/
+settlement/vaultsigning
+*.json
 vendor
 target
 grantTokens.json

--- a/cmd/settlement/bitflyer.go
+++ b/cmd/settlement/bitflyer.go
@@ -98,9 +98,7 @@ func UploadBitflyerSettlement(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	token := viper.GetViper().GetString("bitflyer-client-token")
-	if out == "" {
-		out = strings.TrimSuffix(input, filepath.Ext(input)) + "-finished.json"
-	}
+	out = strings.TrimSuffix(input, filepath.Ext(input)) + "-finished.json"
 	sourceFrom, err := cmd.Flags().GetString("bitflyer-source-from")
 	if err != nil {
 		return err

--- a/cmd/settlement/bitflyer.go
+++ b/cmd/settlement/bitflyer.go
@@ -93,12 +93,8 @@ func UploadBitflyerSettlement(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	out, err := cmd.Flags().GetString("out")
-	if err != nil {
-		return err
-	}
 	token := viper.GetViper().GetString("bitflyer-client-token")
-	out = strings.TrimSuffix(input, filepath.Ext(input)) + "-finished.json"
+	output_file := strings.TrimSuffix(input, filepath.Ext(input)) + "-finished.json"
 	sourceFrom, err := cmd.Flags().GetString("bitflyer-source-from")
 	if err != nil {
 		return err
@@ -115,7 +111,7 @@ func UploadBitflyerSettlement(cmd *cobra.Command, args []string) error {
 		cmd.Context(),
 		"upload",
 		input,
-		out,
+		output_file,
 		token,
 		sourceFrom,
 		excludeLimited,

--- a/cmd/vault/import_key.go
+++ b/cmd/vault/import_key.go
@@ -17,6 +17,7 @@ var (
 	keysList = []string{
 		"uphold-contribution",
 		"uphold-referral",
+		"uphold-adsDirectDeposit",
 		"gemini-contribution",
 		"gemini-referral",
 	}

--- a/cmd/vault/sign_settlement.go
+++ b/cmd/vault/sign_settlement.go
@@ -3,8 +3,8 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -34,10 +34,10 @@ var (
 	// the combination of provider + transaction type gives you the key
 	// under which the vault secrets are located by default
 	providerTransactionTypes = map[string][]string{
-		"uphold":   {"contribution", "referral"},
+		"uphold":   {"contribution", "referral", "adsDirectDeposit"},
 		"paypal":   {"default"},
-		"gemini":   {"contribution", "referral"},
-		"bitflyer": {"default"},
+		"gemini":   {"contribution", "referral", "adsDirectDeposit"},
+		"bitflyer": {"contribution", "referral", "adsDirectDeposit"},
 	}
 	artifactGenerators = map[string]func(
 		context.Context,
@@ -158,7 +158,6 @@ func divideSettlementsByWallet(antifraudTxs []settlement.AntifraudTransaction) m
 
 	for _, antifraudTx := range antifraudTxs {
 		tx := antifraudTx.ToTransaction()
-
 		provider := tx.WalletProvider
 		wallet := tx.Type
 		if len(providerTransactionTypes[provider]) == 1 {
@@ -186,16 +185,6 @@ func createUpholdArtifact(
 	walletKey string,
 	upholdOnlySettlements []settlement.Transaction,
 ) error {
-	response, err := wrappedClient.Client.Logical().Read("wallets/" + walletKey)
-	if err != nil {
-		return err
-	}
-
-	providerID, ok := response.Data["providerId"]
-	if !ok {
-		return errors.New("invalid wallet name")
-	}
-
 	signer, err := wrappedClient.GenerateEd25519Signer(walletKey)
 	if err != nil {
 		return err
@@ -204,7 +193,7 @@ func createUpholdArtifact(
 	var info wallet.Info
 	info.PublicKey = signer.String()
 	info.Provider = "uphold"
-	info.ProviderID = providerID.(string)
+	info.ProviderID = os.Getenv("UPHOLD_PROVIDER_ID")
 	{
 		tmp := altcurrency.BAT
 		info.AltCurrency = &tmp
@@ -255,11 +244,7 @@ func createGeminiArtifact(
 	walletKey string,
 	geminiOnlySettlements []settlement.Transaction,
 ) error {
-	response, err := wrappedClient.Client.Logical().Read("wallets/" + walletKey)
-	if err != nil {
-		return err
-	}
-	oauthClientID := response.Data["clientid"].(string)
+	oauthClientID := os.Getenv("GEMINI_CLIENT_ID")
 	// group transactions (500 at a time)
 	privatePayloads, err := geminisettlement.TransformTransactions(ctx, oauthClientID, geminiOnlySettlements)
 	if err != nil {
@@ -292,6 +277,7 @@ func signGeminiRequests(
 	walletKey string,
 	privateRequests *[][]gemini.PayoutPayload,
 ) (*[]gemini.PrivateRequestSequence, error) {
+	walletKey = os.Getenv("VAULT_WALLET_NAME")
 	response, err := wrappedClient.Client.Logical().Read("wallets/" + walletKey)
 	if err != nil {
 		return nil, err

--- a/cmd/vault/sign_settlement.go
+++ b/cmd/vault/sign_settlement.go
@@ -277,14 +277,20 @@ func signGeminiRequests(
 	walletKey string,
 	privateRequests *[][]gemini.PayoutPayload,
 ) (*[]gemini.PrivateRequestSequence, error) {
-	walletKey = os.Getenv("VAULT_WALLET_NAME")
-	response, err := wrappedClient.Client.Logical().Read("wallets/" + walletKey)
+	existingWalletName, isPresent := os.LookupEnv("VAULT_WALLET_NAME")
+	var preferredWalletKey string
+	if isPresent {
+	 preferredWalletKey = existingWalletName
+	} else {
+	 preferredWalletKey = walletKey
+ }
+	response, err := wrappedClient.Client.Logical().Read("wallets/" + preferredWalletKey)
 	if err != nil {
 		return nil, err
 	}
 	clientID := response.Data["clientid"].(string)
 	clientKey := response.Data["clientkey"].(string)
-	hmacSecret, err := wrappedClient.GetHmacSecret(walletKey)
+	hmacSecret, err := wrappedClient.GetHmacSecret(preferredWalletKey)
 	if err != nil {
 		return nil, err
 	}

--- a/payout_json_conversion_tool.py
+++ b/payout_json_conversion_tool.py
@@ -89,19 +89,19 @@ def convert_ads_file(filename, provider):
 
         provider_exclusive_data.append(transaction)
 
-        # There is some odd limitation with > 250 transaction in a bulk, as the API call also hangs quite a bit
-        if provider == 'bitflyer' and len(provider_exclusive_data) > 250:
+        # There is some odd limitation with > 100 transaction in a bulk, as the API call also hangs quite a bit
+        if provider in ['bitflyer', 'gemini'] and len(provider_exclusive_data) > 100:
             output_filename = provider + "_" + filename.split('.json')[0] + suffix_name + str(suffix) + ".json"
             with open(output_filename, 'w') as outfile:
                 json.dump(provider_exclusive_data, outfile, indent=4)
             suffix += 1
             provider_exclusive_data = []
 
-    if provider == 'bitflyer':
+    if provider in ['bitflyer', 'gemini']:
         output_filename = provider + "_" + filename.split('.json')[0] + suffix_name + str(suffix) + ".json"
         with open(output_filename, 'w') as outfile:
             json.dump(provider_exclusive_data, outfile, indent=4)
-    elif provider in ['uphold', 'gemini'] :
+    elif provider in ['uphold'] :
         output_filename = provider + "_" + filename.split('.json')[0] + "_converted.json"
         with open(output_filename, 'w') as outfile:
             json.dump(provider_exclusive_data, outfile, indent=4)

--- a/payout_json_conversion_tool.py
+++ b/payout_json_conversion_tool.py
@@ -1,0 +1,128 @@
+import json
+import argparse
+from os import listdir
+from os.path import isfile, join
+from decimal import *
+import re
+
+def split_contributions_referrals(filename, provider, contributions, referrals):
+    contributions_output_filename = filename.split('.json')[0] + f"-{provider}-contributions.json"
+    with open(contributions_output_filename, 'w') as outfile:
+        json.dump(contributions, outfile, indent=4)
+
+    referrals_output_filename = filename.split('.json')[0] + f"-{provider}-referrals.json"
+    with open(referrals_output_filename, 'w') as outfile:
+        json.dump(referrals, outfile, indent=4)
+
+def convert_publishers_file(filename, provider):
+    f = open(filename, 'r')
+    data = json.load(f)
+    amount = 0
+
+    # this should be the default already
+    getcontext().prec = 28
+    contributions = []
+    referrals = []
+    gemini_transactions = []
+    contribution_amount = 0
+    referral_amount = 0
+
+    for transaction in data:
+        channel_id = transaction["publisher"]
+        if transaction['wallet_provider_id'] != None and transaction['wallet_provider_id'].startswith(provider):
+            if transaction['type'] == 'contribution':
+                contributions.append(transaction)
+                contribution_amount += Decimal(transaction['bat'])
+            elif transaction['type'] == 'referral':
+                referrals.append(transaction)
+                referral_amount += Decimal(transaction['bat'])
+            if transaction['wallet_provider_id'].startswith('bitflyer'):
+                bat = float(transaction['bat'])
+                transaction['bat'] = str(round(bat, 2))
+
+    split_contributions_referrals(filename, provider, contributions, referrals)
+
+    print("total contribution amount: " + str(contribution_amount))
+    print("total referral amount: " + str(referral_amount))
+    print("total: " + str(referral_amount + contribution_amount))
+
+
+def convert_ads_file(filename, provider):
+    f = open(filename, 'r')
+    data = json.load(f)
+
+    provider_exclusive_data = []
+    total_bat = 0
+    suffix = 1
+    suffix_name = "_converted_fixed_"
+    for transaction in data:
+        if transaction['walletProvider'] != provider:
+            continue
+        bat = float(transaction['probi']) / 1E18
+        if transaction['walletProvider'] == 'uphold':
+            card_id = transaction['publisher'].split(':')[1]
+            transaction['wallet_provider'] = 'uphold'
+            transaction['wallet_provider_id'] = "uphold#card:" + card_id
+            transaction['bat'] = str(bat)
+            transaction['owner'] = transaction['publisher']
+        elif transaction['walletProvider'] == 'bitflyer':
+            transaction['wallet_provider'] = 'bitflyer'
+            transaction['wallet_provider_id'] = "bitflyer#id:" + transaction['address']
+            transaction['bat'] = str(round(bat, 2))
+            transaction['publisher'] = "wallet:" + transaction['address']
+            transaction['owner'] = "wallet:" + transaction['address']
+        elif transaction['walletProvider'] == 'gemini':
+            card_id = transaction['publisher'].split(':')[1]
+            transaction['wallet_provider'] = 'gemini'
+            transaction['wallet_provider_id'] = "gemini#id:" + card_id
+            transaction['bat'] = str(bat)
+            transaction['publisher'] = "wallet:" + transaction['address']
+            transaction['owner'] = "wallet:" + transaction['address']
+
+        total_bat += float(transaction['bat'])
+        transaction['payout_report_id'] = transaction['transactionId']
+
+        # delete unused keys
+        transaction.pop('walletProvider')
+        transaction.pop('probi')
+        transaction.pop('transactionId')
+
+        provider_exclusive_data.append(transaction)
+
+        # There is some odd limitation with > 250 transaction in a bulk, as the API call also hangs quite a bit
+        if provider == 'bitflyer' and len(provider_exclusive_data) > 250:
+            output_filename = provider + "_" + filename.split('.json')[0] + suffix_name + str(suffix) + ".json"
+            with open(output_filename, 'w') as outfile:
+                json.dump(provider_exclusive_data, outfile, indent=4)
+            suffix += 1
+            provider_exclusive_data = []
+
+    if provider == 'bitflyer':
+        output_filename = provider + "_" + filename.split('.json')[0] + suffix_name + str(suffix) + ".json"
+        with open(output_filename, 'w') as outfile:
+            json.dump(provider_exclusive_data, outfile, indent=4)
+    elif provider in ['uphold', 'gemini'] :
+        output_filename = provider + "_" + filename.split('.json')[0] + "_converted.json"
+        with open(output_filename, 'w') as outfile:
+            json.dump(provider_exclusive_data, outfile, indent=4)
+
+    print(f"Total BAT: {total_bat} to {output_filename}")
+
+def main():
+    parser = argparse.ArgumentParser(description='Convert ads or publishers payout file for settlement tool')
+    parser.add_argument('--input', type=str)
+    parser.add_argument('--provider', type=str)
+    parser.add_argument('--kind', type=str)
+
+    args = parser.parse_args()
+    filename = args.input
+    provider = args.provider
+    kind = args.kind
+
+    if kind == 'ads':
+        convert_ads_file(filename, provider)
+    elif kind == 'publishers':
+        convert_publishers_file(filename, provider)
+
+if __name__ == "__main__":
+    main()

--- a/payout_json_conversion_tool.py
+++ b/payout_json_conversion_tool.py
@@ -90,7 +90,7 @@ def convert_ads_file(filename, provider):
         provider_exclusive_data.append(transaction)
 
         # There is some odd limitation with > 100 transaction in a bulk, as the API call also hangs quite a bit
-        if provider in ['bitflyer', 'gemini'] and len(provider_exclusive_data) > 100:
+        if provider in ['bitflyer', 'gemini'] and len(provider_exclusive_data) > 10:
             output_filename = provider + "_" + filename.split('.json')[0] + suffix_name + str(suffix) + ".json"
             with open(output_filename, 'w') as outfile:
                 json.dump(provider_exclusive_data, outfile, indent=4)

--- a/promotion/drain.go
+++ b/promotion/drain.go
@@ -448,10 +448,12 @@ func redeemAndTransferGeminiFunds(
 	wallet *walletutils.Info,
 	total decimal.Decimal,
 ) (*walletutils.TransactionInfo, error) {
+	logger := logging.Logger(ctx, "redeemAndTransferGeminiFunds")
 
 	// in the event that gemini configs or service do not exist
 	// error on redeem and transfer
 	if service.geminiConf == nil || service.geminiClient == nil {
+		logger.Error().Msg("gemini is misconfigured, missing gemini client and configuration")
 		return nil, errGeminiMisconfigured
 	}
 
@@ -491,6 +493,7 @@ func redeemAndTransferGeminiFunds(
 	signer := cryptography.NewHMACHasher([]byte(service.geminiConf.Secret))
 	serializedPayload, err := json.Marshal(payload)
 	if err != nil {
+		logger.Error().Err(err).Msg("failed to serialize payload")
 		return nil, fmt.Errorf("failed to serialize payload: %w", err)
 	}
 	// gemini client will base64 encode the payload prior to sending
@@ -501,6 +504,20 @@ func redeemAndTransferGeminiFunds(
 		string(serializedPayload),
 	)
 	if err != nil {
+		logger.Error().Err(err).Msg("failed request to gemini")
+		var eb *errorutils.ErrorBundle
+		if errors.As(err, &eb) {
+			// okay, there was an errorbundle, unwrap and log the error
+			// convert err.Data() to json and report out
+			b, err := json.Marshal(eb.Data())
+			if err != nil {
+				logger.Error().Err(err).Msg("failed serialize error bundle data")
+			} else {
+				logger.Error().Err(err).
+					Str("data", string(b)).
+					Msg("gemini client error details")
+			}
+		}
 		return nil, fmt.Errorf("failed to transfer funds: %w", err)
 	}
 

--- a/remove_errored_transactions_from_converted_file.rb
+++ b/remove_errored_transactions_from_converted_file.rb
@@ -1,0 +1,42 @@
+require 'json'
+require 'optparse'
+
+@options = {}
+OptionParser.new do |opts|
+  opts.on("-c", "--converted-file C", "The converted file from the payout_json_conversion.py tool") do |file|
+    @options[:converted_file] = file
+  end
+  opts.on("-e", "--error-file E", "The error file from running upload") do |file|
+    @options[:error_file] = file
+  end
+end.parse!
+
+fail "Converted File not provided" unless @options[:converted_file]
+fail "Error File not provided" unless @options[:error_file]
+
+p @options
+
+json_converted = JSON.parse(File.read(@options[:converted_file]))
+json_error = JSON.parse(File.read(@options[:error_file]))
+
+original_entries_to_keep = json_converted.select do |orig_entry|
+    json_error.none? do |error_entry|
+        orig_entry["owner"] == error_entry["owner"] &&
+        orig_entry["publisher"] == error_entry["publisher"]
+    end
+end
+
+fail "Too many or too few error entries removed!" if original_entries_to_keep.size != (json_converted.size - json_error.size)
+
+puts "Found #{json_converted.size} original entries"
+puts "Found #{json_error.size} error entries"
+
+puts "Copying original file to backup"
+`cp -n #{@options[:converted_file]} #{File.basename(@options[:converted_file], '.json') + 'original.json'}`
+
+error_free_file = File.basename(@options[:converted_file], '.json') + '_without_error_entries.json'
+puts "Writing out #{original_entries_to_keep.size} new error-free entries to #{error_free_file}"
+
+File.open(error_free_file,"w") do |f|
+    f.write(JSON.pretty_generate(original_entries_to_keep))
+end

--- a/settlement/README.md
+++ b/settlement/README.md
@@ -10,7 +10,8 @@
 
 ## Creating new local vault instance
 
-Vault is an on-device secure key-value store. 
+Vault is an on-device secure key-value store. This was designed in mind of two separate, air-gapped machines.
+Anywhere you read turning off the vault or unsealing you may skip.
 
 If you have trouble installing from the README, you can also 
 (1) Download from https://www.vaultproject.io/downloads
@@ -51,7 +52,7 @@ The `config.example.yaml` should be copied wherever it is easiest to point to. J
 
 The values name should be unique, as we use the label online (e.g. creating a wallet with the label name).
 
-As of May 2021, the following keys are accepted:
+As of May 2021, the following keys are preferred and accepted. Do note that you SHOULD NOT make a new wallet each month.:
 
 ```bash
 wallets:
@@ -73,6 +74,54 @@ GEMINI_CLIENT_KEY= \
 GEMINI_CLIENT_SECRET= \
 ./bat-go vault import-key --config=./config.yaml
 # pass a known key to only import one: --wallet-refs=gemini-referral
+```
+
+## Creating a new offline wallet
+
+On the offline machine, first bring up vault as described above.
+
+Run vault-create-wallet, this will sign the registration and store it into
+a local file:
+```
+./bat-go vault create-wallet NAME_OF_NEW_WALLET
+```
+
+Copy the created `name-of-new-wallet-registration.json` file to the online
+machine.
+
+Re-run vault-create-wallet, this will submit the pre-signed registration:
+### Uphold
+```
+export UPHOLD_ENVIRONMENT=
+export UPHOLD_HTTP_PROXY=
+export UPHOLD_ACCESS_TOKEN=
+export VAULT_ADDR=
+./bat-go vault create-wallet -offline NAME_OF_NEW_WALLET
+```
+
+### Gemini
+```
+export GEMINI_CLIENT_ID
+export GEMINI_CLIENT_KEY
+export GEMINI_CLIENT_SECRET
+export GEMINI_SERVER
+export GEMINI_SUBMIT_TYPE
+export VAULT_ADDR
+```
+
+### Bitflyer
+export BITFLYER_SOURCE_FROM=tipping # This should either be 'tipping' or 'adsrewards'
+export BITFLYER_DRYRUN=1
+export BITFLYER_CLIENT_ID=
+export BITFLYER_CLIENT_SECRET=
+export BITFLYER_EXTRA_CLIENT_SECRET=
+export BITFLYER_SERVER=https://bitflyer.com
+export BITFLYER_TOKEN= # This is obtained by running ./bat-go settlement bitflyer token
+
+Finally copy `name-of-new-wallet-registration.json` back to the offline
+machine and run vault-create-wallet to record the provider ID in vault:
+```
+./bat-go vault create-wallet -offline NAME_OF_NEW_WALLET
 ```
 
 ## Running settlement
@@ -108,44 +157,6 @@ allow restoring from errors and to avoid duplicate payouts.
 Finally upload the "-finished" output file to eyeshade to account for payout
 transactions that were made.
 
-## Creating a new offline wallet
-
-On the offline machine, first bring up vault as described above.
-
-Run vault-create-wallet, this will sign the registration and store it into
-a local file:
-```
-./bat-go vault create-wallet NAME_OF_NEW_WALLET
-```
-
-Copy the created `name-of-new-wallet-registration.json` file to the online
-machine.
-
-Re-run vault-create-wallet, this will submit the pre-signed registration:
-### Uphold
-```
-export UPHOLD_ENVIRONMENT=
-export UPHOLD_HTTP_PROXY=
-export UPHOLD_ACCESS_TOKEN=
-export VAULT_ADDR=
-./bat-go vault create-wallet -offline NAME_OF_NEW_WALLET
-```
-
-### Gemini
-```
-export GEMINI_CLIENT_ID
-export GEMINI_CLIENT_KEY
-export GEMINI_CLIENT_SECRET
-export GEMINI_SERVER
-export GEMINI_SUBMIT_TYPE
-export VAULT_ADDR
-```
-
-Finally copy `name-of-new-wallet-registration.json` back to the offline
-machine and run vault-create-wallet to record the provider ID in vault:
-```
-./bat-go vault create-wallet -offline NAME_OF_NEW_WALLET
-```
 
 ## Signing Files
 Signing the settlement file will split the input files into many output files depending on the contents of the file
@@ -158,6 +169,11 @@ Signing the settlement file will split the input files into many output files de
 ### Gemini
 ```bash
 ./bat-go vault sign-settlement --config=publishers-gemini.yaml --in=publishers-payout-report-gemini-referrals.json --providers=gemini
+```
+
+### Bitflyer
+```bash
+./bat-go vault sign-settlement --config=publishers-bitflyer.yaml --in=
 ```
 
 ## Uploading files
@@ -179,4 +195,9 @@ gemini has a command available to it for uploading transactions and sending
 and to check the status of each transaction a `checkstatus` command has been added
 ```bash
 ./bat-go settlement gemini checkstatus --input=bulk-signed-transactions.json --all-txs-input=from-antifraud.json
+```
+
+### Bitflyer
+```bash
+go run ./main.go settlement bitflyer upload --input=
 ```

--- a/settlement/bitflyer/upload_mock_test.go
+++ b/settlement/bitflyer/upload_mock_test.go
@@ -303,7 +303,7 @@ func (suite *BitflyerMockSuite) TestFormData() {
 
 	settlementTx1.ProviderID = settlementTx1.TransferID()
 	expectedBytes, err := json.Marshal([]settlement.Transaction{ // serialize for comparison (decimal.Decimal does not do so well)
-		transactionSubmitted("complete", settlementTx1, "SUCCESS"),
+		transactionSubmitted("complete", settlementTx1, "SUCCESS transferID: " + transferID),
 	})
 	suite.Require().JSONEq(
 		string(expectedBytes),

--- a/utils/clients/bitflyer/client.go
+++ b/utils/clients/bitflyer/client.go
@@ -183,6 +183,7 @@ func NewWithdrawsFromTxs(
 	txs []settlement.Transaction,
 ) (*[]WithdrawToDepositIDPayload, error) {
 	withdrawals := []WithdrawToDepositIDPayload{}
+	tolerance := decimal.NewFromFloat(0.00000001)
 	if !validSourceFrom[sourceFrom] {
 		return nil, fmt.Errorf("valid `sourceFrom` value must be passed got: `%s`", sourceFrom)
 	}
@@ -193,7 +194,8 @@ func NewWithdrawsFromTxs(
 		}
 		// exact is never true, equality check needed
 		f64, _ := bat.Float64()
-		if !decimal.NewFromFloat(f64).Equal(bat) {
+		delta :=  decimal.NewFromFloat(f64).Sub(bat).Abs()
+		if delta.GreaterThan(tolerance) {
 			return nil, fmt.Errorf("bat conversion did not work: %.8f is not equal %d", f64, bat)
 		}
 		withdrawals = append(withdrawals, WithdrawToDepositIDPayload{

--- a/utils/clients/client.go
+++ b/utils/clients/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -279,12 +280,21 @@ func (c *SimpleHTTPClient) Do(ctx context.Context, req *http.Request, v interfac
 		header = resp.Header
 	}
 	if err != nil {
+		// if there was an error, read the response body
+		// and inject into error for later
+		b, err := ioutil.ReadAll(resp.Body)
+		rb := string(b)
+		resp.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+
 		return resp, NewHTTPError(err, req.URL.String(), "response", code, struct {
-			Body    interface{}
-			Headers interface{}
+			Body            interface{}
+			RequestHeaders  interface{}
+			ResponseHeaders interface{}
 		}{
-			Body:    v,
-			Headers: req.Header,
+			// put response body/headers in the err state data
+			Body:            rb,
+			RequestHeaders:  req.Header,
+			ResponseHeaders: resp.Header,
 		})
 	}
 	logOut(ctx, "response", *req.URL, code, header, v)

--- a/utils/clients/client.go
+++ b/utils/clients/client.go
@@ -288,12 +288,10 @@ func (c *SimpleHTTPClient) Do(ctx context.Context, req *http.Request, v interfac
 
 		return resp, NewHTTPError(err, req.URL.String(), "response", code, struct {
 			Body            interface{}
-			RequestHeaders  interface{}
 			ResponseHeaders interface{}
 		}{
 			// put response body/headers in the err state data
 			Body:            rb,
-			RequestHeaders:  req.Header,
 			ResponseHeaders: resp.Header,
 		})
 	}

--- a/utils/clients/gemini/client.go
+++ b/utils/clients/gemini/client.go
@@ -3,7 +3,6 @@ package gemini
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -231,7 +230,7 @@ func setHeaders(
 	req.Header.Set("Cache-Control", "no-cache")
 	if payload != "" {
 		// base64 encode the payload
-		req.Header.Set("X-GEMINI-PAYLOAD", base64.StdEncoding.EncodeToString([]byte(payload)))
+		req.Header.Set("X-GEMINI-PAYLOAD", payload)
 	}
 	if submitType != "oauth" {
 		// do not send when oauth
@@ -259,7 +258,7 @@ func setPrivateRequestHeaders(
 		}
 		signs := *signer
 		// only set if sending an hmac salt
-		signature, err := signs.HMACSha384([]byte(base64.StdEncoding.EncodeToString([]byte(payload))))
+		signature, err := signs.HMACSha384([]byte(payload))
 		if err != nil {
 			return err
 		}

--- a/utils/wallet/provider/uphold/errors.go
+++ b/utils/wallet/provider/uphold/errors.go
@@ -104,6 +104,10 @@ func (uhErr upholdError) InsufficientBalance() bool {
 	return false
 }
 
+func (uhErr upholdError) ForbiddenError() bool {
+	return uhErr.Code == "forbidden"
+}
+
 func (uhErr upholdError) InvalidSignature() bool {
 	return uhErr.ValidationError() && len(uhErr.ValidationErrors.SignatureError) > 0
 }

--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -174,7 +174,7 @@ func submit(logger *zerolog.Logger, req *http.Request) ([]byte, *http.Response, 
 	if err != nil {
 		panic(err)
 	}
-	// dump = authLogFilter.ReplaceAll(dump, []byte("Authorization: Basic <token>\n"))
+	dump = authLogFilter.ReplaceAll(dump, []byte("Authorization: B <token>\n"))
 
 	if logger != nil {
 		logger.Debug().

--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -281,7 +281,6 @@ func (w *Wallet) signRegistration(label string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("signing registration")
 
 	req, err := newRequest("POST", "/v0/me/cards", bytes.NewBuffer(payload))
 	if err != nil {
@@ -331,7 +330,6 @@ func (w *Wallet) SubmitRegistration(registrationB64 string) error {
 		return err
 	}
 
-	fmt.Print("submitting registration")
 	req, err := newRequest("POST", "/v0/me/cards", nil)
 	if err != nil {
 		return err
@@ -344,7 +342,6 @@ func (w *Wallet) SubmitRegistration(registrationB64 string) error {
 
 	body, _, err := submit(w.logger, req)
 	if err != nil {
-		fmt.Print("Got an error with submit")
 		return err
 	}
 
@@ -393,7 +390,6 @@ type CardDetails struct {
 
 // GetCardDetails returns the details associated with the wallet's backing Uphold card
 func (w *Wallet) GetCardDetails() (*CardDetails, error) {
-	fmt.Print("getting card details")
 	req, err := newRequest("GET", "/v0/me/cards/"+w.ProviderID, nil)
 	if err != nil {
 		return nil, err
@@ -451,7 +447,6 @@ func (w *Wallet) signTransfer(altc altcurrency.AltCurrency, probi decimal.Decima
 		return nil, fmt.Errorf("%w: %s", errorutils.ErrMarshalTransferRequest, err.Error())
 	}
 
-	fmt.Println("signing transfer")
 	req, err := newRequest("POST", "/v0/me/cards/"+w.ProviderID+"/transactions?commit=true", bytes.NewBuffer(unsignedTransaction))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errorutils.ErrCreateTransferRequest, err.Error())
@@ -749,7 +744,6 @@ func (w *Wallet) SubmitTransaction(transactionB64 string, confirm bool) (*wallet
 		url = url + "?commit=true"
 	}
 
-	fmt.Println("submitting transaction")
 	req, err := newRequest("POST", url, nil)
 	if err != nil {
 		return nil, err

--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -162,7 +162,7 @@ func FromWalletInfo(ctx context.Context, info walletutils.Info) (*Wallet, error)
 func newRequest(method, path string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(method, upholdAPIBase+path, body)
 	if err == nil {
-		req.Header.Add("Authorization", "Bearer " + accessToken)
+		req.Header.Add("Authorization", "Bearer "+accessToken)
 	}
 	return req, err
 }
@@ -423,6 +423,8 @@ type transactionRequest struct {
 	Denomination denomination `json:"denomination"`
 	Destination  string       `json:"destination"`
 	Message      string       `json:"message,omitempty"`
+	Purpose      string       `json:"purpose"`
+	Beneficiary  beneficiary  `json:"beneficiary"`
 }
 
 // denominationRecode type was used in this case to maintain trailing zeros so that the validation performed
@@ -438,10 +440,16 @@ type transactionRequestRecode struct {
 	Denomination denominationRecode `json:"denomination"`
 	Destination  string             `json:"destination"`
 	Message      string             `json:"message,omitempty"`
+	Purpose      string             `json:"purpose"`
+	Beneficiary  beneficiary        `json:"beneficiary"`
+}
+
+type beneficiary struct {
+	Relationship string `json:"relationship"`
 }
 
 func (w *Wallet) signTransfer(altc altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string) (*http.Request, error) {
-	transferReq := transactionRequest{Denomination: denomination{Amount: altc.FromProbi(probi), Currency: &altc}, Destination: destination, Message: message}
+	transferReq := transactionRequest{Denomination: denomination{Amount: altc.FromProbi(probi), Currency: &altc}, Destination: destination, Message: message, Purpose: "payout", Beneficiary: beneficiary{Relationship: "business"}}
 	unsignedTransaction, err := json.Marshal(&transferReq)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errorutils.ErrMarshalTransferRequest, err.Error())


### PR DESCRIPTION
(1) Include a JSON parser called payout_json_conversion_tool which handles the incoming JSON for ads and publishers.
(2) Include Bearer token rather than Basic auth
(3) Support adsDirectDeposit
(4) Process bitflyer transactions to 8th decimal place
(5) Fix an issue when we try processing transactions to Bitflyer and
there's multiple transactions involved. We should merge all the bitflyer
transactions together. The lines involved for bitflyer/upload.go were
removed, as it's possible there's multiple payments to one channel, and
only one of these would succeed given that our transaction hashing algorithm
only takes in the channel and the payout_report_id.

Closes https://github.com/brave-intl/bat-go/issues/954
