### PR TITLE
Fix using checkstatus erroring out on 404

### DIFF
--- a/libs/clients/gemini/client.go
+++ b/libs/clients/gemini/client.go
@@ -395,21 +395,23 @@ func (c *HTTPClient) CheckTxStatus(ctx context.Context, APIKey string, clientID 
 	}
 
 	var body PayoutResult
-	resp, err := c.client.Do(ctx, req, &body)
-
-	if resp.StatusCode == http.StatusNotFound {
-		notFoundReason := "404 From Gemini"
-		body = PayoutResult{
-			Result: "Error",
-			Reason: &notFoundReason,
-			TxRef:  txRef,
-		}
-		return &body, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
+	_, err = c.client.Do(ctx, req, &body)                                                                                            
+        if err != nil {                                                                                                                  
+                var eb *errorutils.ErrorBundle                                                                                           
+                if errors.As(err, eb) {                                                                                                  
+                        if httpState, ok := eb.Data().(clients.HTTPState); ok {                                                          
+                                if httpState.Status == http.StatusNotFound {                                                             
+                                        notFoundReason := "404 From Gemini"                                                              
+                                        return &PayoutResult{                                                                            
+                                                Result: "Error",                                                                         
+                                                Reason: &notFoundReason,                                                                 
+                                                TxRef:  txRef,                                                                           
+                                        }, nil                                                                                           
+                                }                                                                                                        
+                        }                                                                                                                
+                }                                                                                                                        
+                return nil, err                                                                                                          
+        }
 
 	return &body, err
 }

--- a/libs/clients/gemini/client.go
+++ b/libs/clients/gemini/client.go
@@ -396,9 +396,6 @@ func (c *HTTPClient) CheckTxStatus(ctx context.Context, APIKey string, clientID 
 
 	var body PayoutResult
 	resp, err := c.client.Do(ctx, req, &body)
-	if err != nil {
-		return nil, err
-	}
 
 	if resp.StatusCode == http.StatusNotFound {
 		notFoundReason := "404 From Gemini"
@@ -408,6 +405,10 @@ func (c *HTTPClient) CheckTxStatus(ctx context.Context, APIKey string, clientID 
 			TxRef:  txRef,
 		}
 		return &body, nil
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return &body, err


### PR DESCRIPTION
### Summary

A 404 error using checkstatus on Gemini payouts would cause a crash, this pushes the check further down.

