### PR TITLE
Add Neon mapping to ratios service

### DIFF
--- a/services/ratios/mapping.go
+++ b/services/ratios/mapping.go
@@ -90,6 +90,7 @@ var (
 		"muso":  "mirrored-united-states-oil-fund",
 		"nct":   "polyswarm",
 		"ndx":   "ndex",
+		"neon":  "neon",
 		"oil":   "oiler",
 		"one":   "menlo-one",
 		"ousd":  "origin-dollar",


### PR DESCRIPTION
### Summary

Querying price for Neon reports incorrect result:

```sh
$ curl -s https://ratios.rewards.brave.com/v2/relative/provider/coingecko/neon/usd/1d | jq '.payload.neon.usd'
9.27826e-10  # expected 0.063615
```

### Type of change ( select one )

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
