### PR TITLE
Ratios: Cache coin markets reponse in Redis before applying limit

### DIFF
--- a/utils/clients/coingecko/client.go
+++ b/utils/clients/coingecko/client.go
@@ -393,7 +393,6 @@ func (c *HTTPClient) FetchCoinMarkets(
 		return nil, updated, err
 	}
 
-	body = (&body).applyLimit(params.Limit)
 	bodyBytes, err := json.Marshal(&body)
 	if err != nil {
 		return nil, updated, err
@@ -410,5 +409,7 @@ func (c *HTTPClient) FetchCoinMarkets(
 		return nil, updated, err
 	}
 
+	// Apply the limit only after caching the all the results
+	body = (&body).applyLimit(params.Limit)
 	return &body, updated, nil
 }


### PR DESCRIPTION
### Summary
We always fetch 250 results from coingecko, but return a subset of those results to the client depending on the `limit` parameter the client sets.  The problem is that we are not caching all 250 results in Redis, just the subset.  This can cause problems if the client requests with limit=25, then limit=50.  The second call would fetch the results from the cache, but only the first 25 are cached.

The fix in this pull request is to always cache 250 results, and apply the limit after updating the cache and before returning to the client.

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
