### PR TITLE
hotfix correct promotion id in client

### DIFF
--- a/utils/clients/reputation/client.go
+++ b/utils/clients/reputation/client.go
@@ -51,7 +51,7 @@ func New() (Client, error) {
 // IsDrainReputableOpts - the query string options for the is reputable api call
 type IsDrainReputableOpts struct {
 	WithdrawalAmount decimal.Decimal `url:"withdrawal_amount"`
-	PromotionID      uuid.UUID       `url:"promotion_id"`
+	PromotionID      string          `url:"promotion_id"`
 }
 
 // GenerateQueryString - implement the QueryStringBody interface
@@ -77,7 +77,7 @@ func (c *HTTPClient) IsDrainReputable(
 
 	var body = IsDrainReputableOpts{
 		WithdrawalAmount: withdrawalAmount,
-		PromotionID:      promotionID,
+		PromotionID:      promotionID.String(),
 	}
 
 	req, err := c.client.NewRequest(

--- a/utils/clients/reputation/client.go
+++ b/utils/clients/reputation/client.go
@@ -50,8 +50,8 @@ func New() (Client, error) {
 
 // IsDrainReputableOpts - the query string options for the is reputable api call
 type IsDrainReputableOpts struct {
-	WithdrawalAmount decimal.Decimal `url:"withdrawal_amount"`
-	PromotionID      string          `url:"promotion_id"`
+	WithdrawalAmount string `url:"withdrawal_amount"`
+	PromotionID      string `url:"promotion_id"`
 }
 
 // GenerateQueryString - implement the QueryStringBody interface
@@ -76,7 +76,7 @@ func (c *HTTPClient) IsDrainReputable(
 ) (bool, string, error) {
 
 	var body = IsDrainReputableOpts{
-		WithdrawalAmount: withdrawalAmount,
+		WithdrawalAmount: withdrawalAmount.String(),
 		PromotionID:      promotionID.String(),
 	}
 


### PR DESCRIPTION

### Summary

for some reason the url query string library is breaking up the uuid …into an array of bytes, turing the promotion_id into a string to avoid

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
