### PR TITLE
remove signing privilege except through PCR check

### DIFF
--- a/services/payments/templates/sign-policy.tmpl
+++ b/services/payments/templates/sign-policy.tmpl
@@ -14,8 +14,7 @@
                 "kms:Enable*",
                 "kms:Describe*",
                 "kms:CreateKey",
-                "kms:CreateAlias",
-                "kms:Sign"
+                "kms:CreateAlias"
             ],
             "Resource": "*"
         },
@@ -84,7 +83,6 @@
           },
           "Condition": {
             "StringLike": {
-            "kms:RecipientAttestation:ImageSha384": "{{.ImageSHA}}",
             "kms:RecipientAttestation:PCR0": "{{.PCR0}}",
             "kms:RecipientAttestation:PCR1": "{{.PCR1}}",
             "kms:RecipientAttestation:PCR2": "{{.PCR2}}"


### PR DESCRIPTION
### Summary

it should not be possible to use the sign operation unless the PCR value check passes...

also removes `ImageSha384` since this corresponds to PCR0 per https://docs.aws.amazon.com/kms/latest/developerguide/conditions-nitro-enclaves.html#conditions-kms-recipient-image-sha

### Type of change ( select one )

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before submitting this PR:

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security / privacy review if needed
- [ ] Have you performed a self review of this PR?

### Manual Test Plan:

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
