### PR TITLE
Use One Pass in Duration Parsing

### DIFF
--- a/libs/time/duration.go
+++ b/libs/time/duration.go
@@ -88,8 +88,6 @@ var (
 // base retuns a time.Duration from base for the ISODuration.
 //
 // TODO: refactor to not require t. It's not used.
-// TODO: consider relying only on FindStringSubmatch to avoid running regexp twice.
-// A nil result from FindStringSubmatch means no match.
 func (i *ISODuration) base(t time.Time) (time.Duration, error) {
 	if i == nil {
 		return 0, nil
@@ -97,11 +95,10 @@ func (i *ISODuration) base(t time.Time) (time.Duration, error) {
 
 	s := i.String()
 
-	if !pattern.MatchString(s) {
+	match := pattern.FindStringSubmatch(s)
+	if match == nil {
 		return 0, ErrUnsupportedFormat
 	}
-
-	match := pattern.FindStringSubmatch(s)
 
 	var prefix string
 	if strings.HasPrefix(s, "-") {


### PR DESCRIPTION
### Summary

This PR speeds up the ISO duration parsing by ~200ns.

Previously the code would run the regexp twice against the same string - one to determine whether where is a match, and then to get the actual match. Under the hood, both methods use the same low level implementation, and `FindStringSubmatch` is also capable of indicating whether there was a match. Namely, if the result of a call to `FindStringSubmatch` was strictly `nil`, that means no matches found. Hence the change – match a given string against the pattern only once.

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before Submitting

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?
