### PR TITLE
preserve relative coin input and match output

### DIFF
--- a/ratios/cache.go
+++ b/ratios/cache.go
@@ -27,7 +27,7 @@ func (s *Service) GetTopCoins(ctx context.Context, limit int) (CoingeckoCoinList
 
 	list := make([]CoingeckoCoin, len(tmp))
 	for i, coin := range tmp {
-		list[i] = CoingeckoCoin(coin)
+		list[i] = CoingeckoCoin{Coin: coin}
 	}
 
 	resp = CoingeckoCoinList(list)

--- a/ratios/cache.go
+++ b/ratios/cache.go
@@ -27,7 +27,7 @@ func (s *Service) GetTopCoins(ctx context.Context, limit int) (CoingeckoCoinList
 
 	list := make([]CoingeckoCoin, len(tmp))
 	for i, coin := range tmp {
-		list[i] = CoingeckoCoin{Coin: coin}
+		list[i] = CoingeckoCoin{coin: coin}
 	}
 
 	resp = CoingeckoCoinList(list)

--- a/ratios/inputs.go
+++ b/ratios/inputs.go
@@ -10,11 +10,14 @@ import (
 )
 
 // CoingeckoCoin - type for coingecko coin input
-type CoingeckoCoin string
+type CoingeckoCoin struct {
+	Input string
+	Coin  string
+}
 
 // String - stringer implmentation
 func (cc *CoingeckoCoin) String() string {
-	return string(*cc)
+	return string(cc.Coin)
 }
 
 var (
@@ -45,7 +48,7 @@ func (cc *CoingeckoCoin) Decode(ctx context.Context, v []byte) error {
 		}
 	}
 
-	*cc = CoingeckoCoin(c)
+	*cc = CoingeckoCoin{Input: coin, Coin: c}
 	return nil
 }
 

--- a/ratios/inputs.go
+++ b/ratios/inputs.go
@@ -11,13 +11,13 @@ import (
 
 // CoingeckoCoin - type for coingecko coin input
 type CoingeckoCoin struct {
-	Input string
-	Coin  string
+	input string
+	coin  string
 }
 
 // String - stringer implmentation
 func (cc *CoingeckoCoin) String() string {
-	return string(cc.Coin)
+	return string(cc.coin)
 }
 
 var (
@@ -48,7 +48,7 @@ func (cc *CoingeckoCoin) Decode(ctx context.Context, v []byte) error {
 		}
 	}
 
-	*cc = CoingeckoCoin{Input: coin, Coin: c}
+	*cc = CoingeckoCoin{input: coin, coin: c}
 	return nil
 }
 

--- a/ratios/mapping.go
+++ b/ratios/mapping.go
@@ -203,8 +203,8 @@ func mapSimplePriceResponse(ctx context.Context, resp coingecko.SimplePriceRespo
 		}
 
 		for _, vv := range []CoingeckoCoin(coinIDs) {
-			if vv.Coin == k {
-				out[vv.Input] = innerOut
+			if vv.String() == k {
+				out[vv.input] = innerOut
 			}
 		}
 	}

--- a/ratios/mapping.go
+++ b/ratios/mapping.go
@@ -174,8 +174,7 @@ func (s *Service) initializeCoingeckoCurrencies(ctx context.Context) (context.Co
 	return ctx, nil
 }
 
-func mapSimplePriceResponse(ctx context.Context, resp coingecko.SimplePriceResponse, duration CoingeckoDuration, vsCurrencies CoingeckoVsCurrencyList) coingecko.SimplePriceResponse {
-	idToSymbol := ctx.Value(appctx.CoingeckoIDToSymbolCTXKey).(map[string]string)
+func mapSimplePriceResponse(ctx context.Context, resp coingecko.SimplePriceResponse, duration CoingeckoDuration, coinIDs CoingeckoCoinList, vsCurrencies CoingeckoVsCurrencyList) coingecko.SimplePriceResponse {
 	out := map[string]map[string]decimal.Decimal{}
 
 	for k, v := range resp {
@@ -202,7 +201,12 @@ func mapSimplePriceResponse(ctx context.Context, resp coingecko.SimplePriceRespo
 			}
 			innerOut[kk] = rate
 		}
-		out[idToSymbol[k]] = innerOut
+
+		for _, vv := range []CoingeckoCoin(coinIDs) {
+			if vv.Coin == k {
+				out[vv.Input] = innerOut
+			}
+		}
 	}
 
 	return coingecko.SimplePriceResponse(out)

--- a/ratios/service.go
+++ b/ratios/service.go
@@ -195,7 +195,7 @@ func (s *Service) GetRelative(ctx context.Context, coinIDs CoingeckoCoinList, vs
 	}
 
 	return &RelativeResponse{
-		Payload:     mapSimplePriceResponse(ctx, *rates, duration, vsCurrencies),
+		Payload:     mapSimplePriceResponse(ctx, *rates, duration, coinIDs, vsCurrencies),
 		LastUpdated: updated,
 	}, nil
 }


### PR DESCRIPTION
### Summary

restores prior ratios behavior which preserves the coin input ( symbol or contract address ) and matches the output from coingecko to it

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
