### PR TITLE
Calculate Order expires_at Using valid_for_iso

### DIFF
--- a/libs/time/duration.go
+++ b/libs/time/duration.go
@@ -54,6 +54,11 @@ func (i *ISODuration) From(t time.Time) (*time.Time, error) {
 	return &tt, nil
 }
 
+// Duration returns time.Duration.
+func (i *ISODuration) Duration() (time.Duration, error) {
+	return i.base(time.Time{})
+}
+
 const (
 	// HoursPerDay is the number of hours per day according to Google
 	HoursPerDay = 24.0
@@ -80,24 +85,25 @@ var (
 	invalidStrings = []string{"", "P", "PT"}
 )
 
-// base - given a base, produce a time.Duration from base for the ISODuration
+// base retuns a time.Duration from base for the ISODuration.
+//
+// TODO: refactor to not require t. It's not used.
+// TODO: consider relying only on FindStringSubmatch to avoid running regexp twice.
+// A nil result from FindStringSubmatch means no match.
 func (i *ISODuration) base(t time.Time) (time.Duration, error) {
 	if i == nil {
 		return 0, nil
 	}
+
 	s := i.String()
 
-	var (
-		match  []string
-		prefix string
-	)
-
-	if pattern.MatchString(s) {
-		match = pattern.FindStringSubmatch(s)
-	} else {
+	if !pattern.MatchString(s) {
 		return 0, ErrUnsupportedFormat
 	}
 
+	match := pattern.FindStringSubmatch(s)
+
+	var prefix string
 	if strings.HasPrefix(s, "-") {
 		prefix = "-"
 	}


### PR DESCRIPTION
### Summary

This PR is aiming at addressing #1864.

The validity period in ISO format is not part of the order data. It's available on the order's item. (While the code technically allows multiple items per order, at present there is always one item. Consulted with real data).

The fix works as follows:
- When there is a need to update `expires_at` (which is when an order goes to `paid`), fetch it's items.
- From the first (the only) item, get the duration corresponding to the value in `valid_for_iso`.
- If that was successful, use that duration instead of `valid_for` for calculating `expires_at`.
- Otherwise, fallback on the old behaviour for now.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before Submitting This PR

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan

---

![](https://media.giphy.com/media/2J69BC9lp5uf7Xf0EO/giphy-downsized.gif)