### PR TITLE
feat: cleanup response data v4 endpoints

### DIFF
--- a/libs/clients/reputation/client.go
+++ b/libs/clients/reputation/client.go
@@ -310,7 +310,7 @@ func (c *HTTPClient) IsWalletOnPlatform(
 }
 
 type reputationSummaryRequest struct {
-	GeoCountry string `json:"geo_country"`
+	GeoCountry string `json:"geoCountry"`
 }
 
 // UpsertReputationSummary calls the reputation summary upsert endpoint and creates or updates the reputation

--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -27,6 +27,11 @@ type V4Request struct {
 	GeoCountry string `json:"geo_country"`
 }
 
+// V4Response contains the fields for v4 wallet request responses.
+type V4Response struct {
+	PaymentID string `json:"paymentId"`
+}
+
 // CreateWalletV4 creates a brave rewards wallet. This endpoint takes a geo country as part of the request
 // that must be ISO3166Alpha2 format.
 func CreateWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
@@ -76,7 +81,11 @@ func CreateWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *ha
 			}
 		}
 
-		return handlers.RenderContent(ctx, infoToResponseV3(info), w, http.StatusCreated)
+		response := V4Response{
+			PaymentID: info.ID,
+		}
+
+		return handlers.RenderContent(ctx, response, w, http.StatusCreated)
 	}
 }
 

--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -24,7 +24,7 @@ var (
 
 // V4Request contains the fields for making v4 wallet requests.
 type V4Request struct {
-	GeoCountry string `json:"geo_country"`
+	GeoCountry string `json:"geoCountry"`
 }
 
 // V4Response contains the fields for v4 wallet responses.

--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -27,7 +27,7 @@ type V4Request struct {
 	GeoCountry string `json:"geo_country"`
 }
 
-// V4Response contains the fields for v4 wallet request responses.
+// V4Response contains the fields for v4 wallet responses.
 type V4Response struct {
 	PaymentID string `json:"paymentId"`
 }

--- a/services/wallet/controllers_v4_test.go
+++ b/services/wallet/controllers_v4_test.go
@@ -99,12 +99,12 @@ func (suite *WalletControllersV4TestSuite) TestCreateBraveWalletV4_Success() {
 
 	suite.Require().Equal(http.StatusCreated, rw.Code)
 
-	var info walletutils.Info
-	err = json.NewDecoder(rw.Body).Decode(&info)
+	var response wallet.V4Response
+	err = json.NewDecoder(rw.Body).Decode(&response)
 	suite.Require().NoError(err)
 
 	walletID := uuid.NewV5(wallet.ClaimNamespace, publicKey.String())
-	suite.Assert().Equal(walletID.String(), info.ID)
+	suite.Assert().Equal(walletID.String(), response.PaymentID)
 }
 
 func (suite *WalletControllersV4TestSuite) TestCreateBraveWalletV4_GeoCountryDisabled() {


### PR DESCRIPTION
This PR removes response data from wallet info that is no longer needed for v4 endpoints

resolves #1599 