### PR TITLE
Remove ReadmeUrl from SAM Template

### DIFF
--- a/serverless/email/template.yaml
+++ b/serverless/email/template.yaml
@@ -117,7 +117,6 @@ Metadata:
       - 'bravex'
       - 'webhook'
     HomePageUrl: https://github.com/brave-intl/bat-go
-    ReadmeUrl: https://github.com/brave-intl/bat-go/blob/serverless-service/serverless/email/README.md
     SourceCodeUrl: https://github.com/brave-intl/bat-go
 
 Resources:


### PR DESCRIPTION
### Summary

Resolves the following error:

```
   2022-10-02 05:04:42,189 | Unable to export
Traceback (most recent call last):
  File "/home/runner/work/_temp/setup-sam-bCZaXp/.venv/lib/python3.8/site-packages/samcli/lib/package/packageable_resources.py", line 127, in export
    self.do_export(resource_id, resource_dict, parent_dir)
  File "/home/runner/work/_temp/setup-sam-bCZaXp/.venv/lib/python3.8/site-packages/samcli/lib/package/packageable_resources.py", line 149, in do_export
    uploaded_url = upload_local_artifacts(
  File "/home/runner/work/_temp/setup-sam-bCZaXp/.venv/lib/python3.8/site-packages/samcli/lib/package/utils.py", line 177, in upload_local_artifacts
    raise InvalidLocalPathError(resource_id=resource_id, property_name=property_name, local_path=local_path)
samcli.commands.package.exceptions.InvalidLocalPathError: Parameter ReadmeUrl of resource AWS::ServerlessRepo::Application refers to a file or folder that does not exist /home/runner/work/bat-go/bat-go/serverless/email/build/https:/github.com/brave-intl/bat-go/blob/serverless-service/serverless/email/README.md
2022-10-02 05:04:42,211 | Sending Telemetry: {'metrics': [{'commandRun': {'requestId': '2da79cc8-ebcc-4844-b57d-91b78210a045', 'installationId': '19faa702-957a-400d-9705-2331948d93e2', 'sessionId': '3146017f-3ac5-4298-a411-1ac1eddb0f3b', 'executionEnvironment': 'GitHubAction', 'ci': True, 'pyversion': '3.8.14', 'samcliVersion': '1.58.0', 'awsProfileProvided': False, 'debugFlagProvided': True, 'region': '', 'commandName': 'sam deploy', 'metricSpecificAttributes': {'projectType': 'CFN', 'gitOrigin': None, 'projectName': '7c74a7017da375bb7687d3276cd34088a149d2a766775b66f10b9d8ea76d658d', 'initialCommit': None}, 'duration': 588, 'exitReason': 'ExportFailedError', 'exitCode': 1}}]}
2022-10-02 05:04:42,392 | Telemetry response: 200
Error: Unable to upload artifact https://github.com/brave-intl/bat-go/blob/serverless-service/serverless/email/README.md referenced by ReadmeUrl parameter of AWS::ServerlessRepo::Application resource.
Parameter ReadmeUrl of resource AWS::ServerlessRepo::Application refers to a file or folder that does not exist /home/runner/work/bat-go/bat-go/serverless/email/build/https:/github.com/brave-intl/bat-go/blob/serverless-service/serverless/email/README.md
```

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
