### PR TITLE
bitflyer batch payment concurrency issue

### DIFF
--- a/promotion/controllers_test.go
+++ b/promotion/controllers_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/brave-intl/bat-go/middleware"
 	"github.com/brave-intl/bat-go/utils/altcurrency"
 	"github.com/brave-intl/bat-go/utils/clients/bitflyer"
-	cbr "github.com/brave-intl/bat-go/utils/clients/cbr"
+	"github.com/brave-intl/bat-go/utils/clients/cbr"
 	mockcb "github.com/brave-intl/bat-go/utils/clients/cbr/mock"
 	mockreputation "github.com/brave-intl/bat-go/utils/clients/reputation/mock"
 	appctx "github.com/brave-intl/bat-go/utils/context"
@@ -289,6 +289,7 @@ func (suite *ControllersTestSuite) TestGetPromotions() {
 	suite.Assert().JSONEq(expectedOSX, rr.Body.String(), "unexpected result")
 }
 
+// ClaimPromotion helper that calls promotion endpoint and does assertions
 func (suite *ControllersTestSuite) ClaimPromotion(service *Service, w walletutils.Info, privKey crypto.Signer,
 	promotion *Promotion, blindedCreds []string, claimStatus int) *uuid.UUID {
 

--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/jmoiron/sqlx"
 	"os"
 	"strings"
 	"time"
@@ -45,6 +46,16 @@ type BATLossEvent struct {
 	ReportID int             `db:"report_id" json:"reportId"`
 	Amount   decimal.Decimal `db:"amount" json:"amount"`
 	Platform string          `db:"platform" json:"platform"`
+}
+
+// DrainClaim holds drain claim data
+type DrainClaim struct {
+	BatchID     *uuid.UUID
+	Claim       *Claim
+	Credentials []cbr.CredentialRedemption
+	Wallet      *walletutils.Info
+	Total       decimal.Decimal
+	CodedErr    errorutils.DrainCodified
 }
 
 // Datastore abstracts over the underlying datastore
@@ -99,6 +110,8 @@ type Datastore interface {
 	InsertBAPReportEvent(ctx context.Context, paymentID uuid.UUID, amount decimal.Decimal) (*uuid.UUID, error)
 	// DrainClaim by marking the claim as drained and inserting a new drain entry
 	DrainClaim(drainID *uuid.UUID, claim *Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal, codedErr errorutils.DrainCodified) error
+	// InsertBatchDrainClaim insert drain claims
+	DrainClaims(drainClaims []DrainClaim) error
 	// RunNextDrainJob to process deposits if there is one waiting
 	RunNextDrainJob(ctx context.Context, worker DrainWorker) (bool, error)
 	// RunNextDrainRetryJob toggles failed drain jobs to be reprocessed if eligible
@@ -1300,17 +1313,57 @@ func (pg *Postgres) EnqueueMintDrainJob(ctx context.Context, walletID uuid.UUID,
 }
 
 // DrainClaim by marking the claim as drained and inserting a new drain entry
-func (pg *Postgres) DrainClaim(drainPollID *uuid.UUID, claim *Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal, codedErr errorutils.DrainCodified) error {
-	credentialsJSON, err := json.Marshal(credentials)
-	if err != nil {
-		return err
-	}
-
+func (pg *Postgres) DrainClaim(batchID *uuid.UUID, claim *Claim, credentials []cbr.CredentialRedemption, wallet *walletutils.Info, total decimal.Decimal, codedErr errorutils.DrainCodified) error {
 	tx, err := pg.RawDB().Beginx()
 	if err != nil {
 		return err
 	}
 	defer pg.RollbackTx(tx)
+
+	err = pg.txDrainClaim(tx, batchID, claim, credentials, wallet, total, codedErr)
+	if err != nil {
+		return fmt.Errorf("drain claim: error for claimID %s: %w", claim.ID, err)
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DrainClaims marks all drain claim as drained and inserts a new drain entry
+func (pg *Postgres) DrainClaims(drainClaims []DrainClaim) error {
+	tx, err := pg.RawDB().Beginx()
+	if err != nil {
+		return fmt.Errorf("insert batch drain claim: error could not begin tx: %w", err)
+	}
+	defer pg.RollbackTx(tx)
+
+	for _, d := range drainClaims {
+		err = pg.txDrainClaim(tx, d.BatchID, d.Claim, d.Credentials, d.Wallet, d.Total, d.CodedErr)
+		if err != nil {
+			return fmt.Errorf("insert batch drain claim: error could not insert drain claim for claimID %s: %w",
+				d.Claim.ID, err)
+		}
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("insert batch drain claim: error could not commit drain claims: %w", err)
+	}
+
+	return nil
+}
+
+func (pg *Postgres) txDrainClaim(tx *sqlx.Tx, batchID *uuid.UUID, claim *Claim, credentials []cbr.CredentialRedemption,
+	wallet *walletutils.Info, total decimal.Decimal, codedErr errorutils.DrainCodified) error {
+
+	credentialsJSON, err := json.Marshal(credentials)
+	if err != nil {
+		return err
+	}
 
 	var claimID *uuid.UUID
 	// if the claim is not nil, we should set it to drained, as we are in drained state
@@ -1332,7 +1385,7 @@ func (pg *Postgres) DrainClaim(drainPollID *uuid.UUID, claim *Claim, credentials
 		insert into claim_drain (credentials, wallet_id, total, batch_id, claim_id, deposit_destination, updated_at)
 		values ($1, $2, $3, $4, $5, $6, CURRENT_TIMESTAMP)
 		returning *`
-		err = tx.Get(&claimDrain, statement, credentialsJSON, wallet.ID, total, drainPollID, claim.ID, &wallet.UserDepositDestination)
+		err = tx.Get(&claimDrain, statement, credentialsJSON, wallet.ID, total, batchID, claim.ID, &wallet.UserDepositDestination)
 		if err != nil {
 			return err
 		}
@@ -1345,15 +1398,10 @@ func (pg *Postgres) DrainClaim(drainPollID *uuid.UUID, claim *Claim, credentials
 		values ($1, $2, $3, $4, $5, $6, true, $7, CURRENT_TIMESTAMP)
 		returning *`
 		err = tx.Get(&claimDrain, statement, credentialsJSON, wallet.ID, total,
-			drainPollID, claimID, &wallet.UserDepositDestination, code)
+			batchID, claimID, &wallet.UserDepositDestination, code)
 		if err != nil {
 			return fmt.Errorf("failed to insert erred drain job: %w", err)
 		}
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return err
 	}
 
 	return nil

--- a/promotion/datastore.go
+++ b/promotion/datastore.go
@@ -977,11 +977,11 @@ func (pg *Postgres) RunNextBatchPaymentsJob(ctx context.Context, worker BatchTra
 			join wallets w on w.id=cd.wallet_id
 		where
 			cd.erred = false and
-			cd.status='prepared' and
 			w.user_deposit_account_provider = 'bitflyer'
 		group by
 			cd.batch_id
-		having bool_and(transaction_id is not null) = true
+		having bool_and(transaction_id is not null) = true 
+		   and bool_and(cd.status = 'prepared') = true
 		limit 1
 `
 	var batchID = new(uuid.UUID)
@@ -1465,7 +1465,7 @@ func (pg *Postgres) RunNextDrainJob(ctx context.Context, worker DrainWorker) (bo
 select *
 from claim_drain
 where not erred and transaction_id is null
-and (status is null or status not in ('complete', 'reputation-failed', 'failed', 'prepared', 'gemini-pending'))
+and (status is null or status not in ('complete', 'reputation-failed', 'failed', 'prepared', 'gemini-pending', 'submitted'))
 for update skip locked
 limit 1`
 

--- a/promotion/drain.go
+++ b/promotion/drain.go
@@ -121,74 +121,107 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 		}
 	}
 
+	drainClaims := make([]DrainClaim, 0)
 	for k, v := range fundingSources {
-		var (
-			promotion = promotions[k]
-		)
+		var promotion = promotions[k]
 
 		// if the type is not ads
 		// except in the case the promotion is for ios and deposit provider is a brave wallet
-		if v.Type != "ads" &&
-			depositProvider != "brave" && strings.ToLower(promotion.Platform) != "ios" {
+		if v.Type != "ads" && depositProvider != "brave" && strings.ToLower(promotion.Platform) != "ios" {
 			sublogger.Error().Msg("invalid promotion platform, must be ads")
-			return nil, errors.New("only ads suggestions can be drained")
+			continue
 		}
 
 		claim, err := service.Datastore.GetClaimByWalletAndPromotion(wallet, promotion)
 		if err != nil || claim == nil {
 			sublogger.Error().Err(err).Str("promotion_id", promotion.ID.String()).Msg("claim does not exist for wallet")
 			// the case where there this wallet never got this promotion
-			return &batchID, service.Datastore.DrainClaim(&batchID, claim, v.Credentials, wallet, v.Amount, errMismatchedWallet)
+			drainClaims = append(drainClaims, DrainClaim{
+				BatchID:     &batchID,
+				Claim:       claim,
+				Credentials: v.Credentials,
+				Wallet:      wallet,
+				Total:       v.Amount,
+				CodedErr:    errMismatchedWallet,
+			})
+			continue
 		}
 
 		suggestionsExpected, err := claim.SuggestionsNeeded(promotion)
 		if err != nil {
 			sublogger.Error().Err(err).Str("promotion_id", promotion.ID.String()).Msg("invalid number of suggestions")
 			// the case where there is an invalid number of suggestions
-			return &batchID, service.Datastore.DrainClaim(&batchID, claim, v.Credentials, wallet, v.Amount, errInvalidSuggestionCount)
+			drainClaims = append(drainClaims, DrainClaim{
+				BatchID:     &batchID,
+				Claim:       claim,
+				Credentials: v.Credentials,
+				Wallet:      wallet,
+				Total:       v.Amount,
+				CodedErr:    errInvalidSuggestionCount,
+			})
+			continue
 		}
 
 		amountExpected := decimal.New(int64(suggestionsExpected), 0).Mul(promotion.CredentialValue())
 		if v.Amount.GreaterThan(amountExpected) {
 			sublogger.Error().Str("promotion_id", promotion.ID.String()).Msg("attempting to claim more funds than earned")
 			// the case where there the amount is higher than expected
-			return &batchID, service.Datastore.DrainClaim(&batchID, claim, v.Credentials, wallet, v.Amount, errInvalidSuggestionAmount)
+			drainClaims = append(drainClaims, DrainClaim{
+				BatchID:     &batchID,
+				Claim:       claim,
+				Credentials: v.Credentials,
+				Wallet:      wallet,
+				Total:       v.Amount,
+				CodedErr:    errInvalidSuggestionAmount,
+			})
+			continue
 		}
 
-		// Skip already drained promotions for idempotency
+		// skip already drained promotions for idempotency
 		if !claim.Drained {
-			// Mark corresponding claim as drained
-			err := service.Datastore.DrainClaim(&batchID, claim, v.Credentials, wallet, v.Amount, nil)
-			if err != nil {
-				sublogger.Error().Msg("failed to drain the claim")
-				return nil, fmt.Errorf("error draining claim: %w", err)
-			}
-
-			// the original request context will be cancelled as soon as the dialer closes the connection.
-			// this will setup a new context with the same values and a 90 second timeout
-			asyncCtx, asyncCancel := context.WithTimeout(context.Background(), 90*time.Second)
-			scopedCtx := appctx.Wrap(ctx, asyncCtx)
-
-			go func() {
-				defer asyncCancel()
-				defer middleware.ConcurrentGoRoutines.With(
-					prometheus.Labels{
-
-						"method": "NextDrainJob",
-					}).Dec()
-
-				middleware.ConcurrentGoRoutines.With(
-					prometheus.Labels{
-						"method": "NextDrainJob",
-					}).Inc()
-
-				_, err := service.RunNextDrainJob(scopedCtx)
-				if err != nil {
-					sentry.CaptureException(err)
-				}
-			}()
+			drainClaims = append(drainClaims, DrainClaim{
+				BatchID:     &batchID,
+				Claim:       claim,
+				Credentials: v.Credentials,
+				Wallet:      wallet,
+				Total:       v.Amount,
+				CodedErr:    nil,
+			})
 		}
 	}
+
+	if len(drainClaims) > 0 {
+		err = service.Datastore.DrainClaims(drainClaims)
+		if err != nil {
+			return nil, fmt.Errorf("faied to insert drain claims for walletID %s: %w", walletID, err)
+		}
+	}
+
+	for i := 0; i < len(drainClaims); i++ {
+		// the original request context will be cancelled as soon as the dialer closes the connection.
+		// this will setup a new context with the same values and a 90 second timeout
+		asyncCtx, asyncCancel := context.WithTimeout(context.Background(), 90*time.Second)
+		scopedCtx := appctx.Wrap(ctx, asyncCtx)
+
+		go func() {
+			defer asyncCancel()
+			defer middleware.ConcurrentGoRoutines.With(
+				prometheus.Labels{
+					"method": "NextDrainJob",
+				}).Dec()
+
+			middleware.ConcurrentGoRoutines.With(
+				prometheus.Labels{
+					"method": "NextDrainJob",
+				}).Inc()
+
+			_, err := service.RunNextDrainJob(scopedCtx)
+			if err != nil {
+				sentry.CaptureException(err)
+			}
+		}()
+	}
+
 	if depositProvider == "brave" && wallet.UserDepositDestination != "" {
 		asyncCtx, asyncCancel := context.WithTimeout(context.Background(), 90*time.Second)
 		scopedCtx := appctx.Wrap(ctx, asyncCtx)
@@ -211,6 +244,7 @@ func (service *Service) Drain(ctx context.Context, credentials []CredentialBindi
 			}
 		}()
 	}
+
 	return &batchID, nil
 }
 

--- a/promotion/drain.go
+++ b/promotion/drain.go
@@ -448,10 +448,6 @@ func (service *Service) SubmitBatchTransfer(ctx context.Context, batchID *uuid.U
 		}
 	}
 
-	if err := service.Datastore.MarkBatchTransferSubmitted(ctx, batchID); err != nil {
-		return err
-	}
-
 	if overLimitErr != nil {
 		return overLimitErr
 	}

--- a/promotion/drain_test.go
+++ b/promotion/drain_test.go
@@ -617,10 +617,6 @@ func TestSubmitBatchTransfer_UploadBulkPayout_Bitflyer_Unauthorized_Retry(t *tes
 		UploadBulkPayout(ctx, gomock.Any()).
 		Return(&withdrawToDepositIDBulkResponse, nil)
 
-	datastore.EXPECT().
-		MarkBatchTransferSubmitted(ctx, batchID).
-		Return(nil)
-
 	s := Service{
 		bfClient:  bfClient,
 		Datastore: datastore,

--- a/promotion/instrumented_datastore.go
+++ b/promotion/instrumented_datastore.go
@@ -144,6 +144,20 @@ func (_d DatastoreWithPrometheus) DrainClaim(drainID *uuid.UUID, claim *Claim, c
 	return _d.base.DrainClaim(drainID, claim, credentials, wallet, total, codedErr)
 }
 
+// DrainClaims implements Datastore
+func (_d DatastoreWithPrometheus) DrainClaims(drainClaims []DrainClaim) (err error) {
+	_since := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+
+		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "DrainClaims", result).Observe(time.Since(_since).Seconds())
+	}()
+	return _d.base.DrainClaims(drainClaims)
+}
+
 // EnqueueMintDrainJob implements Datastore
 func (_d DatastoreWithPrometheus) EnqueueMintDrainJob(ctx context.Context, walletID uuid.UUID, promotionIDs ...uuid.UUID) (err error) {
 	_since := time.Now()

--- a/promotion/mockdatastore.go
+++ b/promotion/mockdatastore.go
@@ -144,6 +144,20 @@ func (mr *MockDatastoreMockRecorder) DrainClaim(drainID, claim, credentials, wal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DrainClaim", reflect.TypeOf((*MockDatastore)(nil).DrainClaim), drainID, claim, credentials, wallet, total, codedErr)
 }
 
+// DrainClaims mocks base method.
+func (m *MockDatastore) DrainClaims(drainClaims []DrainClaim) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DrainClaims", drainClaims)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DrainClaims indicates an expected call of DrainClaims.
+func (mr *MockDatastoreMockRecorder) DrainClaims(drainClaims interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DrainClaims", reflect.TypeOf((*MockDatastore)(nil).DrainClaims), drainClaims)
+}
+
 // EnqueueMintDrainJob mocks base method.
 func (m *MockDatastore) EnqueueMintDrainJob(ctx context.Context, walletID go_uuid.UUID, promotionIDs ...go_uuid.UUID) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This resolves #1186 where claim drains were being processed before they were ready for batching


