### PR TITLE
Add coingecko mapping for BOO token on Solana

### DIFF
--- a/services/ratios/mapping.go
+++ b/services/ratios/mapping.go
@@ -39,6 +39,7 @@ var (
 		"bnb":   "binancecoin",
 		"boa":   "bosagora",
 		"bob":   "bobs_repair",
+		"boo":   "boo",
 		"booty": "candybooty",
 		"box":   "box-token",
 		"btu":   "btu-protocol",


### PR DESCRIPTION
### Summary

Price of BOO token on Solana is incorrect. Add a mapping in ratios service to prevent collisions.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->

Resolves https://github.com/brave/brave-browser/issues/29359

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [x] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

https://ratios.rewards.brave.com/v2/relative/provider/coingecko/boo/usd/1d should return [Boo (Solana)](https://www.coingecko.com/en/coins/boo) price.