### PR TITLE
Update SAM template to remove incorrect Fn::GetAtt reference

### DIFF
--- a/serverless/email/template.yaml
+++ b/serverless/email/template.yaml
@@ -146,9 +146,14 @@ Resources:
       Runtime: go1.x
       Architectures:
         - x86_64
+      Role: !Ref EventsExecutionRoleArn
       VpcConfig:
         SubnetIds: !Ref VpcSubnetIds
         SecurityGroupIds: !Ref EventsLambdaSgIds
+      Environment:
+        Variables:
+          DYNAMODB_ROLE_ARN: !Ref EventsDynamoDBRoleArn
+          DYNAMODB_ENDPOINT: !Ref DynamoDBEndpoint
       Events:
         CatchAll:
           Type: SNS
@@ -160,17 +165,16 @@ Outputs:
     Description: "API Gateway endpoint URL for Email webhook"
     Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.amazonaws.com/${DeploymentEnvironment}/webhook/"
   EmailWebhookFunction:
-    Description: "Email Webhook Function ARN"
+    Description: "Email Webhook Lambda Function ARN"
     Value: !GetAtt EmailWebhookFunction.Arn
 
   EmailUnsubscribeAPI:
     Description: "API Gateway endpoint URL for for unsubscribe"
     Value: !Sub "https://${ApiGatewayApi}.execute-api.${AWS::Region}.amazonaws.com//${DeploymentEnvironment}/unsubscribe/"
   EmailUnsubscribeFunction:
-    Description: "unsubscribe lambda ARN"
+    Description: "Unsubscribe Lambda Function ARN"
     Value: !GetAtt EmailUnsubscribeFunction.Arn
-  EmailUnsubscribeFunctionIamRole:
-    Description: "Implicit IAM Role created for function"
-    Value: !GetAtt EmailUnsubscribeFunctionRole.Arn
+    Value: !Ref EmailUnsubscribeFunctionRole
+
   SnsEmailNotificationConsumerFunction:
     Value: !GetAtt SnsEmailNotificationConsumerFunction.Arn

--- a/serverless/email/template.yaml
+++ b/serverless/email/template.yaml
@@ -146,11 +146,14 @@ Resources:
       Runtime: go1.x
       Architectures:
         - x86_64
+      VpcConfig:
+        SubnetIds: !Ref VpcSubnetIds
+        SecurityGroupIds: !Ref EventsLambdaSgIds
       Events:
         CatchAll:
           Type: SNS
           Properties:
-            Topic: arn:aws:sns:us-west-2:123456789:topic # TODO
+            Topic: !Ref StatusTopicArn
 
 Outputs:
   EmailWebhookAPI:


### PR DESCRIPTION
- fixing go.work files
- addressing review concerns
- go mod tidy
- more go mod tidy
- Update SAM template for Events Lambda (#1627) (#1629)
- Fixed SAM Template to remove incorrect Fn::GetAtt reference

### Summary

Fix for the following error:

```
   2022-09-23 16:25:41,834 | HTTPSConnectionPool(host='aws-serverless-tools-telemetry.us-west-2.amazonaws.com', port=443): Read timed out. (read timeout=0.1)
Error: Failed to create changeset for the stack: bravex-frontend, ex: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state: For expression "Status" we matched expected path: "FAILED" Status: FAILED. Reason: Template error: instance of Fn::GetAtt references undefined resource EmailUnsubscribeFunctionRole
```

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
