### PR TITLE
Omit beneficiary information that breaks uphold validation

### DIFF
--- a/utils/wallet/provider/uphold/uphold.go
+++ b/utils/wallet/provider/uphold/uphold.go
@@ -419,11 +419,11 @@ type denomination struct {
 // Beneficiary includes information about the recipient of the transaction
 type Beneficiary struct {
 	Address struct {
-		City    string `json:"city"`
-		Country string `json:"country"`
-		Line1   string `json:"line1"`
-		State   string `json:"state"`
-		ZipCode string `json:"zipCode"`
+		City    string `json:"city,omitempty"`
+		Country string `json:"country,omitempty"`
+		Line1   string `json:"line1,omitempty"`
+		State   string `json:"state,omitempty"`
+		ZipCode string `json:"zipCode,omitempty"`
 	} `json:"address,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Relationship string `json:"relationship"`


### PR DESCRIPTION
### Summary

If beneficiary country and state are provided, but left empty, Uphold will fail to validate and prevent transaction upload.

### Type of change ( select one )

- [ ] Product feature
- [X] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [X] Production
