### PR TITLE
always return an AppError from submit endpoint

### DIFF
--- a/libs/payments/submit.go
+++ b/libs/payments/submit.go
@@ -1,7 +1,5 @@
 package payments
 
-import ()
-
 // SubmitRequest is provided to indicate a payment that should be executed.
 type SubmitRequest struct {
 	DocumentID string `json:"documentId,omitempty"`
@@ -10,6 +8,5 @@ type SubmitRequest struct {
 // SubmitResponse is returned to provide the status of a payment after submission, along with any
 // error that resulted, if necessary.
 type SubmitResponse struct {
-	Status    PaymentStatus `json:"status" valid:"required"`
-	LastError *PaymentError `json:"error,omitempty"`
+	Status PaymentStatus `json:"status" valid:"required"`
 }


### PR DESCRIPTION
### Summary

always return an AppError from submit endpoint, this solves serialization issues with PaymentError and makes the return type consistent in all cases

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
