### PR TITLE
numPerInterval for Leo sku is 192, 2 is default

### DIFF
--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -300,6 +300,13 @@ func (s *Service) CreateOrderFromRequest(ctx context.Context, req model.CreateOr
 			return nil, err
 		}
 
+		// TODO: we ultimately need to figure out how to provision numPerInterval and numIntervals
+		// on the order item instead of the order itself to support multiple orders with
+		// different time limited v2 issuers.  For now leo sku needs 192 as num per interval
+		if orderItem.SKU == "brave-leo-premium" {
+			numPerInterval = 192 // 192 credentials per day for leo
+		}
+
 		// Create issuer for sku. This only happens when a new sku is created.
 		switch orderItem.CredentialType {
 		case singleUse:


### PR DESCRIPTION
### Summary

numPerInterval for Leo sku is 192, 2 is default

this will do until  https://github.com/brave-intl/bat-go/issues/1997 is fixed.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
