### PR TITLE
add purpose and beneficiary fields for Uphold prepared transfers

### DIFF
--- a/cmd/vault/sign_settlement.go
+++ b/cmd/vault/sign_settlement.go
@@ -211,7 +211,7 @@ func createUpholdArtifact(
 	}
 	settlementWallet := &uphold.Wallet{Info: info, PrivKey: signer, PubKey: signer}
 
-	err = settlement.PrepareTransactions(settlementWallet, upholdOnlySettlements)
+	err = settlement.PrepareTransactions(settlementWallet, upholdOnlySettlements, "payout", &uphold.Beneficiary{Relationship: "business"}))
 	if err != nil {
 		return err
 	}

--- a/cmd/vault/sign_settlement.go
+++ b/cmd/vault/sign_settlement.go
@@ -211,7 +211,7 @@ func createUpholdArtifact(
 	}
 	settlementWallet := &uphold.Wallet{Info: info, PrivKey: signer, PubKey: signer}
 
-	err = settlement.PrepareTransactions(settlementWallet, upholdOnlySettlements, "payout", &uphold.Beneficiary{Relationship: "business"}))
+	err = settlement.PrepareTransactions(settlementWallet, upholdOnlySettlements, "payout", &uphold.Beneficiary{Relationship: "business"})
 	if err != nil {
 		return err
 	}

--- a/cmd/wallets/transfer_funds.go
+++ b/cmd/wallets/transfer_funds.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"os"
 
@@ -52,6 +53,14 @@ func init() {
 		"optional note for the transfer").
 		Bind("note")
 
+	transferFundsBuilder.Flag().String("purpose", "",
+		"purpose for the transfer, required for value > $3000").
+		Bind("purpose")
+
+	transferFundsBuilder.Flag().String("beneficiary", "",
+		"JSON formatted beneficiary for the transfer, required for value > $3000").
+		Bind("beneficiary")
+
 	transferFundsBuilder.Flag().Bool("oneshot", false,
 		"submit and commit without confirming").
 		Bind("oneshot")
@@ -97,6 +106,21 @@ func RunTransferFunds(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	purpose, err := command.Flags().GetString("purpose")
+	if err != nil {
+		return err
+	}
+	beneficiaryJSON, err := command.Flags().GetString("beneficiary")
+	if err != nil {
+		return err
+	}
+	var beneficiary *uphold.Beneficiary
+	if len(beneficiaryJSON) > 0 {
+		err := json.Unmarshal([]byte(beneficiaryJSON), beneficiary)
+		if err != nil {
+			return err
+		}
+	}
 	oneshot, err := command.Flags().GetBool("oneshot")
 	if err != nil {
 		return err
@@ -114,6 +138,8 @@ func RunTransferFunds(command *cobra.Command, args []string) error {
 		value,
 		currency,
 		note,
+		purpose,
+		beneficiary,
 		oneshot,
 		usevault,
 	)
@@ -201,6 +227,8 @@ func TransferFunds(
 	value string,
 	currency string,
 	note string,
+	purpose string,
+	beneficiary *uphold.Beneficiary,
 	oneshot bool,
 	usevault bool,
 ) error {
@@ -268,7 +296,7 @@ func TransferFunds(
 		}
 	}
 
-	signedTx, err := w.PrepareTransaction(altc, valueProbi, to, note)
+	signedTx, err := w.PrepareTransaction(altc, valueProbi, to, note, purpose, beneficiary)
 	if err != nil {
 		return err
 	}

--- a/cmd/wallets/transfer_funds.go
+++ b/cmd/wallets/transfer_funds.go
@@ -116,6 +116,7 @@ func RunTransferFunds(command *cobra.Command, args []string) error {
 	}
 	var beneficiary *uphold.Beneficiary
 	if len(beneficiaryJSON) > 0 {
+		beneficiary = &uphold.Beneficiary{}
 		err := json.Unmarshal([]byte(beneficiaryJSON), beneficiary)
 		if err != nil {
 			return err

--- a/payment/controllers_test.go
+++ b/payment/controllers_test.go
@@ -885,7 +885,7 @@ func (suite *ControllersTestSuite) TestAnonymousCardE2E() {
 	}
 
 	suite.Require().True(balanceAfter.GreaterThan(balanceBefore.TotalProbi), "balance should have increased")
-	txn, err := userWallet.PrepareTransaction(altcurrency.BAT, altcurrency.BAT.ToProbi(order.TotalPrice), uphold.SettlementDestination, "bat-go:grant-server.TestAC")
+	txn, err := userWallet.PrepareTransaction(altcurrency.BAT, altcurrency.BAT.ToProbi(order.TotalPrice), uphold.SettlementDestination, "bat-go:grant-server.TestAC", "", nil)
 	suite.Require().NoError(err)
 
 	walletID, err := uuid.FromString(userWallet.ID)

--- a/settlement/settlement.go
+++ b/settlement/settlement.go
@@ -155,7 +155,7 @@ func (tx Transaction) IsFailed() bool {
 }
 
 // PrepareTransactions by embedding signed transactions into the settlement documents
-func PrepareTransactions(wallet *uphold.Wallet, settlements []Transaction) error {
+func PrepareTransactions(wallet *uphold.Wallet, settlements []Transaction, purpose string, beneficiary *uphold.Beneficiary) error {
 	for i := 0; i < len(settlements); i++ {
 		settlement := &settlements[i]
 
@@ -164,7 +164,7 @@ func PrepareTransactions(wallet *uphold.Wallet, settlements []Transaction) error
 		if len(settlement.Note) > 0 {
 			message = settlement.Note
 		}
-		tx, err := wallet.PrepareTransaction(*settlement.AltCurrency, settlement.Probi, settlement.Destination, message, "payout", &uphold.Beneficiary{Relationship: "business"})
+		tx, err := wallet.PrepareTransaction(*settlement.AltCurrency, settlement.Probi, settlement.Destination, message, purpose, beneficiary)
 		if err != nil {
 			return err
 		}

--- a/settlement/settlement.go
+++ b/settlement/settlement.go
@@ -164,7 +164,7 @@ func PrepareTransactions(wallet *uphold.Wallet, settlements []Transaction) error
 		if len(settlement.Note) > 0 {
 			message = settlement.Note
 		}
-		tx, err := wallet.PrepareTransaction(*settlement.AltCurrency, settlement.Probi, settlement.Destination, message)
+		tx, err := wallet.PrepareTransaction(*settlement.AltCurrency, settlement.Probi, settlement.Destination, message, "payout", &uphold.Beneficiary{Relationship: "business"})
 		if err != nil {
 			return err
 		}

--- a/settlement/settlement_test.go
+++ b/settlement/settlement_test.go
@@ -81,7 +81,7 @@ func TestTransactions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = PrepareTransactions(donorWallet, settlements)
+	err = PrepareTransactions(donorWallet, settlements, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestDeterministicSigning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = PrepareTransactions(donorWallet, settlements)
+	err = PrepareTransactions(donorWallet, settlements, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -419,6 +419,7 @@ type denomination struct {
 	Currency *altcurrency.AltCurrency `json:"currency"`
 }
 
+// Beneficiary includes information about the recipient of the transaction
 type Beneficiary struct {
 	Relationship string `json:"relationship"`
 }

--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -258,7 +258,7 @@ func (w *Wallet) IsUserKYC(ctx context.Context, destination string) (string, boo
 	}
 
 	// prepare a transaction by creating a payload
-	transactionB64, err := grantWallet.PrepareTransaction(altcurrency.BAT, decimal.New(0, 1), destination, "")
+	transactionB64, err := grantWallet.PrepareTransaction(altcurrency.BAT, decimal.New(0, 1), destination, "", "", nil)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to prepare transaction")
 		return "", false, fmt.Errorf("failed to prepare transaction: %w", err)
@@ -419,10 +419,16 @@ type denomination struct {
 	Currency *altcurrency.AltCurrency `json:"currency"`
 }
 
+type Beneficiary struct {
+	Relationship string `json:"relationship"`
+}
+
 type transactionRequest struct {
 	Denomination denomination `json:"denomination"`
 	Destination  string       `json:"destination"`
 	Message      string       `json:"message,omitempty"`
+	Purpose      string       `json:"purpose,omitempty"`
+	Beneficiary  *Beneficiary `json:"beneficiary,omitempty"`
 }
 
 // denominationRecode type was used in this case to maintain trailing zeros so that the validation performed
@@ -438,10 +444,12 @@ type transactionRequestRecode struct {
 	Denomination denominationRecode `json:"denomination"`
 	Destination  string             `json:"destination"`
 	Message      string             `json:"message,omitempty"`
+	Purpose      string             `json:"purpose,omitempty"`
+	Beneficiary  *Beneficiary       `json:"beneficiary,omitempty"`
 }
 
-func (w *Wallet) signTransfer(altc altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string) (*http.Request, error) {
-	transferReq := transactionRequest{Denomination: denomination{Amount: altc.FromProbi(probi), Currency: &altc}, Destination: destination, Message: message}
+func (w *Wallet) signTransfer(altc altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string, purpose string, beneficiary *Beneficiary) (*http.Request, error) {
+	transferReq := transactionRequest{Denomination: denomination{Amount: altc.FromProbi(probi), Currency: &altc}, Destination: destination, Message: message, Purpose: purpose, Beneficiary: beneficiary}
 	unsignedTransaction, err := json.Marshal(&transferReq)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", errorutils.ErrMarshalTransferRequest, err.Error())
@@ -464,8 +472,8 @@ func (w *Wallet) signTransfer(altc altcurrency.AltCurrency, probi decimal.Decima
 }
 
 // PrepareTransaction returns a b64 encoded serialized signed transaction suitable for SubmitTransaction
-func (w *Wallet) PrepareTransaction(altcurrency altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string) (string, error) {
-	req, err := w.signTransfer(altcurrency, probi, destination, message)
+func (w *Wallet) PrepareTransaction(altcurrency altcurrency.AltCurrency, probi decimal.Decimal, destination string, message string, purpose string, beneficiary *Beneficiary) (string, error) {
+	req, err := w.signTransfer(altcurrency, probi, destination, message, purpose, beneficiary)
 	if err != nil {
 		return "", err
 	}
@@ -485,7 +493,7 @@ func (w *Wallet) PrepareTransaction(altcurrency altcurrency.AltCurrency, probi d
 
 // Transfer moves funds out of the associated wallet and to the specific destination
 func (w *Wallet) Transfer(altcurrency altcurrency.AltCurrency, probi decimal.Decimal, destination string) (*walletutils.TransactionInfo, error) {
-	req, err := w.signTransfer(altcurrency, probi, destination, "")
+	req, err := w.signTransfer(altcurrency, probi, destination, "", "", nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign the transfer: %w", err)
 	}

--- a/utils/wallet/provider/uphold/uphold_test.go
+++ b/utils/wallet/provider/uphold/uphold_test.go
@@ -188,6 +188,8 @@ func TestTransactions(t *testing.T) {
 		altcurrency.BAT.ToProbi(value),
 		destWallet.Info.ProviderID,
 		"bat-go:uphold.TestTransactions",
+		"",
+		nil,
 	)
 	if err != nil {
 		t.Error(err)

--- a/wallet/controllers_test.go
+++ b/wallet/controllers_test.go
@@ -389,7 +389,7 @@ func (suite *WalletControllersTestSuite) claimCardV3(
 	amount decimal.Decimal,
 	anonymousAddress *uuid.UUID,
 ) (*walletutils.Info, string) {
-	signedCreationRequest, err := w.PrepareTransaction(*w.AltCurrency, altcurrency.BAT.ToProbi(amount), destination, "")
+	signedCreationRequest, err := w.PrepareTransaction(*w.AltCurrency, altcurrency.BAT.ToProbi(amount), destination, "", "", nil)
 
 	suite.Require().NoError(err, "transaction must be signed client side")
 


### PR DESCRIPTION
### Summary

these fields were added by Uphold several months back and are required for large transfers. 

support for these fields was previously added in:
https://github.com/brave-intl/bat-go/pull/955/files

unfortunately, the approach there is not mergable as said values were hardcoded for all transfers.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
