### PR TITLE
Possible Fixes For 1897

### DIFF
--- a/libs/clients/gemini/clientx_test.go
+++ b/libs/clients/gemini/clientx_test.go
@@ -1,0 +1,73 @@
+package gemini
+
+import (
+	"testing"
+
+	should "github.com/stretchr/testify/assert"
+)
+
+func TestCountryForDocByPrecendence(t *testing.T) {
+	type testCase struct {
+		name  string
+		given []ValidDocument
+		exp   string
+	}
+
+	tests := []testCase{
+		{
+			name: "empty",
+		},
+
+		{
+			name: "one_passport",
+			given: []ValidDocument{
+				{
+					Type:           "passport",
+					IssuingCountry: "US",
+				},
+			},
+			exp: "US",
+		},
+
+		{
+			name: "two_docs",
+			given: []ValidDocument{
+				{
+					Type:           "passport",
+					IssuingCountry: "US",
+				},
+
+				{
+					Type:           "drivers_license",
+					IssuingCountry: "CA",
+				},
+			},
+			exp: "US",
+		},
+
+		{
+			name: "two_docs_reverse",
+			given: []ValidDocument{
+				{
+					Type:           "drivers_license",
+					IssuingCountry: "CA",
+				},
+
+				{
+					Type:           "passport",
+					IssuingCountry: "US",
+				},
+			},
+			exp: "US",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			act := countryForDocByPrecendence(documentTypePrecedence, tc.given)
+			should.Equal(t, tc.exp, act)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

When I saw #1897, a few things attracted my attention:
1. While looping over document precedence and valid documents, we compared a desired document from the precedence slice to a issuing country. This is odd.
    - I think we should be comparing a document type from precedence to the type of the document in the list.
2. At the end of the loop, the `issuingCountry` variable will be the equal to the country from the _last_ document matched, not the first. This is because we are breaking out only of the inner loop. The outer loop continues.
    - I think the intent is to pick the first match based on the precedence regardless of the order of the documents, and the first preferred match should be the value for `issuingCountry`.

So this PR fixes that with a bit of refactoring and tests.


### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
