### PR TITLE
try to speedup json serialization for settlement logs

### DIFF
--- a/cmd/settlement/uphold.go
+++ b/cmd/settlement/uphold.go
@@ -17,6 +17,7 @@ import (
 	appctx "github.com/brave-intl/bat-go/utils/context"
 	"github.com/brave-intl/bat-go/utils/logging"
 	"github.com/brave-intl/bat-go/utils/wallet/provider/uphold"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
 )
 
@@ -98,7 +99,7 @@ func RunUpholdUpload(cmd *cobra.Command, args []string) error {
 
 func recordProgress(f *os.File, settlementTransaction *settlement.Transaction) error {
 	var out []byte
-	out, err := json.Marshal(settlementTransaction)
+	out, err := jsoniter.Marshal(settlementTransaction)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal settlement transaction: %v", err)
 	}
@@ -141,7 +142,7 @@ func UpholdUpload(
 	}
 
 	var settlementState settlement.State
-	err = json.Unmarshal(settlementJSON, &settlementState)
+	err = jsoniter.Unmarshal(settlementJSON, &settlementState)
 	if err != nil {
 		logger.Panic().Err(err).Msg("failed to unmarshal input file")
 	}
@@ -157,7 +158,7 @@ func UpholdUpload(
 	isResubmit := false
 	for scanner.Scan() {
 		var tmp settlement.Transaction
-		err = json.Unmarshal(scanner.Bytes(), &tmp)
+		err = jsoniter.Unmarshal(scanner.Bytes(), &tmp)
 		if err != nil {
 			logger.Panic().Err(err).Msg("failed to scan the transaction log")
 		}


### PR DESCRIPTION
### Summary

uses a library that is supposedly faster than the standard library to try to speed up settlement log loading / snapshots

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
