### PR TITLE
pass nil instead of empty byte array in nitro attestation

### DIFF
--- a/libs/httpsignature/nitro.go
+++ b/libs/httpsignature/nitro.go
@@ -19,7 +19,7 @@ type NitroSigner struct{}
 
 // Sign the message using the nitro signer
 func (s NitroSigner) Sign(rand io.Reader, message []byte, opts crypto.SignerOpts) (signature []byte, err error) {
-	return nitro.Attest(context.Background(), []byte{}, message, []byte{})
+	return nitro.Attest(context.Background(), nil, message, nil)
 }
 
 // NitroVerifier specifies the PCR values required for verification


### PR DESCRIPTION
### Summary

Pass nil instead of empty byte array in nitro attestation optional fields as currently we're failing validity checks due to array length == 0.

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
