### PR TITLE
kafka consumer signalling drain retry

### DIFF
--- a/promotion/service.go
+++ b/promotion/service.go
@@ -147,7 +147,7 @@ func (s *Service) InitKafka(ctx context.Context) error {
 			return errors.New("failed not initialize kafka could not find consumer group")
 		}
 
-		s.kafkaAdminAttestationReader, err = kafkautils.NewKafkaReader(ctx, groupID, adminAttestationTopic, kafka.FirstOffset)
+		s.kafkaAdminAttestationReader, err = kafkautils.NewKafkaReader(ctx, groupID, adminAttestationTopic)
 		if err != nil {
 			return fmt.Errorf("failed to initialize kafka attestation reader: %w", err)
 		}

--- a/utils/kafka/dialer.go
+++ b/utils/kafka/dialer.go
@@ -26,7 +26,7 @@ type KafkaRead struct {
 	kafkaDialer *kafka.Dialer
 }
 
-func NewKafkaReader(ctx context.Context, groupID string, topic string, startOffset int64) (*KafkaRead, error) {
+func NewKafkaReader(ctx context.Context, groupID string, topic string) (*KafkaRead, error) {
 	_, logger := logging.SetupLogger(ctx)
 
 	dialer, x509Cert, err := TLSDialer()
@@ -40,12 +40,11 @@ func NewKafkaReader(ctx context.Context, groupID string, topic string, startOffs
 	kafkaBrokers := ctx.Value(appctx.KafkaBrokersCTXKey).(string)
 
 	kafkaReader := kafka.NewReader(kafka.ReaderConfig{
-		Brokers:     strings.Split(kafkaBrokers, ","),
-		GroupID:     groupID,
-		Topic:       topic,
-		StartOffset: startOffset,
-		Dialer:      dialer,
-		Logger:      kafka.LoggerFunc(logger.Printf), // FIXME
+		Brokers: strings.Split(kafkaBrokers, ","),
+		GroupID: groupID,
+		Topic:   topic,
+		Dialer:  dialer,
+		Logger:  kafka.LoggerFunc(logger.Printf), // FIXME
 	})
 
 	return &KafkaRead{


### PR DESCRIPTION
removed offset for use with kafka reader and group id
