### PR TITLE
bug: cleanup order job extra logging error

### DIFF
--- a/skus/datastore.go
+++ b/skus/datastore.go
@@ -934,9 +934,6 @@ func (pg *Postgres) InsertVote(ctx context.Context, vr VoteRecord) error {
 
 // RunNextOrderJob to sign order credentials if there is a order waiting, returning true if a job was attempted
 func (pg *Postgres) RunNextOrderJob(ctx context.Context, worker OrderWorker) (bool, error) {
-
-	logger := logging.Logger(ctx, "RunNextOrderJob")
-
 	tx, err := pg.RawDB().Beginx()
 	attempted := false
 	if err != nil {
@@ -989,14 +986,9 @@ ON order_cred.issuer_id = order_cred_issuers.id`
 		if errors.As(err, &eb) {
 			// pull out the data and see if this is an http client error
 			if hs, ok := eb.Data().(clients.HTTPState); ok {
-				// this is an http client error from cbr
-				// get more details about the failure
-				logger.Error().Err(eb.Cause()).Str("status", fmt.Sprintf("%d", hs.Status)).Str(
-					"body", fmt.Sprintf("%+v", hs.Body)).Msg("failed to call SignOrderCreds")
-
 				// if the error is from CBR and contains "Cannot decompress Edwards point" this job will never complete
-				// and keep retrying over and over.  We want to filter this out and set batch proof
-				// to empty string so it will not be picked up
+				// and keep retrying over and over. We want to filter this out and set batch proof
+				// to empty string, so it will not be picked up again
 				if strings.Contains("cannot decompress edwards point",
 					strings.ToLower(fmt.Sprintf("%+v", hs.Body))) {
 					bp := ""

--- a/skus/service.go
+++ b/skus/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/brave-intl/bat-go/utils/wallet/provider"
 	"github.com/brave-intl/bat-go/utils/wallet/provider/uphold"
 	"github.com/brave-intl/bat-go/wallet"
-	sentry "github.com/getsentry/sentry-go"
 	"github.com/linkedin/goavro"
 	stripe "github.com/stripe/stripe-go/v72"
 
@@ -751,8 +750,6 @@ func (s *Service) RunNextOrderJob(ctx context.Context) (bool, error) {
 	for {
 		attempted, err := s.Datastore.RunNextOrderJob(ctx, s)
 		if err != nil {
-			sentry.CaptureMessage(err.Error())
-			sentry.Flush(time.Second * 2)
 			return attempted, fmt.Errorf("failed to attempt run next order job: %w", err)
 		}
 		if !attempted {


### PR DESCRIPTION
removes sentry message capture and extra logging for order jobs

resolves #1474 