### PR TITLE
Add timestamps to the nitro-shim log output

### DIFF
--- a/nitro-shim/scripts/sleep.sh
+++ b/nitro-shim/scripts/sleep.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+echo --- Monitoring enclave $(date) ---
 set -eux
 
 while true
 do
         # check every so often that the enclave is running
         sleep 480
+        date
 
         EID=$(nitro-cli describe-enclaves | jq -r .[].EnclaveID)
         if [ "${EID}" == "" ]; then


### PR DESCRIPTION
After launching the enclave application `run.sh` execs `sleep.sh` which periodically polls the enclave state and exits if it dies, propagating the failure to the container.

In debugging, it's difficult to match up events in the container log, which are largely the trace output of the run and sleep scripts, so add periodic timestamps to it's clear how long things were running.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
