### PR TITLE
Bundles XX – Refactor CreateOrder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       - pg_data:/var/lib/postgresql/data
       - ./create_dbs.sh:/docker-entrypoint-initdb.d/00_create_dbs.sh
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U grants -d grants"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -11,6 +11,12 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/cors"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72/webhook"
+
 	appctx "github.com/brave-intl/bat-go/libs/context"
 	"github.com/brave-intl/bat-go/libs/datastore"
 	"github.com/brave-intl/bat-go/libs/handlers"
@@ -19,11 +25,7 @@ import (
 	"github.com/brave-intl/bat-go/libs/middleware"
 	"github.com/brave-intl/bat-go/libs/requestutils"
 	"github.com/brave-intl/bat-go/libs/responses"
-	"github.com/go-chi/chi"
-	"github.com/go-chi/cors"
-	uuid "github.com/satori/go.uuid"
-	"github.com/stripe/stripe-go/v72"
-	"github.com/stripe/stripe-go/v72/webhook"
+	"github.com/brave-intl/bat-go/services/skus/handler"
 )
 
 func corsMiddleware(allowedMethods []string) func(next http.Handler) http.Handler {
@@ -47,11 +49,22 @@ func Router(service *Service, instrumentHandler middleware.InstrumentHandlerDef)
 	r := chi.NewRouter()
 	merchantSignedMiddleware := service.MerchantSignedMiddleware()
 
-	if os.Getenv("ENV") == "local" {
-		r.Method("OPTIONS", "/", middleware.InstrumentHandler("CreateOrderOptions", corsMiddleware([]string{"POST"})(nil)))
-		r.Method("POST", "/", middleware.InstrumentHandler("CreateOrder", corsMiddleware([]string{"POST"})(CreateOrder(service))))
-	} else {
-		r.Method("POST", "/", middleware.InstrumentHandler("CreateOrder", CreateOrder(service)))
+	{
+		orderh := handler.NewOrder(service)
+
+		if os.Getenv("ENV") == "local" {
+			r.Method(http.MethodOptions, "/", middleware.InstrumentHandler(
+				"CreateOrderOptions",
+				corsMiddleware([]string{http.MethodPost})(nil),
+			))
+
+			r.Method(http.MethodPost, "/", middleware.InstrumentHandler(
+				"CreateOrder",
+				corsMiddleware([]string{http.MethodPost})(handlers.AppHandler(orderh.Create)),
+			))
+		} else {
+			r.Method(http.MethodPost, "/", middleware.InstrumentHandler("CreateOrder", handlers.AppHandler(orderh.Create)))
+		}
 	}
 
 	r.Method("OPTIONS", "/{orderID}", middleware.InstrumentHandler("GetOrderOptions", corsMiddleware([]string{"GET"})(nil)))
@@ -241,58 +254,8 @@ func VoteRouter(service *Service, instrumentHandler middleware.InstrumentHandler
 	return r
 }
 
-// OrderItemRequest is the body for creating new items
-type OrderItemRequest struct {
-	SKU      string `json:"sku" valid:"-"`
-	Quantity int    `json:"quantity" valid:"int"`
-}
-
-// CreateOrderRequest includes information needed to create an order
-type CreateOrderRequest struct {
-	Items []OrderItemRequest `json:"items" valid:"-"`
-	Email string             `json:"email" valid:"-"`
-}
-
-// CreateOrder is the handler for creating a new order
-func CreateOrder(service *Service) handlers.AppHandler {
-	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-
-		ctx := r.Context()
-		sublogger := logging.Logger(ctx, "payments").With().Str("func", "CreateOrderHandler").Logger()
-
-		var req CreateOrderRequest
-		err := requestutils.ReadJSON(r.Context(), r.Body, &req)
-		if err != nil {
-			return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
-		}
-
-		_, err = govalidator.ValidateStruct(req)
-		if err != nil {
-			return handlers.WrapValidationError(err)
-		}
-		if len(req.Items) == 0 {
-			return handlers.ValidationError(
-				"Error validating request body",
-				map[string]interface{}{
-					"items": "array must contain at least one item",
-				},
-			)
-		}
-		// validation of sku tokens happens in createorderitemfrommacaroon
-		order, err := service.CreateOrderFromRequest(ctx, req)
-
-		if err != nil {
-			if errors.Is(err, ErrInvalidSKU) {
-				sublogger.Error().Err(err).Msg("invalid sku")
-				return handlers.ValidationError(ErrInvalidSKU.Error(), nil)
-			}
-			sublogger.Error().Err(err).Msg("error creating the order")
-			return handlers.WrapError(err, "Error creating the order in the database", http.StatusInternalServerError)
-		}
-
-		return handlers.RenderContent(r.Context(), order, w, http.StatusCreated)
-	}
-}
+type OrderItemRequest = handler.OrderItemRequest
+type CreateOrderRequest = handler.CreateOrderRequest
 
 // SetOrderTrialDaysInput - SetOrderTrialDays handler input
 type SetOrderTrialDaysInput struct {

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -49,22 +49,20 @@ func Router(service *Service, instrumentHandler middleware.InstrumentHandlerDef)
 	r := chi.NewRouter()
 	merchantSignedMiddleware := service.MerchantSignedMiddleware()
 
-	{
-		orderh := handler.NewOrder(service)
+	orderh := handler.NewOrder(service)
 
-		if os.Getenv("ENV") == "local" {
-			r.Method(http.MethodOptions, "/", middleware.InstrumentHandler(
-				"CreateOrderOptions",
-				corsMiddleware([]string{http.MethodPost})(nil),
-			))
+	if os.Getenv("ENV") == "local" {
+		r.Method(http.MethodOptions, "/", middleware.InstrumentHandler(
+			"CreateOrderOptions",
+			corsMiddleware([]string{http.MethodPost})(nil),
+		))
 
-			r.Method(http.MethodPost, "/", middleware.InstrumentHandler(
-				"CreateOrder",
-				corsMiddleware([]string{http.MethodPost})(handlers.AppHandler(orderh.Create)),
-			))
-		} else {
-			r.Method(http.MethodPost, "/", middleware.InstrumentHandler("CreateOrder", handlers.AppHandler(orderh.Create)))
-		}
+		r.Method(http.MethodPost, "/", middleware.InstrumentHandler(
+			"CreateOrder",
+			corsMiddleware([]string{http.MethodPost})(handlers.AppHandler(orderh.Create)),
+		))
+	} else {
+		r.Method(http.MethodPost, "/", middleware.InstrumentHandler("CreateOrder", handlers.AppHandler(orderh.Create)))
 	}
 
 	r.Method("OPTIONS", "/{orderID}", middleware.InstrumentHandler("GetOrderOptions", corsMiddleware([]string{"GET"})(nil)))

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -252,9 +252,6 @@ func VoteRouter(service *Service, instrumentHandler middleware.InstrumentHandler
 	return r
 }
 
-type OrderItemRequest = handler.OrderItemRequest
-type CreateOrderRequest = handler.CreateOrderRequest
-
 // SetOrderTrialDaysInput - SetOrderTrialDays handler input
 type SetOrderTrialDaysInput struct {
 	TrialDays int64 `json:"trialDays" valid:"int"`

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -39,6 +39,7 @@ import (
 	walletutils "github.com/brave-intl/bat-go/libs/wallet"
 	"github.com/brave-intl/bat-go/libs/wallet/provider/uphold"
 	"github.com/brave-intl/bat-go/services/skus/handler"
+	"github.com/brave-intl/bat-go/services/skus/model"
 	"github.com/brave-intl/bat-go/services/skus/skustest"
 	"github.com/brave-intl/bat-go/services/wallet"
 	macaroon "github.com/brave-intl/bat-go/tools/macaroon/cmd"
@@ -279,8 +280,8 @@ func (suite *ControllersTestSuite) setupCreateOrder(skuToken string, token macar
 
 	// create order this will also create the issuer
 
-	createRequest := &CreateOrderRequest{
-		Items: []OrderItemRequest{
+	createRequest := &model.CreateOrderRequest{
+		Items: []model.OrderItemRequest{
 			{
 				SKU:      skuToken,
 				Quantity: quantity,
@@ -438,8 +439,8 @@ func (suite *ControllersTestSuite) TestCreateFreeOrderWhitelistedSKU() {
 }
 
 func (suite *ControllersTestSuite) TestCreateInvalidOrder() {
-	createRequest := &CreateOrderRequest{
-		Items: []OrderItemRequest{
+	createRequest := &model.CreateOrderRequest{
+		Items: []model.OrderItemRequest{
 			{
 				SKU:      InvalidFreeTestSkuToken,
 				Quantity: 1,
@@ -1443,9 +1444,9 @@ func (suite *ControllersTestSuite) TestE2E_CreateOrderCreds_StoreSignedOrderCred
 	ctx = context.WithValue(ctx, appctx.WhitelistSKUsCTXKey, []string{FreeTestSkuToken})
 
 	// create order with order items
-	request := CreateOrderRequest{
+	request := model.CreateOrderRequest{
 		Email: test.RandomString(),
-		Items: []OrderItemRequest{
+		Items: []model.OrderItemRequest{
 			{
 				SKU:      FreeTestSkuToken,
 				Quantity: 3,
@@ -1580,9 +1581,9 @@ func (suite *ControllersTestSuite) TestE2E_CreateOrderCreds_StoreSignedOrderCred
 	ctx = context.WithValue(ctx, appctx.WhitelistSKUsCTXKey, []string{token})
 
 	// create order with order items
-	request := CreateOrderRequest{
+	request := model.CreateOrderRequest{
 		Email: test.RandomString(),
-		Items: []OrderItemRequest{
+		Items: []model.OrderItemRequest{
 			{
 				SKU:      token,
 				Quantity: 1,
@@ -1701,9 +1702,9 @@ func (suite *ControllersTestSuite) TestCreateOrderCreds_SingleUse_ExistingOrderC
 	ctx = context.WithValue(ctx, appctx.WhitelistSKUsCTXKey, []string{FreeTestSkuToken})
 
 	// create order with order items
-	request := CreateOrderRequest{
+	request := model.CreateOrderRequest{
 		Email: test.RandomString(),
-		Items: []OrderItemRequest{
+		Items: []model.OrderItemRequest{
 			{
 				SKU:      FreeTestSkuToken,
 				Quantity: 3,

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -15,7 +15,7 @@ import (
 )
 
 type orderService interface {
-	CreateOrderFromRequest(ctx context.Context, req CreateOrderRequest) (*model.Order, error)
+	CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 }
 
 type Order struct {
@@ -33,7 +33,7 @@ func NewOrder(svc orderService) *Order {
 func (h *Order) Create(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	ctx := r.Context()
 
-	var req CreateOrderRequest
+	var req model.CreateOrderRequest
 	if err := requestutils.ReadJSON(ctx, r.Body, &req); err != nil {
 		return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
 	}
@@ -66,16 +66,4 @@ func (h *Order) Create(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 	}
 
 	return handlers.RenderContent(ctx, order, w, http.StatusCreated)
-}
-
-// CreateOrderRequest includes information needed to create an order.
-type CreateOrderRequest struct {
-	Email string             `json:"email" valid:"-"`
-	Items []OrderItemRequest `json:"items" valid:"-"`
-}
-
-// OrderItemRequest represents an item in a order request.
-type OrderItemRequest struct {
-	SKU      string `json:"sku" valid:"-"`
-	Quantity int    `json:"quantity" valid:"int"`
 }

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -34,7 +34,7 @@ func (h *Order) Create(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 	ctx := r.Context()
 
 	var req CreateOrderRequest
-	if err := requestutils.ReadJSON(r.Context(), r.Body, &req); err != nil {
+	if err := requestutils.ReadJSON(ctx, r.Body, &req); err != nil {
 		return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
 	}
 

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/asaskevich/govalidator"
+
+	"github.com/brave-intl/bat-go/libs/handlers"
+	"github.com/brave-intl/bat-go/libs/logging"
+	"github.com/brave-intl/bat-go/libs/requestutils"
+
+	"github.com/brave-intl/bat-go/services/skus/model"
+)
+
+type orderService interface {
+	CreateOrderFromRequest(ctx context.Context, req CreateOrderRequest) (*model.Order, error)
+}
+
+type Order struct {
+	svc orderService
+}
+
+func NewOrder(svc orderService) *Order {
+	result := &Order{
+		svc: svc,
+	}
+
+	return result
+}
+
+func (h *Order) Create(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	var req CreateOrderRequest
+	if err := requestutils.ReadJSON(r.Context(), r.Body, &req); err != nil {
+		return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
+	}
+
+	if _, err := govalidator.ValidateStruct(req); err != nil {
+		return handlers.WrapValidationError(err)
+	}
+
+	if len(req.Items) == 0 {
+		return handlers.ValidationError(
+			"Error validating request body",
+			map[string]interface{}{
+				"items": "array must contain at least one item",
+			},
+		)
+	}
+
+	lg := logging.Logger(ctx, "payments").With().Str("func", "CreateOrderHandler").Logger()
+
+	// The SKU is validated in CreateOrderItemFromMacaroon.
+	order, err := h.svc.CreateOrderFromRequest(ctx, req)
+	if err != nil {
+		if errors.Is(err, model.ErrInvalidSKU) {
+			lg.Error().Err(err).Msg("invalid sku")
+			return handlers.ValidationError(err.Error(), nil)
+		}
+
+		lg.Error().Err(err).Msg("error creating the order")
+		return handlers.WrapError(err, "Error creating the order in the database", http.StatusInternalServerError)
+	}
+
+	return handlers.RenderContent(ctx, order, w, http.StatusCreated)
+}
+
+// CreateOrderRequest includes information needed to create an order.
+type CreateOrderRequest struct {
+	Email string             `json:"email" valid:"-"`
+	Items []OrderItemRequest `json:"items" valid:"-"`
+}
+
+// OrderItemRequest represents an item in a order request.
+type OrderItemRequest struct {
+	SKU      string `json:"sku" valid:"-"`
+	Quantity int    `json:"quantity" valid:"int"`
+}

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -28,10 +28,10 @@ func TestMain(m *testing.M) {
 }
 
 type mockOrderService struct {
-	fnCreateOrderFromRequest func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error)
+	fnCreateOrderFromRequest func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 }
 
-func (s *mockOrderService) CreateOrderFromRequest(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+func (s *mockOrderService) CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
 	if s.fnCreateOrderFromRequest == nil {
 		return &model.Order{Items: []model.OrderItem{{}}}, nil
 	}
@@ -80,7 +80,7 @@ func TestOrder_Create(t *testing.T) {
 			name: "invalid_sku",
 			given: tcGiven{
 				svc: &mockOrderService{
-					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+					fnCreateOrderFromRequest: func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
 						return nil, model.ErrInvalidSKU
 					},
 				},
@@ -103,7 +103,7 @@ func TestOrder_Create(t *testing.T) {
 			name: "some_error",
 			given: tcGiven{
 				svc: &mockOrderService{
-					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+					fnCreateOrderFromRequest: func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
 						return nil, model.Error("some_error")
 					},
 				},
@@ -130,7 +130,7 @@ func TestOrder_Create(t *testing.T) {
 			name: "success",
 			given: tcGiven{
 				svc: &mockOrderService{
-					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+					fnCreateOrderFromRequest: func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
 						result := &model.Order{
 							Location: datastore.NullString{
 								NullString: sql.NullString{

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -1,0 +1,261 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/shopspring/decimal"
+	should "github.com/stretchr/testify/assert"
+	must "github.com/stretchr/testify/require"
+
+	"github.com/brave-intl/bat-go/libs/datastore"
+	"github.com/brave-intl/bat-go/libs/handlers"
+
+	"github.com/brave-intl/bat-go/services/skus/handler"
+	"github.com/brave-intl/bat-go/services/skus/model"
+)
+
+func TestMain(m *testing.M) {
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	os.Exit(m.Run())
+}
+
+type mockOrderService struct {
+	fnCreateOrderFromRequest func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error)
+}
+
+func (s *mockOrderService) CreateOrderFromRequest(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+	if s.fnCreateOrderFromRequest == nil {
+		return &model.Order{Items: []model.OrderItem{{}}}, nil
+	}
+
+	return s.fnCreateOrderFromRequest(ctx, req)
+}
+
+func TestOrder_Create(t *testing.T) {
+	type tcGiven struct {
+		svc  *mockOrderService
+		body string
+	}
+
+	type tcExpected struct {
+		err    *handlers.AppError
+		result *model.Order
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invalid_data",
+			given: tcGiven{
+				svc: &mockOrderService{},
+				body: `{
+					"email": "you@example.com",
+					"items": []
+				}`,
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError(
+					"Error validating request body",
+					map[string]interface{}{
+						"items": "array must contain at least one item",
+					},
+				),
+			},
+		},
+
+		{
+			name: "invalid_sku",
+			given: tcGiven{
+				svc: &mockOrderService{
+					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+						return nil, model.ErrInvalidSKU
+					},
+				},
+				body: `{
+					"email": "you@example.com",
+					"items": [
+						{
+							"sku": "invalid_sku",
+							"quantity": 1
+						}
+					]
+				}`,
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError(model.ErrInvalidSKU.Error(), nil),
+			},
+		},
+
+		{
+			name: "some_error",
+			given: tcGiven{
+				svc: &mockOrderService{
+					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+						return nil, model.Error("some_error")
+					},
+				},
+				body: `{
+					"email": "you@example.com",
+					"items": [
+						{
+							"sku": "invalid_sku",
+							"quantity": 1
+						}
+					]
+				}`,
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(
+					model.Error("some_error"),
+					"Error creating the order in the database",
+					http.StatusInternalServerError,
+				),
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				svc: &mockOrderService{
+					fnCreateOrderFromRequest: func(ctx context.Context, req handler.CreateOrderRequest) (*model.Order, error) {
+						result := &model.Order{
+							Location: datastore.NullString{
+								NullString: sql.NullString{
+									Valid:  true,
+									String: "somewhere",
+								},
+							},
+							Items: []model.OrderItem{
+								{
+									SKU:      "some_sku",
+									Quantity: 1,
+									Price:    mustDecimalFromString("2"),
+									Subtotal: mustDecimalFromString("2"),
+									Location: datastore.NullString{
+										NullString: sql.NullString{
+											Valid:  true,
+											String: "somewhere",
+										},
+									},
+									Description: datastore.NullString{
+										NullString: sql.NullString{
+											Valid:  true,
+											String: "something",
+										},
+									},
+								},
+							},
+							TotalPrice: mustDecimalFromString("2"),
+						}
+
+						return result, nil
+					},
+				},
+				body: `{
+					"email": "you@example.com",
+					"items": [
+						{
+							"sku": "some_sku",
+							"quantity": 1
+						}
+					]
+				}`,
+			},
+			exp: tcExpected{
+				result: &model.Order{
+					Location: datastore.NullString{
+						NullString: sql.NullString{
+							Valid:  true,
+							String: "somewhere",
+						},
+					},
+					Items: []model.OrderItem{
+						{
+							SKU:      "some_sku",
+							Quantity: 1,
+							Price:    mustDecimalFromString("2"),
+							Subtotal: mustDecimalFromString("2"),
+							Location: datastore.NullString{
+								NullString: sql.NullString{
+									Valid:  true,
+									String: "somewhere",
+								},
+							},
+							Description: datastore.NullString{
+								NullString: sql.NullString{
+									Valid:  true,
+									String: "something",
+								},
+							},
+						},
+					},
+					TotalPrice: mustDecimalFromString("2"),
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			h := handler.NewOrder(tc.given.svc)
+
+			body := bytes.NewBufferString(tc.given.body)
+
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", body)
+
+			rw := httptest.NewRecorder()
+			rw.Header().Set("content-type", "application/json")
+
+			act1 := h.Create(rw, req)
+			must.Equal(t, tc.exp.err, act1)
+
+			if tc.exp.err != nil {
+				act1.ServeHTTP(rw, req)
+				resp := rw.Body.Bytes()
+
+				act2 := &handlers.AppError{}
+				err := json.Unmarshal(resp, act2)
+				must.Equal(t, nil, err)
+
+				// Cause is excluded from JSON.
+				tc.exp.err.Cause = nil
+
+				should.Equal(t, tc.exp.err, act2)
+
+				return
+			}
+
+			resp := rw.Body.Bytes()
+			act2 := &model.Order{}
+
+			err := json.Unmarshal(resp, act2)
+			must.Equal(t, nil, err)
+
+			should.Equal(t, tc.exp.result, act2)
+		})
+	}
+}
+
+func mustDecimalFromString(v string) decimal.Decimal {
+	result, err := decimal.NewFromString(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return result
+}

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -286,3 +286,15 @@ func (x *OrderTimeBounds) ExpiresAtWithFallback(fallback time.Time) time.Time {
 
 	return expiresAt
 }
+
+// CreateOrderRequest includes information needed to create an order.
+type CreateOrderRequest struct {
+	Email string             `json:"email" valid:"-"`
+	Items []OrderItemRequest `json:"items" valid:"-"`
+}
+
+// OrderItemRequest represents an item in a order request.
+type OrderItemRequest struct {
+	SKU      string `json:"sku" valid:"-"`
+	Quantity int    `json:"quantity" valid:"int"`
+}

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -26,6 +26,9 @@ const (
 	ErrNoRowsChangedOrder                     Error = "model: no rows changed in orders"
 	ErrNoRowsChangedOrderPayHistory           Error = "model: no rows changed in order_payment_history"
 	ErrExpiredStripeCheckoutSessionIDNotFound Error = "model: expired stripeCheckoutSessionId not found"
+
+	// The text of the error is preserved as is, in case anything depends on it.
+	ErrInvalidSKU Error = "Invalid SKU Token provided in request"
 )
 
 const (

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -3,7 +3,6 @@ package skus
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -34,11 +33,6 @@ const (
 	StripeInvoiceUpdated              = "invoice.updated"
 	StripeInvoicePaid                 = "invoice.paid"
 	StripeCustomerSubscriptionDeleted = "customer.subscription.deleted"
-)
-
-var (
-	// ErrInvalidSKU - this sku is malformed or failed signature validation
-	ErrInvalidSKU = errors.New("Invalid SKU Token provided in request")
 )
 
 // TODO(pavelb): Gradually replace it everywhere.
@@ -84,7 +78,7 @@ func (s *Service) CreateOrderItemFromMacaroon(ctx context.Context, sku string, q
 	// perform validation
 	if !valid {
 		sublogger.Error().Err(err).Msg("invalid sku")
-		return nil, nil, nil, ErrInvalidSKU
+		return nil, nil, nil, model.ErrInvalidSKU
 	}
 
 	// read the macaroon, its valid

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -231,7 +231,7 @@ func (s *Service) ExternalIDExists(ctx context.Context, externalID string) (bool
 }
 
 // CreateOrderFromRequest creates an order from the request
-func (s *Service) CreateOrderFromRequest(ctx context.Context, req CreateOrderRequest) (*Order, error) {
+func (s *Service) CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*Order, error) {
 	totalPrice := decimal.New(0, 0)
 	var (
 		currency              string


### PR DESCRIPTION
### Summary

This PR refactors `CreateOrder` into `handler.Order`, in accordance with what'd been described in #1825.


## Main Changes

💎 A new package, `handler`, has been added to the `skus` service. This is new home for _types_ that are handlers. A method on a handler type becomes a handler for one [or more] endpoints.
💎 A new _handler_, `Order`, has been added that currently has only one method, `Create`. It reads as `order.Create`.
💎 The new handler has been supplied with tests for `Create`.

## Related Changes

💠 Adjusted the `pg_isready` command (used in local and test environments) to stop misleading errors complaining about `root` user not found.
💠 The order create request types have been moved to the `model` package.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
