### PR TITLE
disconnect on new custodian linking

### DIFF
--- a/services/wallet/controllers_v3_test.go
+++ b/services/wallet/controllers_v3_test.go
@@ -262,6 +262,9 @@ func TestLinkBitFlyerWalletV3(t *testing.T) {
 	var linkingIDRows = sqlmock.NewRows([]string{"linking_id"}).AddRow(linkingID)
 	mock.ExpectQuery("^select linking_id from (.+)").WithArgs(idFrom, "bitflyer").WillReturnRows(linkingIDRows)
 
+	// updates the link to the wallet_custodian record in wallets
+	mock.ExpectExec("^update wallet_custodian (.+)").WithArgs(linkingID, idFrom).WillReturnResult(sqlmock.NewResult(1, 1))
+
 	clRows := sqlmock.NewRows([]string{"created_at", "linked_at"}).
 		AddRow(time.Now(), time.Now())
 
@@ -416,6 +419,9 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 	var lastUnlink = sqlmock.NewRows([]string{"last_unlinking"}).AddRow(time.Now())
 	mock.ExpectQuery("^select max(.+)").WithArgs(linkingID).WillReturnRows(lastUnlink)
 
+	// updates the link to the wallet_custodian record in wallets
+	mock.ExpectExec("^update wallet_custodian (.+)").WithArgs(linkingID, idFrom).WillReturnResult(sqlmock.NewResult(1, 1))
+
 	clRows := sqlmock.NewRows([]string{"created_at", "linked_at"}).
 		AddRow(time.Now(), time.Now())
 
@@ -525,6 +531,9 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 	// get last un linking
 	lastUnlink = sqlmock.NewRows([]string{"last_unlinking"}).AddRow(time.Now())
 	mock.ExpectQuery("^select max(.+)").WithArgs(linkingID).WillReturnRows(lastUnlink)
+
+	// updates the link to the wallet_custodian record in wallets
+	mock.ExpectExec("^update wallet_custodian (.+)").WithArgs(linkingID, idFrom).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	clRows = sqlmock.NewRows([]string{"created_at", "linked_at"}).
 		AddRow(time.Now(), time.Now())
@@ -655,6 +664,9 @@ func TestLinkGeminiWalletV3FirstLinking(t *testing.T) {
 	var lastUnlink = sqlmock.NewRows([]string{"last_unlinking"}).AddRow(time.Now())
 	mock.ExpectQuery("^select max(.+)").WithArgs(linkingID).WillReturnRows(lastUnlink)
 
+	// updates the link to the wallet_custodian record in wallets
+	mock.ExpectExec("^update wallet_custodian (.+)").WithArgs(linkingID, idFrom).WillReturnResult(sqlmock.NewResult(1, 1))
+
 	clRows := sqlmock.NewRows([]string{"created_at", "linked_at"}).
 		AddRow(time.Now(), time.Now())
 
@@ -770,6 +782,9 @@ func TestLinkGeminiWalletV3(t *testing.T) {
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	mock.ExpectQuery("^select linking_id from (.+)").WithArgs(idFrom, "gemini").WillReturnRows(linkingIDRows)
+
+	// updates the link to the wallet_custodian record in wallets
+	mock.ExpectExec("^update wallet_custodian (.+)").WithArgs(linkingID, idFrom).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// this wallet has been linked prior, with the same linking id that the request is with
 	// SHOULD SKIP THE linking limit checks


### PR DESCRIPTION
### Summary

force eviction of prior linked custodian linking on new linking

fixes: https://github.com/brave-intl/tickets-ledger/issues/75

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
