### PR TITLE
Use custom type for SES MessageTag instead of AWS type, add test for …

### DIFF
--- a/serverless/email/status/go.mod
+++ b/serverless/email/status/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/aws/aws-lambda-go v1.34.1
 	github.com/aws/aws-sdk-go v1.44.101
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.17.0
-	github.com/aws/aws-sdk-go-v2/service/ses v1.14.18
 	github.com/brave-intl/bat-go/libs v0.0.0-20220913154833-730f36b772de
 	github.com/google/uuid v1.3.0
 	github.com/rs/zerolog v1.28.0

--- a/serverless/email/status/go.sum
+++ b/serverless/email/status/go.sum
@@ -73,8 +73,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.7.2 h1:RnZjLgtCGLsF2xY
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.7.2/go.mod h1:np7TMuJNT83O0oDOSF8i4dF3dvGqA6hPYYo6YYkzgRA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.16.1 h1:z+P3r4LrwdudLKBoEVWxIORrk4sVg4/iqpG3+CS53AY=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.16.1/go.mod h1:CQe/KvWV1AqRc65KqeJjrLzr5X2ijnFTTVzJW0VBRCI=
-github.com/aws/aws-sdk-go-v2/service/ses v1.14.18 h1:4hlsHBoglPrwFzU9qZvku1B4YpU29Mc2I6AuGZs9b/s=
-github.com/aws/aws-sdk-go-v2/service/ses v1.14.18/go.mod h1:Q7t7H+51Q/ymjXzRf7f1XcTRR00Vf1aIGCFFG3xL60w=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2 h1:pZwkxZbspdqRGzddDB92bkZBoB7lg85sMRE7OqdB3V0=
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2 h1:ol2Y5DWqnJeKqNd8th7JWzBtqu63xpOfs1Is+n1t8/4=

--- a/serverless/email/status/main_test.go
+++ b/serverless/email/status/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParsing(t *testing.T) {
+	sesNotificationJSON := "{\"eventType\":\"Delivery\",\"mail\":{\"messageId\":\"010101837a8465ac-5ac03c49-d6bc-426a-907e-1378e1e6831c-000000\",\"tags\":{\"ses:operation\":[\"SendTemplatedEmail\"],\"idempotencyKey\":[\"b968f271-24f7-4f57-84cf-6713a9823154\"]}},\"delivery\":{\"timestamp\":\"2022-09-26T15:57:21.861Z\"}}\n"
+	var notification sesNotification
+	err := json.Unmarshal([]byte(sesNotificationJSON), &notification)
+	if err != nil {
+		t.Error("Unable to unmarshal sesNotification:", err)
+	}
+
+	if notification.Mail.Tags["idempotencyKey"][0] != "b968f271-24f7-4f57-84cf-6713a9823154" {
+		t.Errorf("Idempotency key is incorrect")
+	}
+}


### PR DESCRIPTION
…parsing mail.tags

### Summary

I think the AWS docs are wrong about the expected structure for the tags.  [Here](https://docs.aws.amazon.com/ses/latest/dg/event-publishing-retrieving-sns-contents.html#event-publishing-retrieving-sns-contents-mail-object) they say mail.tags is
> A list of tags associated with the email.
And [here](https://docs.aws.amazon.com/ses/latest/APIReference/API_MessageTag.html) they define a MessageTag as an object with a Name and a Value.  But the structure we get back is this
```
> notification.mail.tags
{
  'ses:operation': [ 'SendTemplatedEmail' ],
  'ses:configuration-set': [ '...' ],
  idempotencyKey: [ 'b968f271-24f7-4f57-84cf-6713a9823154' ],
  'ses:from-domain': [ '...' ],
  'ses:caller-identity': [ '...' ],
}
```
which is not a list, it's an object with multiple keys, whose values are lists
### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
