### PR TITLE
Use Go Module Cache For Tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,19 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Go
+      id: setup-go
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.goversion }}
+        cache-dependency-path: "**/go.sum"
+
+    - name: Ensure Module Path
+      run: mkdir -p /opt/go/pkg/mod
+
+    - name: Copy From Module Cache
+      if: steps.setup-go.outputs.cache-hit == 'true'
+      run: |
+        rsync -au "/home/runner/go/pkg/" "/opt/go/pkg"
 
     - name: Install Docker Compose
       uses: KengoTODA/actions-setup-docker-compose@92cbaf8ac8c113c35e1cedd1182f217043fbdd00
@@ -64,9 +74,18 @@ jobs:
     - name: Start Vault
       run: |
         docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d vault;
-        sleep 3;
+        sleep 3
 
     - name: Run Tests
       run: |
         export VAULT_TOKEN=$(docker logs grant-vault 2>&1 | grep "Root Token" | tail -1 | cut -d ' ' -f 3 );
-        docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm dev make;
+        docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm -v /opt/go/pkg:/go/pkg dev make
+
+    - name: Ensure Module Directory
+      if: steps.setup-go.outputs.cache-hit != 'true'
+      run: mkdir -p /home/runner/go/pkg
+
+    - name: Copy To Module Cache
+      run: |
+        sudo rsync -au "/opt/go/pkg/" "/home/runner/go/pkg"
+        sudo chown -R runner:runner /home/runner/go/pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
 FROM golang:1.18-alpine as builder
 
-
-# put certs in builder image
+# Put certs in builder image.
 RUN apk update
 RUN apk add -U --no-cache ca-certificates && update-ca-certificates
-RUN apk add make
-RUN apk add build-base
-RUN apk add git
-RUN apk add bash
+RUN apk add make build-base git bash
 
 ARG VERSION
 ARG BUILD_TIME
@@ -15,19 +11,18 @@ ARG COMMIT
 
 WORKDIR /src
 COPY . ./
-RUN chown -R nobody:nobody /src/
-RUN mkdir /.cache
-RUN chown -R nobody:nobody /.cache
+
+RUN chown -R nobody:nobody /src/ && mkdir /.cache && chown -R nobody:nobody /.cache
 
 USER nobody
-RUN cd main && go mod download
 
-RUN cd main && CGO_ENABLED=0 GOOS=linux go build \
+RUN cd main && go mod download && CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-w -s -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X main.commit=${COMMIT}" \
     -o bat-go main.go
 
 FROM alpine:3.15 as base
-# put certs in artifact from builder
+
+# Put certs in artifact from builder.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /src/main/bat-go /bin/
 
@@ -38,4 +33,3 @@ FROM base as artifact
 COPY --from=builder /src/migrations/ /migrations/
 EXPOSE 3333
 CMD ["bat-go", "serve", "grant", "--enable-job-workers", "true"]
-

--- a/Makefile
+++ b/Makefile
@@ -189,8 +189,7 @@ format:
 format-lint:
 	make format && make lint
 
-lint:
-	docker volume create batgo_lint_gomod
+lint: ensure-gomod-volume
 	docker run --rm -v "$$(pwd):/app" -v batgo_lint_gomod:/go/pkg --workdir /app/main golangci/golangci-lint:v1.49.0 golangci-lint run -v ./...
 	docker run --rm -v "$$(pwd):/app" -v batgo_lint_gomod:/go/pkg --workdir /app/cmd golangci/golangci-lint:v1.49.0 golangci-lint run -v ./...
 	docker run --rm -v "$$(pwd):/app" -v batgo_lint_gomod:/go/pkg --workdir /app/libs golangci/golangci-lint:v1.49.0 golangci-lint run -v ./...
@@ -208,3 +207,6 @@ download-mod:
 	cd ./serverless/email/status && go mod download && cd ../../..
 	cd ./serverless/email/unsubscribe && go mod download && cd ../../..
 	cd ./serverless/email/webhook && go mod download && cd ../../..
+
+ensure-gomod-volume:
+	docker volume create batgo_lint_gomod


### PR DESCRIPTION
### Summary

This PR slightly improves the tests run time in CI by utilising GitHub Actions cache for Go modules.

With this PR, the overall run time for a full CI starting from the second push to a branch with a PR is around 12 minutes (I saw a couple of runs going as low as 11:47).

Our current development and CI tooling is unnecessarily complicated – Docker is abused without strict need for it in CI. That means we can't simply benefit, for example,  from caching.

However, I've managed to find a way to use cache. It does not speed things up too much, because the majority of time is spent in tests, but we at least no longer have to re-download dependencies on subsequent pushes to a branch with a PR.

One place that is still not using cached modules is the build step in the Dockerfile. Ideally, that build step has to happen outside. Thankfully, that should be achievable, and I will look at that some time in the future. That might help to cut a few more minutes.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
