### PR TITLE
Implement Database-Side History For Order Items

### DIFF
--- a/libs/datastore/postgres.go
+++ b/libs/datastore/postgres.go
@@ -41,7 +41,7 @@ var (
 	}
 	dbs = map[string]*sqlx.DB{}
 	// CurrentMigrationVersion holds the default migration version
-	CurrentMigrationVersion = uint(59)
+	CurrentMigrationVersion = uint(60)
 	// MigrationTracks holds the migration version for a given track (eyeshade, promotion, wallet)
 	MigrationTracks = map[string]uint{
 		"eyeshade": 20,

--- a/migrations/0060_order_item_history.down.sql
+++ b/migrations/0060_order_item_history.down.sql
@@ -1,0 +1,9 @@
+DROP TRIGGER IF EXISTS handle_order_item_insert ON order_items;
+DROP TRIGGER IF EXISTS handle_order_item_update ON order_items;
+DROP TRIGGER IF EXISTS handle_order_item_delete ON order_items;
+
+DROP FUNCTION IF EXISTS fn_order_item_insert;
+DROP FUNCTION IF EXISTS fn_order_item_update;
+DROP FUNCTION IF EXISTS fn_order_item_delete;
+
+DROP TABLE IF EXISTS order_item_history;

--- a/migrations/0060_order_item_history.up.sql
+++ b/migrations/0060_order_item_history.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS order_item_history (
+    id serial PRIMARY KEY,
+    operation text NOT NULL,
+    executed_by text NOT NULL DEFAULT current_user,
+    recorded_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    order_item_id uuid NOT NULL,
+    order_id uuid NOT NULL,
+    value_before jsonb,
+    value_after jsonb
+);
+
+CREATE OR REPLACE FUNCTION fn_order_item_insert() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'INSERT' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_item_update() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'UPDATE' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_before, value_after)
+            VALUES (TG_OP, NEW.id, NEW.order_id, row_to_json(OLD)::jsonb, row_to_json(NEW)::jsonb);
+
+            RETURN NEW;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION fn_order_item_delete() RETURNS TRIGGER AS $$
+    BEGIN
+        IF TG_OP = 'DELETE' THEN
+            INSERT INTO order_item_history(operation, order_item_id, order_id, value_before)
+            VALUES (TG_OP, OLD.id, OLD.order_id, row_to_json(OLD)::jsonb);
+
+            RETURN OLD;
+        END IF;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER handle_order_item_insert AFTER INSERT ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_insert();
+
+CREATE OR REPLACE TRIGGER handle_order_item_update AFTER UPDATE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_update();
+
+CREATE OR REPLACE TRIGGER handle_order_item_delete AFTER DELETE ON order_items FOR EACH ROW EXECUTE PROCEDURE fn_order_item_delete();


### PR DESCRIPTION
### Summary

Similar to #1829 and #1831, this PR adds functionality for tracking history of order items, and partially addresses #1824. This is implemented inside the database and is transparent for the application code.

### Implementation Details

- The history of order item changes is kept in a separate table, `order_item_history`.
- The table is automatically populated by a set of three triggers – each for `INSERT`, `UPDATE` and `DELETE`.
- Data is captured before and after a change.
- The value fields correspond to the operation that has resulted in a change:
    - `INSERT` -> `value_before` is `NULL`, `value_after` contains the inserted data.
    - `UPDATE` -> `value_before` contains data prior to the change, `value_after` contains data after the change.
    - `DELETE` -> `value_before` contains data before the deletion, `value_after` is `NULL`.
- Data is stored as `jsonb` fields.
- The history contains `order_item_id` and `order_id` fields for look ups in the future.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Submitting This PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

- [x] ✅ Manually executed code from the `down` migration.
    - [x] Also, before the `up` migration, and after.
- [x] ✅ Manually executed code from the `up` migration.
    - [x] Also, multiple times.
- [x] ✅ The history is recorded when a new order item is created.
- [x] ✅ The history is recorded when an existing order item is updated.
- [x] ✅ The history is recorded when an existing order item is deleted.
- [x] ✅ The order item history can be found for a given `order_id`.