### PR TITLE
Return a users country code in linking endpoint

### DIFF
--- a/services/wallet/controllers_v3_test.go
+++ b/services/wallet/controllers_v3_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mockgemini "github.com/brave-intl/bat-go/libs/clients/gemini/mock"
 	mockreputation "github.com/brave-intl/bat-go/libs/clients/reputation/mock"
@@ -303,18 +304,19 @@ func TestLinkBitFlyerWalletV3(t *testing.T) {
 	router.Post("/v3/wallet/bitflyer/{paymentID}/claim", handlers.AppHandler(handler).ServeHTTP)
 	router.ServeHTTP(w, r)
 
-	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
 		t.Logf("%+v\n", resp)
 		body, err := ioutil.ReadAll(resp.Body)
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
 
-	var res wallet.LinkDepositAccountResponse
-	err = json.NewDecoder(w.Body).Decode(&res)
-	assert.NoError(t, err)
+	var linkDepositAccountResponse wallet.LinkDepositAccountResponse
+	err = json.NewDecoder(resp.Body).Decode(&linkDepositAccountResponse)
+	require.NoError(t, err)
 
-	assert.Equal(t, "JP", res.GeoCountry)
+	assert.Equal(t, "JP", linkDepositAccountResponse.GeoCountry)
 }
 
 func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
@@ -450,18 +452,19 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 	router.Post("/v3/wallet/gemini/{paymentID}/claim", handlers.AppHandler(handler).ServeHTTP)
 	router.ServeHTTP(w, r)
 
-	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
 		t.Logf("%+v\n", resp)
 		body, err := ioutil.ReadAll(resp.Body)
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
 
-	var res wallet.LinkDepositAccountResponse
-	err := json.NewDecoder(w.Body).Decode(&res)
-	assert.NoError(t, err)
+	var linkDepositAccountResponse wallet.LinkDepositAccountResponse
+	err := json.NewDecoder(resp.Body).Decode(&linkDepositAccountResponse)
+	require.NoError(t, err)
 
-	assert.Equal(t, "US", res.GeoCountry)
+	require.Equal(t, "US", linkDepositAccountResponse.GeoCountry)
 
 	// delete linking
 	r = httptest.NewRequest(
@@ -501,18 +504,6 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 		},
 	}
 	ctx = context.WithValue(ctx, appctx.CustodianRegionsCTXKey, custodianRegions)
-
-	/*
-		mockGeminiClient.EXPECT().ValidateAccount(
-			gomock.Any(),
-			gomock.Any(),
-			gomock.Any(),
-		).Return(
-			accountID.String(),
-			"US",
-			nil,
-		)
-	*/
 
 	// begin linking tx
 	mock.ExpectBegin()
@@ -570,7 +561,6 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
-
 }
 
 func TestLinkGeminiWalletV3FirstLinking(t *testing.T) {
@@ -895,18 +885,19 @@ func TestLinkZebPayWalletV3(t *testing.T) {
 	router.Post("/v3/wallet/zebpay/{paymentID}/claim", handlers.AppHandler(handler).ServeHTTP)
 	router.ServeHTTP(w, r)
 
-	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
 		t.Logf("%+v\n", resp)
 		body, err := ioutil.ReadAll(resp.Body)
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
 
-	var res wallet.LinkDepositAccountResponse
-	err = json.NewDecoder(w.Body).Decode(&res)
-	assert.NoError(t, err)
+	var linkDepositAccountResponse wallet.LinkDepositAccountResponse
+	err = json.NewDecoder(resp.Body).Decode(&linkDepositAccountResponse)
+	require.NoError(t, err)
 
-	assert.Equal(t, "IN", res.GeoCountry)
+	assert.Equal(t, "IN", linkDepositAccountResponse.GeoCountry)
 }
 
 func TestLinkGeminiWalletV3(t *testing.T) {
@@ -1021,18 +1012,19 @@ func TestLinkGeminiWalletV3(t *testing.T) {
 	router.Post("/v3/wallet/gemini/{paymentID}/claim", handlers.AppHandler(handler).ServeHTTP)
 	router.ServeHTTP(w, r)
 
-	if resp := w.Result(); resp.StatusCode != http.StatusOK {
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
 		t.Logf("%+v\n", resp)
 		body, err := ioutil.ReadAll(resp.Body)
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
 
-	var res wallet.LinkDepositAccountResponse
-	err := json.NewDecoder(w.Body).Decode(&res)
-	assert.NoError(t, err)
+	var linkDepositAccountResponse wallet.LinkDepositAccountResponse
+	err := json.NewDecoder(resp.Body).Decode(&linkDepositAccountResponse)
+	require.NoError(t, err)
 
-	assert.Equal(t, "GB", res.GeoCountry)
+	assert.Equal(t, "GB", linkDepositAccountResponse.GeoCountry)
 }
 
 func TestDisconnectCustodianLinkV3(t *testing.T) {

--- a/services/wallet/controllers_v3_test.go
+++ b/services/wallet/controllers_v3_test.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -17,6 +18,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+
 	mockgemini "github.com/brave-intl/bat-go/libs/clients/gemini/mock"
 	mockreputation "github.com/brave-intl/bat-go/libs/clients/reputation/mock"
 	appctx "github.com/brave-intl/bat-go/libs/context"
@@ -306,6 +309,12 @@ func TestLinkBitFlyerWalletV3(t *testing.T) {
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
+
+	var res wallet.LinkDepositAccountResponse
+	err = json.NewDecoder(w.Body).Decode(&res)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "JP", res.GeoCountry)
 }
 
 func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
@@ -447,6 +456,12 @@ func TestLinkGeminiWalletV3RelinkBadRegion(t *testing.T) {
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
+
+	var res wallet.LinkDepositAccountResponse
+	err := json.NewDecoder(w.Body).Decode(&res)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "US", res.GeoCountry)
 
 	// delete linking
 	r = httptest.NewRequest(
@@ -886,6 +901,12 @@ func TestLinkZebPayWalletV3(t *testing.T) {
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
+
+	var res wallet.LinkDepositAccountResponse
+	err = json.NewDecoder(w.Body).Decode(&res)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "IN", res.GeoCountry)
 }
 
 func TestLinkGeminiWalletV3(t *testing.T) {
@@ -948,7 +969,7 @@ func TestLinkGeminiWalletV3(t *testing.T) {
 		gomock.Any(),
 	).Return(
 		accountID.String(),
-		"",
+		"GB",
 		nil,
 	)
 
@@ -1006,6 +1027,12 @@ func TestLinkGeminiWalletV3(t *testing.T) {
 		t.Logf("%s, %+v\n", body, err)
 		must(t, "invalid response", fmt.Errorf("expected %d, got %d", http.StatusOK, resp.StatusCode))
 	}
+
+	var res wallet.LinkDepositAccountResponse
+	err := json.NewDecoder(w.Body).Decode(&res)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "GB", res.GeoCountry)
 }
 
 func TestDisconnectCustodianLinkV3(t *testing.T) {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -432,6 +432,7 @@ func (service *Service) LinkBitFlyerWallet(ctx context.Context, walletID uuid.UU
 
 		return "", handlers.WrapError(err, "unable to link bitflyer wallets", status)
 	}
+
 	return country, nil
 }
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -668,6 +668,7 @@ func (service *Service) LinkWallet(ctx context.Context, wallet uphold.Wallet, tr
 			return "", handlers.WrapError(err, "unable to transfer tokens", http.StatusBadRequest)
 		}
 	}
+
 	return country, nil
 }
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -414,7 +414,6 @@ func (service *Service) LinkBitFlyerWallet(ctx context.Context, walletID uuid.UU
 	// we also validated that this "info" signed the request to perform the linking with http signature
 	// we assume that since we got linkingInfo signed from BF that they are KYC
 	providerLinkingID := uuid.NewV5(ClaimNamespace, accountHash)
-	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking
 	err := service.Datastore.LinkWallet(ctx, walletID.String(), depositID, providerLinkingID, nil, "bitflyer", country)
 	if err != nil {
 		if errors.Is(err, ErrUnusualActivity) {
@@ -487,7 +486,6 @@ func (service *Service) LinkZebPayWallet(ctx context.Context, walletID uuid.UUID
 
 	providerLinkingID := uuid.NewV5(ClaimNamespace, claims.AccountID)
 
-	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking.
 	if err := service.Datastore.LinkWallet(ctx, walletID.String(), claims.DepositID, providerLinkingID, nil, "zebpay", country); err != nil {
 		if errors.Is(err, ErrUnusualActivity) {
 			return "", handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -523,8 +523,8 @@ func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID
 	}
 
 	// If a wallet has previously been linked i.e. has a prior linking, but the country is now invalid/blocked
-	// then we can ignore this error and allow the account to link due to its prior successful linking.
-	// If there is no prior linking then we should return the original error.
+	// then we can allow the account to link due to its prior successful linking i.e. it is grandfathered.
+	// If there is no prior linking and the country is invalid/blocked then we should apply the current rules and block it.
 
 	accountID, country, err := geminiClient.ValidateAccount(ctx, verificationToken, depositID)
 	if err != nil {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -522,10 +522,10 @@ func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID
 		ctx = context.WithValue(ctx, appctx.CustodianRegionsCTXKey, &cr)
 	}
 
-	// Validate the account with Gemini. If a wallet has previously been linked but the country is now invalid
-	// i.e. validate account returns errorutils.ErrInvalidCountry then we can ignore this
-	// error and allow the account to link due to its prior successful linking.
+	// If a wallet has previously been linked i.e. has a prior linking, but the country is now invalid/blocked
+	// then we can ignore this error and allow the account to link due to its prior successful linking.
 	// If there is no prior linking then we should return the original error.
+
 	accountID, country, err := geminiClient.ValidateAccount(ctx, verificationToken, depositID)
 	if err != nil {
 		if errors.Is(err, errorutils.ErrInvalidCountry) {
@@ -568,8 +568,7 @@ func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID
 }
 
 // LinkWallet links a wallet and transfers funds to newly linked wallet
-func (service *Service) LinkWallet(ctx context.Context, wallet uphold.Wallet, transaction string,
-	anonymousAddress *uuid.UUID) (string, error) {
+func (service *Service) LinkWallet(ctx context.Context, wallet uphold.Wallet, transaction string, anonymousAddress *uuid.UUID) (string, error) {
 	// do not confirm this transaction yet
 	info := wallet.GetWalletInfo()
 

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -408,62 +408,68 @@ func (service *Service) GetLinkingInfo(ctx context.Context, providerLinkingID, c
 }
 
 // LinkBitFlyerWallet links a wallet and transfers funds to newly linked wallet
-func (service *Service) LinkBitFlyerWallet(ctx context.Context, walletID uuid.UUID, depositID, accountHash string) error {
+func (service *Service) LinkBitFlyerWallet(ctx context.Context, walletID uuid.UUID, depositID, accountHash string) (string, error) {
+	const country = "JP"
 	// during validation, we verified that the account hash and deposit id were signed by bitflyer
 	// we also validated that this "info" signed the request to perform the linking with http signature
 	// we assume that since we got linkingInfo signed from BF that they are KYC
 	providerLinkingID := uuid.NewV5(ClaimNamespace, accountHash)
 	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking
-	err := service.Datastore.LinkWallet(ctx, walletID.String(), depositID, providerLinkingID, nil, "bitflyer", "JP")
+	err := service.Datastore.LinkWallet(ctx, walletID.String(), depositID, providerLinkingID, nil, "bitflyer", country)
 	if err != nil {
+		if errors.Is(err, ErrUnusualActivity) {
+			return "", handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
+		}
+
+		if errors.Is(err, ErrGeoResetDifferent) {
+			return "", handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
+		}
+
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrTooManyCardsLinked) {
 			status = http.StatusConflict
 		}
-		if errors.Is(err, ErrUnusualActivity) {
-			return handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
-		}
-		if errors.Is(err, ErrGeoResetDifferent) {
-			return handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
-		}
-		return handlers.WrapError(err, "unable to link bitflyer wallets", status)
+
+		return "", handlers.WrapError(err, "unable to link bitflyer wallets", status)
 	}
-	return nil
+	return country, nil
 }
 
 // LinkZebPayWallet links a wallet and transfers funds to newly linked wallet.
-func (service *Service) LinkZebPayWallet(ctx context.Context, walletID uuid.UUID, verificationToken string) error {
+func (service *Service) LinkZebPayWallet(ctx context.Context, walletID uuid.UUID, verificationToken string) (string, error) {
+	const country = "IN"
+
 	// Get zebpay linking_info signing key.
 	linkingKeyB64, ok := ctx.Value(appctx.ZebPayLinkingKeyCTXKey).(string)
 	if !ok {
 		const msg = "zebpay linking validation misconfigured"
-		return handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusInternalServerError)
+		return "", handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusInternalServerError)
 	}
 
 	// Decode base64 encoded jwt key.
 	decodedJWTKey, err := base64.StdEncoding.DecodeString(linkingKeyB64)
 	if err != nil {
 		const msg = "zebpay linking validation misconfigured"
-		return handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusInternalServerError)
+		return "", handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusInternalServerError)
 	}
 
 	// Parse the signed verification token from input.
 	tok, err := jwt.ParseSigned(verificationToken)
 	if err != nil {
 		const msg = "zebpay linking info parsing failed"
-		return handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusBadRequest)
+		return "", handlers.WrapError(appctx.ErrNotInContext, msg, http.StatusBadRequest)
 	}
 
 	if len(tok.Headers) == 0 {
 		const msg = "linking info token invalid no headers"
-		return handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
+		return "", handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
 	}
 
 	// validate algorithm used
 	for i := range tok.Headers {
 		if tok.Headers[i].Algorithm != "HS256" {
 			const msg = "linking info token invalid"
-			return handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
+			return "", handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
 		}
 	}
 
@@ -471,23 +477,23 @@ func (service *Service) LinkZebPayWallet(ctx context.Context, walletID uuid.UUID
 	claims := &claimsZP{}
 	if err := tok.Claims(decodedJWTKey, claims); err != nil {
 		const msg = "zebpay linking info validation failed"
-		return handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
+		return "", handlers.WrapError(errors.New(msg), msg, http.StatusBadRequest)
 	}
 
 	if err := claims.validate(time.Now()); err != nil {
-		return err
+		return "", err
 	}
 
 	providerLinkingID := uuid.NewV5(ClaimNamespace, claims.AccountID)
 
 	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking.
-	if err := service.Datastore.LinkWallet(ctx, walletID.String(), claims.DepositID, providerLinkingID, nil, "zebpay", "IN"); err != nil {
+	if err := service.Datastore.LinkWallet(ctx, walletID.String(), claims.DepositID, providerLinkingID, nil, "zebpay", country); err != nil {
 		if errors.Is(err, ErrUnusualActivity) {
-			return handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
+			return "", handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
 		}
 
 		if errors.Is(err, ErrGeoResetDifferent) {
-			return handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
+			return "", handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
 		}
 
 		status := http.StatusInternalServerError
@@ -495,20 +501,19 @@ func (service *Service) LinkZebPayWallet(ctx context.Context, walletID uuid.UUID
 			status = http.StatusConflict
 		}
 
-		return handlers.WrapError(err, "unable to link zebpay wallets", status)
+		return "", handlers.WrapError(err, "unable to link zebpay wallets", status)
 	}
 
-	return nil
+	return country, nil
 }
 
 // LinkGeminiWallet links a wallet and transfers funds to newly linked wallet
-func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID, verificationToken, depositID string) error {
+func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID, verificationToken, depositID string) (string, error) {
 	// get gemini client from context
 	geminiClient, ok := ctx.Value(appctx.GeminiClientCTXKey).(gemini.Client)
 	if !ok {
 		// no gemini client on context
-		return handlers.WrapError(
-			appctx.ErrNotInContext, "gemini client misconfigured", http.StatusInternalServerError)
+		return "", handlers.WrapError(appctx.ErrNotInContext, "gemini client misconfigured", http.StatusInternalServerError)
 	}
 
 	// add custodian regions to ctx going to client
@@ -518,54 +523,54 @@ func (service *Service) LinkGeminiWallet(ctx context.Context, walletID uuid.UUID
 		ctx = context.WithValue(ctx, appctx.CustodianRegionsCTXKey, &cr)
 	}
 
-	// perform an Account Validation call to gemini to get the accountID
+	// Validate the account with Gemini. If a wallet has previously been linked but the country is now invalid
+	// i.e. validate account returns errorutils.ErrInvalidCountry then we can ignore this
+	// error and allow the account to link due to its prior successful linking.
+	// If there is no prior linking then we should return the original error.
 	accountID, country, err := geminiClient.ValidateAccount(ctx, verificationToken, depositID)
 	if err != nil {
-		// check if this gemini accountID has already been linked to this wallet,
 		if errors.Is(err, errorutils.ErrInvalidCountry) {
-			ok, priorLinkingErr := service.Datastore.HasPriorLinking(
-				ctx, walletID, uuid.NewV5(ClaimNamespace, accountID))
+			hasPriorLinking, priorLinkingErr := service.Datastore.HasPriorLinking(ctx, walletID, uuid.NewV5(ClaimNamespace, accountID))
 			if priorLinkingErr != nil && !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("failed to check prior linkings: %w", priorLinkingErr)
+				return "", fmt.Errorf("failed to check prior linkings: %w", priorLinkingErr)
 			}
-			if !ok {
-				// then pass back the original geo error
-				return fmt.Errorf("failed to validate account: %w", err)
+
+			if !hasPriorLinking {
+				return "", fmt.Errorf("failed to validate account: %w", err)
 			}
-			// allow invalid country if there was a prior linking
+
 		} else {
 			// not err invalid country error
-			return fmt.Errorf("failed to validate account: %w", err)
+			return "", fmt.Errorf("failed to validate account: %w", err)
 		}
 	}
 
 	// we assume that since we got linking_info(VerificationToken) signed from Gemini that they are KYC
 	providerLinkingID := uuid.NewV5(ClaimNamespace, accountID)
-	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking
 	err = service.Datastore.LinkWallet(ctx, walletID.String(), depositID, providerLinkingID, nil, "gemini", country)
 	if err != nil {
+		if errors.Is(err, ErrUnusualActivity) {
+			return "", handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
+		}
+
+		if errors.Is(err, ErrGeoResetDifferent) {
+			return "", handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
+		}
+
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrTooManyCardsLinked) {
 			status = http.StatusConflict
 		}
-		if errors.Is(err, ErrUnusualActivity) {
-			return handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
-		}
-		if errors.Is(err, ErrGeoResetDifferent) {
-			return handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
-		}
-		return handlers.WrapError(err, "unable to link gemini wallets", status)
+
+		return "", handlers.WrapError(err, "unable to link gemini wallets", status)
 	}
-	return nil
+
+	return country, nil
 }
 
 // LinkWallet links a wallet and transfers funds to newly linked wallet
-func (service *Service) LinkWallet(
-	ctx context.Context,
-	wallet uphold.Wallet,
-	transaction string,
-	anonymousAddress *uuid.UUID,
-) error {
+func (service *Service) LinkWallet(ctx context.Context, wallet uphold.Wallet, transaction string,
+	anonymousAddress *uuid.UUID) (string, error) {
 	// do not confirm this transaction yet
 	info := wallet.GetWalletInfo()
 
@@ -578,7 +583,7 @@ func (service *Service) LinkWallet(
 
 	transactionInfo, err := wallet.VerifyTransaction(ctx, transaction)
 	if err != nil {
-		return handlers.WrapError(
+		return "", handlers.WrapError(
 			errors.New("failed to verify transaction"), "transaction verification failure",
 			http.StatusForbidden)
 	}
@@ -595,28 +600,28 @@ func (service *Service) LinkWallet(
 		// get the rewards wallet id from the uphold wallet info
 		infoID, infoIDErr := uuid.FromString(info.ID)
 		if infoIDErr != nil {
-			return fmt.Errorf("failed to parse uphold id: %w", infoIDErr)
+			return "", fmt.Errorf("failed to parse uphold id: %w", infoIDErr)
 		}
 		// check if this gemini accountID has already been linked to this wallet,
 		if errors.Is(err, errorutils.ErrInvalidCountry) {
 			ok, priorLinkingErr := service.Datastore.HasPriorLinking(
 				ctx, infoID, uuid.NewV5(ClaimNamespace, userID))
 			if priorLinkingErr != nil && !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("failed to check prior linkings: %w", priorLinkingErr)
+				return "", fmt.Errorf("failed to check prior linkings: %w", priorLinkingErr)
 			}
 			// if a wallet has a prior linking to this account, allow the invalid country, otherwise
 			// return the kyc error
 			if !ok {
 				// then pass back the original geo error
-				return err
+				return "", err
 			}
 			// allow invalid country if there was a prior linking
 		} else {
-			return fmt.Errorf("wallet could not be kyc checked: %w", err)
+			return "", fmt.Errorf("wallet could not be kyc checked: %w", err)
 		}
 	} else if !ok {
 		// fail
-		return handlers.WrapError(
+		return "", handlers.WrapError(
 			errors.New("user kyc did not pass"),
 			"KYC required",
 			http.StatusForbidden)
@@ -627,7 +632,7 @@ func (service *Service) LinkWallet(
 
 	// check kyc user id validity
 	if userID == "" {
-		return handlers.WrapError(
+		return "", handlers.WrapError(
 			errors.New("user id not provided"),
 			"KYC required",
 			http.StatusForbidden)
@@ -640,27 +645,30 @@ func (service *Service) LinkWallet(
 	// tx.Destination will be stored as UserDepositDestination in the wallet info upon linking
 	err = service.Datastore.LinkWallet(ctx, info.ID, transactionInfo.Destination, providerLinkingID, anonymousAddress, depositProvider, country)
 	if err != nil {
+		if errors.Is(err, ErrUnusualActivity) {
+			return "", handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
+		}
+
+		if errors.Is(err, ErrGeoResetDifferent) {
+			return "", handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
+		}
+
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrTooManyCardsLinked) {
 			status = http.StatusConflict
 		}
-		if errors.Is(err, ErrUnusualActivity) {
-			return handlers.WrapError(err, "unable to link - unusual activity", http.StatusBadRequest)
-		}
-		if errors.Is(err, ErrGeoResetDifferent) {
-			return handlers.WrapError(err, "mismatched provider account regions", http.StatusBadRequest)
-		}
-		return handlers.WrapError(err, "unable to link uphold wallets", status)
+
+		return "", handlers.WrapError(err, "unable to link uphold wallets", status)
 	}
 
 	// if this wallet is linking a deposit account do not submit a transaction
 	if decimal.NewFromFloat(0).LessThan(probi) {
 		_, err := service.SubmitCommitableAnonCardTransaction(ctx, &info, transaction, "", true)
 		if err != nil {
-			return handlers.WrapError(err, "unable to transfer tokens", http.StatusBadRequest)
+			return "", handlers.WrapError(err, "unable to transfer tokens", http.StatusBadRequest)
 		}
 	}
-	return nil
+	return country, nil
 }
 
 // DisconnectCustodianLink - removes the link to the custodian wallet that is active


### PR DESCRIPTION
### Summary

This PR resolves [#133](https://github.com/brave-intl/payment-services/issues/133)  return a users country code in the linking endpoint.

When a user connects their wallet to a custodian the country code will now be returned in the response body. 

This applies to all custodians and both the `/claim` and `/connect` routes; there is no change to the current status codes or error responses.

An example response for the Gemini connect route is shown below -

```
POST v3/wallet/gemini/{paymentID}/connect

Code 200 // this is the current success status code

Response Body
{
    geoCountry : <string>
}
```
 

### Type of change ( select one )

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
