### PR TITLE
automatically poll all settlements in the processing state to finalization

### DIFF
--- a/settlement/settlement.go
+++ b/settlement/settlement.go
@@ -183,6 +183,11 @@ func (tx Transaction) IsFailed() bool {
 	return tx.Status == "failed"
 }
 
+// IsProcessing returns true if the transaction status is processing
+func (tx Transaction) IsProcessing() bool {
+	return tx.Status == "processing"
+}
+
 // PrepareTransactions by embedding signed transactions into the settlement documents
 func PrepareTransactions(wallet *uphold.Wallet, settlements []Transaction, purpose string, beneficiary *uphold.Beneficiary) error {
 	for i := 0; i < len(settlements); i++ {


### PR DESCRIPTION
### Summary

Since uphold settlements now enter a `processing` state on confirm, on average there are many more transactions that must be retried manually. This change relies on the fact that transactions which enter the processing state will either eventually fail ( we assume permanently ) or complete successfully. 

>  Otherwise, the request is completed successfully and the response body will contain a status property with value processing. In the meantime, we perform another set of validations that can lead to a transaction’s status becoming failed or completed

https://uphold.com/en/developer/api/documentation/

Essentially we reframe the original loop through transactions with submit and confirm as a way to attempt to get as many transactions as possible into the pending state. This PR adds a second loop which will attempt to drive all transactions in the processing state to completion, retrying as many times as needed.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
