### PR TITLE
snapshot the settlement log file, fixes #1275

### DIFF
--- a/cmd/settlement/uphold.go
+++ b/cmd/settlement/uphold.go
@@ -168,7 +168,7 @@ func UpholdUpload(
 		}
 	}
 
-	// Optimization the case where we are rerunning by creating a truncated snapshot of the last state
+	// Optimize the case where we are rerunning by creating a truncated snapshot of the last state
 	if isResubmit {
 		backupFile := strings.TrimSuffix(logFile, filepath.Ext(logFile)) + "-backup.json"
 		backupF, err := os.OpenFile(backupFile, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)


### PR DESCRIPTION
### Summary

attempts to better optimize the case where we have to rerun a settlement upload multiple times by snapshotting the fully caught up state of the settlement log.

fixes #1275 

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
