### PR TITLE
Add Cache-Control header to /v2/relative/provider/coingecko/{coinIDs}/{vsCurrencies}/{duration}

### DIFF
--- a/libs/clients/coingecko/client.go
+++ b/libs/clients/coingecko/client.go
@@ -151,7 +151,7 @@ type MarketChartResponse struct {
 	TotalVolumes [][]decimal.Decimal `json:"total_volumes"`
 }
 
-// FetchMarketChart fetches the history rate of a currency to BAT
+// FetchMarketChart fetches the history rate of a currency
 func (c *HTTPClient) FetchMarketChart(ctx context.Context, id string, vsCurrency string, days float32) (*MarketChartResponse, time.Time, error) {
 	updated := time.Now()
 

--- a/services/ratios/cache.go
+++ b/services/ratios/cache.go
@@ -13,7 +13,13 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-//GetTopCoins - get the top coins
+const (
+	// The amount of seconds price data can be in the Redis cache
+	// before it is considered stale
+	GetRelativeTTL = 900
+)
+
+// GetTopCoins - get the top coins
 func (s *Service) GetTopCoins(ctx context.Context, limit int) (CoingeckoCoinList, error) {
 	conn := s.redis.Get()
 	defer closers.Log(ctx, conn)
@@ -35,7 +41,7 @@ func (s *Service) GetTopCoins(ctx context.Context, limit int) (CoingeckoCoinList
 	return resp, nil
 }
 
-//GetTopCurrencies - get the top currencies
+// GetTopCurrencies - get the top currencies
 func (s *Service) GetTopCurrencies(ctx context.Context, limit int) (CoingeckoVsCurrencyList, error) {
 	conn := s.redis.Get()
 	defer closers.Log(ctx, conn)
@@ -150,7 +156,7 @@ func (s *Service) GetRelativeFromCache(ctx context.Context, vsCurrencies Coingec
 			// the least recently updated
 			if r.LastUpdated.Before(updated) {
 				updated = r.LastUpdated
-				if time.Since(updated) > 15*time.Minute {
+				if time.Since(updated) > GetRelativeTTL*time.Second {
 					return nil, updated, fmt.Errorf("cached rate is too old: %s", updated)
 				}
 			}

--- a/services/ratios/service.go
+++ b/services/ratios/service.go
@@ -125,7 +125,12 @@ func (s *Service) RunNextRelativeCachePrepopulationJob(ctx context.Context) (boo
 }
 
 // GetRelative - respond to caller with the relative exchange rates
-func (s *Service) GetRelative(ctx context.Context, coinIDs CoingeckoCoinList, vsCurrencies CoingeckoVsCurrencyList, duration CoingeckoDuration) (*ratiosclient.RelativeResponse, error) {
+func (s *Service) GetRelative(
+	ctx context.Context,
+	coinIDs CoingeckoCoinList,
+	vsCurrencies CoingeckoVsCurrencyList,
+	duration CoingeckoDuration,
+) (*ratiosclient.RelativeResponse, error) {
 	// get logger from context
 	logger := logging.Logger(ctx, "ratios.GetRelative")
 
@@ -192,7 +197,7 @@ func (s *Service) GetRelative(ctx context.Context, coinIDs CoingeckoCoinList, vs
 	}, nil
 }
 
-//HistoryResponse - the response structure for history calls
+// HistoryResponse - the response structure for history calls
 type HistoryResponse struct {
 	Payload     coingecko.MarketChartResponse `json:"payload"`
 	LastUpdated time.Time                     `json:"lastUpdated"`


### PR DESCRIPTION
### Summary

We want to have browser clients use the browser's HTTP cache in order to reduce network requests when the data doesn't change.  This capability was added in the browser here https://github.com/brave/brave-browser/issues/29071.  In order to be able to use this, the server needs to set the Cache-Control header, which is currently not set.

This PR adds the cache control header to the `/v2/relative/provider/coingecko/{coinIDs}/{vsCurrencies}/{duration}` endpoint.  It sets it to the to match when the rates expire in the server cache and would be fetched from Coingecko again, at most 15 minutes.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
