### PR TITLE
Multiple Items vs DeleteOrderCreds

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -657,12 +657,13 @@ func DeleteOrderCreds(service *Service) handlers.AppHandler {
 			)
 		}
 
-		if err := service.validateOrderMerchantAndCaveats(ctx, *orderID.UUID()); err != nil {
+		id := *orderID.UUID()
+		if err := service.validateOrderMerchantAndCaveats(ctx, id); err != nil {
 			return handlers.WrapError(err, "Error validating auth merchant and caveats", http.StatusForbidden)
 		}
 
 		isSigned := r.URL.Query().Get("isSigned") == "true"
-		if err := service.DeleteOrderCreds(ctx, *orderID.UUID(), isSigned); err != nil {
+		if err := service.DeleteOrderCreds(ctx, id, isSigned); err != nil {
 			return handlers.WrapError(err, "Error deleting credentials", http.StatusBadRequest)
 		}
 

--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -616,8 +616,7 @@ func (s *Service) DeleteOrderCreds(ctx context.Context, orderID uuid.UUID, isSig
 		return err
 	}
 
-	nitems := len(order.Items)
-	if nitems == 0 {
+	if len(order.Items) == 0 {
 		return ErrOrderHasNoItems
 	}
 

--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -620,16 +620,7 @@ func (s *Service) DeleteOrderCreds(ctx context.Context, orderID uuid.UUID, isSig
 		return ErrOrderHasNoItems
 	}
 
-	var doSingleUse, doTlv2 bool
-
-	for i := range order.Items {
-		switch order.Items[i].CredentialType {
-		case singleUse:
-			doSingleUse = true
-		case timeLimitedV2:
-			doTlv2 = true
-		}
-	}
+	doSingleUse, doTlv2 := doItemsHaveSUOrTlv2(order.Items)
 
 	// Handle special cases:
 	// - 1 item with time-limited credential type;
@@ -699,4 +690,19 @@ func checkNumBlindedCreds(ord *model.Order, item *model.OrderItem, ncreds int) e
 	default:
 		return nil
 	}
+}
+
+func doItemsHaveSUOrTlv2(items []model.OrderItem) (bool, bool) {
+	var hasSingleUse, hasTlv2 bool
+
+	for i := range items {
+		switch items[i].CredentialType {
+		case singleUse:
+			hasSingleUse = true
+		case timeLimitedV2:
+			hasTlv2 = true
+		}
+	}
+
+	return hasSingleUse, hasTlv2
 }

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -190,14 +190,11 @@ func getEmailFromCheckoutSession(stripeSession *stripe.CheckoutSession) string {
 	return email
 }
 
-// RenewOrder updates the orders status to paid and paid at time, inserts record of this order
+// RenewOrder updates the order status to paid and records payment history.
+//
 // Status should either be one of pending, paid, fulfilled, or canceled.
 func (s *Service) RenewOrder(ctx context.Context, orderID uuid.UUID) error {
-
-	// renew order is an update order with paid status
-	// and an update order expires at with the new expiry time of the order
-	err := s.Datastore.UpdateOrder(orderID, OrderStatusPaid) // this performs a record order payment
-	if err != nil {
+	if err := s.Datastore.UpdateOrder(orderID, OrderStatusPaid); err != nil {
 		return fmt.Errorf("failed to set order status to paid: %w", err)
 	}
 

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -244,3 +244,138 @@ func TestCheckNumBlindedCreds(t *testing.T) {
 		})
 	}
 }
+
+func TestDoItemsHaveSUOrTlv2(t *testing.T) {
+	type testCase struct {
+		name    string
+		given   []model.OrderItem
+		expSU   bool
+		expTlv2 bool
+	}
+
+	tests := []testCase{
+		{
+			name: "nil",
+		},
+
+		{
+			name:  "empty",
+			given: []model.OrderItem{},
+		},
+
+		{
+			name: "one_single_use",
+			given: []model.OrderItem{
+				{
+					CredentialType: singleUse,
+				},
+			},
+			expSU: true,
+		},
+
+		{
+			name: "two_single_use",
+			given: []model.OrderItem{
+				{
+					CredentialType: singleUse,
+				},
+
+				{
+					CredentialType: singleUse,
+				},
+			},
+			expSU: true,
+		},
+
+		{
+			name: "one_time_limited",
+			given: []model.OrderItem{
+				{
+					CredentialType: timeLimited,
+				},
+			},
+		},
+
+		{
+			name: "two_time_limited",
+			given: []model.OrderItem{
+				{
+					CredentialType: timeLimited,
+				},
+
+				{
+					CredentialType: timeLimited,
+				},
+			},
+		},
+
+		{
+			name: "one_time_limited_v2",
+			given: []model.OrderItem{
+				{
+					CredentialType: timeLimitedV2,
+				},
+			},
+			expTlv2: true,
+		},
+
+		{
+			name: "two_time_limited_v2",
+			given: []model.OrderItem{
+				{
+					CredentialType: timeLimitedV2,
+				},
+
+				{
+					CredentialType: timeLimitedV2,
+				},
+			},
+			expTlv2: true,
+		},
+
+		{
+			name: "one_single_use_one_time_limited_v2",
+			given: []model.OrderItem{
+				{
+					CredentialType: singleUse,
+				},
+
+				{
+					CredentialType: timeLimitedV2,
+				},
+			},
+			expSU:   true,
+			expTlv2: true,
+		},
+
+		{
+			name: "all_one",
+			given: []model.OrderItem{
+				{
+					CredentialType: singleUse,
+				},
+
+				{
+					CredentialType: timeLimited,
+				},
+
+				{
+					CredentialType: timeLimitedV2,
+				},
+			},
+			expSU:   true,
+			expTlv2: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			doSingleUse, doTlv2 := doItemsHaveSUOrTlv2(tc.given)
+
+			should.Equal(t, tc.expSU, doSingleUse)
+			should.Equal(t, tc.expTlv2, doTlv2)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

This PR adjusts `DeleteOrderCreds` such that it can handle orders that have multiple items in them. It resolves #2161.

The method deletes credentials by the order id. In case an order has got more than one item, we've got a few possibilities:
- items are of the same credential type:
    - `single-use` -> credentials are deleted by the order id, therefore one deletion is sufficient;
    - `time-limited` -> no-op, early successful termination;
    - `time-limited-v2` -> credentials are deleted by the order id, therefore one deletion is sufficient;
- items are of different credential types:
    - nothing will be done for `time-limited`, as before;
    - in accordance with the description above, credentials of the corresponding types will be deleted, followed by the deletion of the signing request, as before.


### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [x] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [x] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
