### PR TITLE
Use One Postgres Container Locally

### DIFF
--- a/create_dbs.sh
+++ b/create_dbs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -eu
+
+function create_database_and_user() {
+    local database=$1
+    local user=$2
+    local password=$3
+
+    echo "Creating database with user: $database $user"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+CREATE USER $user WITH PASSWORD '$password';
+CREATE DATABASE $database;
+GRANT ALL PRIVILEGES ON DATABASE $database TO $user;
+EOSQL
+}
+
+if [ -n $POSTGRES_EXTRA_DATABASES ]; then
+    echo "Creating multiple databases and users: $POSTGRES_EXTRA_DATABASES"
+    for dup in $(echo $POSTGRES_EXTRA_DATABASES | tr ',' ' '); do
+        db=$(echo $dup | awk -F":" '{print $1}')
+        user=$(echo $dup | awk -F":" '{print $2}')
+        password=$(echo $dup | awk -F":" '{print $3}')
+
+        if [ -z "$user"]; then
+            user=$db
+        fi
+
+        if [ -z "$password" ]; then
+            password=$user
+        fi
+
+        create_database_and_user $db $user $password
+    done
+
+    echo "Created multiple databases"
+fi

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,7 +15,7 @@ services:
       - no-new-privileges:true
     environment:
       - OUTPUT_DIR="/out"
-      - "CHALLENGE_BYPASS_DATABASE_URL=postgres://btokens:password@challenge-bypass-postgres/btokens?sslmode=disable"
+      - "CHALLENGE_BYPASS_DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
       - "VAULT_ADDR=http://vault:8200"
       - TEST_TAGS
       - VAULT_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.4"
 
 volumes:
+  pg_data:
   out:
     driver_opts:
       type: tmpfs
@@ -203,26 +204,14 @@ services:
     environment:
       - "POSTGRES_USER=grants"
       - "POSTGRES_PASSWORD=password"
+      - "POSTGRES_EXTRA_DATABASES=btokens:btokens:password"
       - "TZ=UTC"
     networks:
       - grant
     command: ["postgres", "-c", "log_statement=all"]
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
-
-  challenge-bypass-postgres:
-    container_name: challenge-bypass-postgres
-    image: postgres:14
-    environment:
-      - "POSTGRES_USER=btokens"
-      - "POSTGRES_PASSWORD=password"
-      - "TZ=UTC"
-    networks:
-      - grant
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ./create_dbs.sh:/docker-entrypoint-initdb.d/00_create_dbs.sh
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 5s
@@ -239,7 +228,7 @@ services:
     environment:
       - "ENV=devtest"
       - "SENTRY_DSN"
-      - "DATABASE_URL=postgres://btokens:password@challenge-bypass-postgres/btokens?sslmode=disable"
+      - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
       - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
       - KAFKA_BROKERS=kafka:19092
       - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
@@ -257,7 +246,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=dummy
       - AWS_REGION=us-west-2
     depends_on:
-      challenge-bypass-postgres:
+      postgres:
         condition: service_healthy
       dynamodb:
         condition: service_healthy


### PR DESCRIPTION
### Summary

This PR updates the local dev environment to use one Postgres for the `web` and `challenge-bypass` services instead of two.

Although computers get more powerful, software does not have to be wasteful in how it consumes resources. The official [Postgres image](https://hub.docker.com/_/postgres#Initialization-scripts) that we use has for a long time supported customisation through initialisation scripts (there is a similarly called section in the linked page).

With a custom initialisation script we can create as many users and databases as we like. This is what I do in this PR.

PS: I am not yet sure about the Reputations docker-compose file, if it's even used. If that is, we can add a database for it too, and ditch that third (!) Postgres.

NOTE on migrating: In order for changes from this PR to take effect in your environment, you need to fully remove the old environment with `docker-compose down -v`, ideally, prior to git-pulling fresh version.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

- [x] `docker-compose up -d` brings all the services up.
