### PR TITLE
Add Cache-Control header for /v2/market/provider/coingecko

### DIFF
--- a/libs/clients/coingecko/client.go
+++ b/libs/clients/coingecko/client.go
@@ -17,9 +17,11 @@ import (
 )
 
 const (
-	coinMarketsPageSize      = 250
-	coinMarketsCacheTTLHours = 1 // How long we consider Redis cached FetchCoinMarkets responses to be valid
-	coingeckoImageProxy      = "assets.cgproxy.brave.com"
+	// CoinMarketsCacheTTLSeconds is how long FetchCoinMarkets responses cached
+	// in Redis are considered valid
+	CoinMarketsCacheTTLSeconds = 60 * 60
+	coinMarketsPageSize        = 250
+	coingeckoImageProxy        = "assets.cgproxy.brave.com"
 )
 
 // Client abstracts over the underlying client
@@ -379,7 +381,7 @@ func (c *HTTPClient) FetchCoinMarkets(
 		}
 
 		// Check if cache is still fresh
-		if time.Since(entry.LastUpdated).Hours() < float64(coinMarketsCacheTTLHours) {
+		if time.Since(entry.LastUpdated).Seconds() < float64(CoinMarketsCacheTTLSeconds) {
 			body = (&body).applyLimit(params.Limit)
 			return &body, entry.LastUpdated, err
 		}

--- a/services/ratios/controllers.go
+++ b/services/ratios/controllers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/brave-intl/bat-go/libs/clients/coingecko"
 	appctx "github.com/brave-intl/bat-go/libs/context"
 	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/libs/inputs"
@@ -305,6 +306,11 @@ func GetCoinMarketsHandler(service *Service) handlers.AppHandler {
 			logger.Error().Err(err).Msg("failed to get top currencies")
 			return handlers.WrapError(err, "failed to get top currencies", http.StatusInternalServerError)
 		}
+
+		// Set Cache-Control header to match when the market data in the Reis cache expires,
+		// and would be fetched from Coingecko again.
+		maxAge := coingecko.CoinMarketsCacheTTLSeconds*time.Second - time.Since(data.LastUpdated)
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d", int(maxAge.Seconds())))
 		return handlers.RenderContent(ctx, data, w, http.StatusOK)
 	})
 }


### PR DESCRIPTION
Same as https://github.com/brave-intl/bat-go/pull/1812 and https://github.com/brave-intl/bat-go/pull/1813, but for the market tab data endpoint.

Small refactor to use seconds instead of hours as the units when referring to cache durations since that's what the Cache-Control header uses.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
