### PR TITLE
Implement Database-Side History For Orders And Related Data

### DIFF
--- a/libs/datastore/postgres.go
+++ b/libs/datastore/postgres.go
@@ -41,7 +41,7 @@ var (
 	}
 	dbs = map[string]*sqlx.DB{}
 	// CurrentMigrationVersion holds the default migration version
-	CurrentMigrationVersion = uint(57)
+	CurrentMigrationVersion = uint(60)
 	// MigrationTracks holds the migration version for a given track (eyeshade, promotion, wallet)
 	MigrationTracks = map[string]uint{
 		"eyeshade": 20,

--- a/migrations/0058_order_history.down.sql
+++ b/migrations/0058_order_history.down.sql
@@ -1,0 +1,9 @@
+DROP TRIGGER IF EXISTS handle_order_insert ON orders;
+DROP TRIGGER IF EXISTS handle_order_update ON orders;
+DROP TRIGGER IF EXISTS handle_order_delete ON orders;
+
+DROP FUNCTION IF EXISTS fn_order_insert;
+DROP FUNCTION IF EXISTS fn_order_update;
+DROP FUNCTION IF EXISTS fn_order_delete;
+
+DROP TABLE IF EXISTS order_history;

--- a/migrations/0058_order_history.down.sql
+++ b/migrations/0058_order_history.down.sql
@@ -1,9 +1,5 @@
-DROP TRIGGER IF EXISTS handle_order_insert ON orders;
-DROP TRIGGER IF EXISTS handle_order_update ON orders;
-DROP TRIGGER IF EXISTS handle_order_delete ON orders;
+DROP TRIGGER IF EXISTS handle_order_change ON orders;
 
-DROP FUNCTION IF EXISTS fn_order_insert;
-DROP FUNCTION IF EXISTS fn_order_update;
-DROP FUNCTION IF EXISTS fn_order_delete;
+DROP FUNCTION IF EXISTS save_order_history;
 
 DROP TABLE IF EXISTS order_history;

--- a/migrations/0058_order_history.up.sql
+++ b/migrations/0058_order_history.up.sql
@@ -14,7 +14,7 @@ CREATE OR REPLACE FUNCTION save_order_history() RETURNS TRIGGER AS $$
             INSERT INTO order_history(operation, order_id, value_after)
             VALUES (TG_OP, NEW.id, row_to_json(NEW)::jsonb);
 
-            -- Can return NULL because it's used in an AFTER trigger.
+            -- Here and below, can return NULL because it's used in an AFTER trigger.
             RETURN NEW;
 
         ELSIF (TG_OP = 'UPDATE') THEN

--- a/migrations/0058_order_history.up.sql
+++ b/migrations/0058_order_history.up.sql
@@ -8,31 +8,22 @@ CREATE TABLE IF NOT EXISTS order_history (
     value_after jsonb
 );
 
-CREATE OR REPLACE FUNCTION fn_order_insert() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION save_order_history() RETURNS TRIGGER AS $$
     BEGIN
         IF TG_OP = 'INSERT' THEN
             INSERT INTO order_history(operation, order_id, value_after)
             VALUES (TG_OP, NEW.id, row_to_json(NEW)::jsonb);
 
+            -- Can return NULL because it's used in an AFTER trigger.
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_order_update() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'UPDATE' THEN
+        ELSIF TG_OP = 'UPDATE' THEN
             INSERT INTO order_history(operation, order_id, value_before, value_after)
             VALUES (TG_OP, NEW.id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_order_delete() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'DELETE' THEN
+        ELSIF TG_OP = 'DELETE' THEN
             INSERT INTO order_history(operation, order_id, value_before)
             VALUES (TG_OP, OLD.id, row_to_json(OLD)::jsonb);
 
@@ -41,8 +32,4 @@ CREATE OR REPLACE FUNCTION fn_order_delete() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER handle_order_insert AFTER INSERT ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_insert();
-
-CREATE OR REPLACE TRIGGER handle_order_update AFTER UPDATE ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_update();
-
-CREATE OR REPLACE TRIGGER handle_order_delete AFTER DELETE ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_delete();
+CREATE OR REPLACE TRIGGER handle_order_change AFTER INSERT OR UPDATE OR DELETE ON orders FOR EACH ROW EXECUTE FUNCTION save_order_history();

--- a/migrations/0058_order_history.up.sql
+++ b/migrations/0058_order_history.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS order_history (
-    id serial PRIMARY KEY,
+    id bigserial PRIMARY KEY,
     operation text NOT NULL,
     executed_by text NOT NULL DEFAULT current_user,
     recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/0058_order_history.up.sql
+++ b/migrations/0058_order_history.up.sql
@@ -10,20 +10,20 @@ CREATE TABLE IF NOT EXISTS order_history (
 
 CREATE OR REPLACE FUNCTION save_order_history() RETURNS TRIGGER AS $$
     BEGIN
-        IF TG_OP = 'INSERT' THEN
+        IF (TG_OP = 'INSERT') THEN
             INSERT INTO order_history(operation, order_id, value_after)
             VALUES (TG_OP, NEW.id, row_to_json(NEW)::jsonb);
 
             -- Can return NULL because it's used in an AFTER trigger.
             RETURN NEW;
 
-        ELSIF TG_OP = 'UPDATE' THEN
+        ELSIF (TG_OP = 'UPDATE') THEN
             INSERT INTO order_history(operation, order_id, value_before, value_after)
             VALUES (TG_OP, NEW.id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
 
-        ELSIF TG_OP = 'DELETE' THEN
+        ELSIF (TG_OP = 'DELETE') THEN
             INSERT INTO order_history(operation, order_id, value_before)
             VALUES (TG_OP, OLD.id, row_to_json(OLD)::jsonb);
 
@@ -32,4 +32,5 @@ CREATE OR REPLACE FUNCTION save_order_history() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER handle_order_change AFTER INSERT OR UPDATE OR DELETE ON orders FOR EACH ROW EXECUTE FUNCTION save_order_history();
+CREATE OR REPLACE TRIGGER handle_order_change
+AFTER INSERT OR UPDATE OR DELETE ON orders FOR EACH ROW EXECUTE FUNCTION save_order_history();

--- a/migrations/0058_order_history.up.sql
+++ b/migrations/0058_order_history.up.sql
@@ -1,0 +1,48 @@
+CREATE TABLE IF NOT EXISTS order_history (
+    id serial PRIMARY KEY,
+    operation text NOT NULL,
+    executed_by text NOT NULL DEFAULT current_user,
+    recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    order_id uuid NOT NULL,
+    value_before jsonb,
+    value_after jsonb
+);
+
+CREATE OR REPLACE FUNCTION fn_order_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            INSERT INTO order_history(operation, order_id, value_after)
+            VALUES (TG_OP, NEW.id, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_update() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            INSERT INTO order_history(operation, order_id, value_before, value_after)
+            VALUES (TG_OP, NEW.id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_delete() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+            INSERT INTO order_history(operation, order_id, value_before)
+            VALUES (TG_OP, OLD.id, row_to_json(OLD)::jsonb);
+
+            RETURN OLD;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER handle_order_insert AFTER INSERT ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_insert();
+
+CREATE OR REPLACE TRIGGER handle_order_update AFTER UPDATE ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_update();
+
+CREATE OR REPLACE TRIGGER handle_order_delete AFTER DELETE ON orders FOR EACH ROW EXECUTE PROCEDURE fn_order_delete();

--- a/migrations/0059_transaction_history.down.sql
+++ b/migrations/0059_transaction_history.down.sql
@@ -1,0 +1,9 @@
+DROP TRIGGER IF EXISTS handle_transaction_insert ON transactions;
+DROP TRIGGER IF EXISTS handle_transaction_update ON transactions;
+DROP TRIGGER IF EXISTS handle_transaction_delete ON transactions;
+
+DROP FUNCTION IF EXISTS fn_transaction_insert;
+DROP FUNCTION IF EXISTS fn_transaction_update;
+DROP FUNCTION IF EXISTS fn_transaction_delete;
+
+DROP TABLE IF EXISTS transaction_history;

--- a/migrations/0059_transaction_history.down.sql
+++ b/migrations/0059_transaction_history.down.sql
@@ -1,9 +1,5 @@
-DROP TRIGGER IF EXISTS handle_transaction_insert ON transactions;
-DROP TRIGGER IF EXISTS handle_transaction_update ON transactions;
-DROP TRIGGER IF EXISTS handle_transaction_delete ON transactions;
+DROP TRIGGER IF EXISTS handle_transaction_change ON transactions;
 
-DROP FUNCTION IF EXISTS fn_transaction_insert;
-DROP FUNCTION IF EXISTS fn_transaction_update;
-DROP FUNCTION IF EXISTS fn_transaction_delete;
+DROP FUNCTION IF EXISTS save_transaction_history;
 
 DROP TABLE IF EXISTS transaction_history;

--- a/migrations/0059_transaction_history.up.sql
+++ b/migrations/0059_transaction_history.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS transaction_history (
+    id serial PRIMARY KEY,
+    operation text NOT NULL,
+    executed_by text NOT NULL DEFAULT current_user,
+    recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    transaction_id uuid NOT NULL,
+    order_id uuid NOT NULL,
+    value_before jsonb,
+    value_after jsonb
+);
+
+CREATE OR REPLACE FUNCTION fn_transaction_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            INSERT INTO transaction_history(operation, transaction_id, order_id, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_transaction_update() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            INSERT INTO transaction_history(operation, transaction_id, order_id, value_before, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_transaction_delete() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+            INSERT INTO transaction_history(operation, transaction_id, order_id, value_before)
+            VALUES (TG_OP, OLD.id, OLD.order_id, row_to_json(OLD)::jsonb);
+
+            RETURN OLD;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER handle_transaction_insert AFTER INSERT ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_insert();
+
+CREATE OR REPLACE TRIGGER handle_transaction_update AFTER UPDATE ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_update();
+
+CREATE OR REPLACE TRIGGER handle_transaction_delete AFTER DELETE ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_delete();

--- a/migrations/0059_transaction_history.up.sql
+++ b/migrations/0059_transaction_history.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS transaction_history (
-    id serial PRIMARY KEY,
+    id bigserial PRIMARY KEY,
     operation text NOT NULL,
     executed_by text NOT NULL DEFAULT current_user,
     recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/0059_transaction_history.up.sql
+++ b/migrations/0059_transaction_history.up.sql
@@ -9,31 +9,21 @@ CREATE TABLE IF NOT EXISTS transaction_history (
     value_after jsonb
 );
 
-CREATE OR REPLACE FUNCTION fn_transaction_insert() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION save_transaction_history() RETURNS TRIGGER AS $$
     BEGIN
-        IF TG_OP = 'INSERT' THEN
+        IF (TG_OP = 'INSERT') THEN
             INSERT INTO transaction_history(operation, transaction_id, order_id, value_after)
             VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_transaction_update() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'UPDATE' THEN
+        ELSIF (TG_OP = 'UPDATE') THEN
             INSERT INTO transaction_history(operation, transaction_id, order_id, value_before, value_after)
             VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_transaction_delete() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'DELETE' THEN
+        ELSIF (TG_OP = 'DELETE') THEN
             INSERT INTO transaction_history(operation, transaction_id, order_id, value_before)
             VALUES (TG_OP, OLD.id, OLD.order_id, row_to_json(OLD)::jsonb);
 
@@ -42,8 +32,5 @@ CREATE OR REPLACE FUNCTION fn_transaction_delete() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER handle_transaction_insert AFTER INSERT ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_insert();
-
-CREATE OR REPLACE TRIGGER handle_transaction_update AFTER UPDATE ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_update();
-
-CREATE OR REPLACE TRIGGER handle_transaction_delete AFTER DELETE ON transactions FOR EACH ROW EXECUTE PROCEDURE fn_transaction_delete();
+CREATE OR REPLACE TRIGGER handle_transaction_change
+AFTER INSERT OR UPDATE OR DELETE ON transactions FOR EACH ROW EXECUTE FUNCTION save_transaction_history();

--- a/migrations/0060_order_item_history.down.sql
+++ b/migrations/0060_order_item_history.down.sql
@@ -1,9 +1,5 @@
-DROP TRIGGER IF EXISTS handle_order_item_insert ON order_items;
-DROP TRIGGER IF EXISTS handle_order_item_update ON order_items;
-DROP TRIGGER IF EXISTS handle_order_item_delete ON order_items;
+DROP TRIGGER IF EXISTS handle_order_item_change ON order_items;
 
-DROP FUNCTION IF EXISTS fn_order_item_insert;
-DROP FUNCTION IF EXISTS fn_order_item_update;
-DROP FUNCTION IF EXISTS fn_order_item_delete;
+DROP FUNCTION IF EXISTS save_order_item_history;
 
 DROP TABLE IF EXISTS order_item_history;

--- a/migrations/0060_order_item_history.down.sql
+++ b/migrations/0060_order_item_history.down.sql
@@ -1,0 +1,9 @@
+DROP TRIGGER IF EXISTS handle_order_item_insert ON order_items;
+DROP TRIGGER IF EXISTS handle_order_item_update ON order_items;
+DROP TRIGGER IF EXISTS handle_order_item_delete ON order_items;
+
+DROP FUNCTION IF EXISTS fn_order_item_insert;
+DROP FUNCTION IF EXISTS fn_order_item_update;
+DROP FUNCTION IF EXISTS fn_order_item_delete;
+
+DROP TABLE IF EXISTS order_item_history;

--- a/migrations/0060_order_item_history.up.sql
+++ b/migrations/0060_order_item_history.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS order_item_history (
+    id serial PRIMARY KEY,
+    operation text NOT NULL,
+    executed_by text NOT NULL DEFAULT current_user,
+    recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    order_item_id uuid NOT NULL,
+    order_id uuid NOT NULL,
+    value_before jsonb,
+    value_after jsonb
+);
+
+CREATE OR REPLACE FUNCTION fn_order_item_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_item_update() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_before, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_item_delete() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_before)
+            VALUES (TG_OP, OLD.id, OLD.order_id, row_to_json(OLD)::jsonb);
+
+            RETURN OLD;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER handle_order_item_insert AFTER INSERT ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_insert();
+
+CREATE OR REPLACE TRIGGER handle_order_item_update AFTER UPDATE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_update();
+
+CREATE OR REPLACE TRIGGER handle_order_item_delete AFTER DELETE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_delete();

--- a/migrations/0060_order_item_history.up.sql
+++ b/migrations/0060_order_item_history.up.sql
@@ -9,31 +9,21 @@ CREATE TABLE IF NOT EXISTS order_item_history (
     value_after jsonb
 );
 
-CREATE OR REPLACE FUNCTION fn_order_item_insert() RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION save_order_item_history() RETURNS TRIGGER AS $$
     BEGIN
-        IF TG_OP = 'INSERT' THEN
+        IF (TG_OP = 'INSERT') THEN
             INSERT INTO order_item_history(operation, order_item_id, order_id, value_after)
             VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_order_item_update() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'UPDATE' THEN
+        ELSIF (TG_OP = 'UPDATE') THEN
             INSERT INTO order_item_history(operation, order_item_id, order_id, value_before, value_after)
             VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
 
             RETURN NEW;
-        END IF;
-    END;
-$$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE FUNCTION fn_order_item_delete() RETURNS TRIGGER AS $$
-    BEGIN
-        IF TG_OP = 'DELETE' THEN
+        ELSIF (TG_OP = 'DELETE') THEN
             INSERT INTO order_item_history(operation, order_item_id, order_id, value_before)
             VALUES (TG_OP, OLD.id, OLD.order_id, row_to_json(OLD)::jsonb);
 
@@ -42,8 +32,5 @@ CREATE OR REPLACE FUNCTION fn_order_item_delete() RETURNS TRIGGER AS $$
     END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE TRIGGER handle_order_item_insert AFTER INSERT ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_insert();
-
-CREATE OR REPLACE TRIGGER handle_order_item_update AFTER UPDATE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_update();
-
-CREATE OR REPLACE TRIGGER handle_order_item_delete AFTER DELETE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_delete();
+CREATE OR REPLACE TRIGGER handle_order_item_change
+AFTER INSERT OR UPDATE OR DELETE ON order_items FOR EACH ROW EXECUTE PROCEDURE save_order_item_history();

--- a/migrations/0060_order_item_history.up.sql
+++ b/migrations/0060_order_item_history.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS order_item_history (
-    id serial PRIMARY KEY,
+    id bigserial PRIMARY KEY,
     operation text NOT NULL,
     executed_by text NOT NULL DEFAULT current_user,
     recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
### Summary

This PR adds functionality for tracking history of orders order items and transactions, and partially addresses #1824. This is implemented inside the database and is transparent for the application code.

### Implementation Details

- The history of order-related changes is kept in three separate tables:
    - `orders` -> `order_history`
    - `oder_items` -> `oder_item_history`
    - `transactions` -> `transaction_history`
- Data is written to the history tables automatically, by a set of triggers, 1 per each history table, executed on `INSERT`, `UPDATE` or `DELETE`.
- Data is captured before and after a change.
- The value fields in the history tables correspond to the operation that has resulted in a change:
    - `INSERT` -> `value_before` is `NULL`, `value_after` contains the inserted data.
    - `UPDATE` -> `value_before` contains data prior to the change, `value_after` contains data after the change.
    - `DELETE` -> `value_before` contains data before the deletion, `value_after` is `NULL`.
- Actual data (such as order, order item or transaction) is stored as `jsonb` fields.
- The order id (as well as the entity's `id`) is a separate field in all three history tables, to enable easier lookups in the future.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Submitting This PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [x] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

- [x] ✅ Manually executed code from the `down` migrations.
    - [x] Also, before the `up` migrations, and after.
- [x] ✅ Manually executed code from the `up` migrations.
    - [x] Also, multiple times.
- [x] ✅ The history is recorded when a new order (and/or order item, transaction) is created.
- [x] ✅ The history is recorded when an existing order (and/or order item, transaction) is updated.
- [x] ✅ The history is recorded when an existing order (and/or order item, transaction) is deleted.
