### PR TITLE
allow single device refresh

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -573,7 +573,7 @@ func CreateOrderCreds(service *Service) handlers.AppHandler {
 
 		requestID := uuid.NewV4()
 
-		if err := service.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, req.BlindedCreds, requestID); err != nil {
+		if err := service.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, requestID, req.BlindedCreds); err != nil {
 			logger.Error().Err(err).Msg("failed to create the order credentials")
 			return handlers.WrapError(err, "Error creating order creds", http.StatusBadRequest)
 		}

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/cors"
 	uuid "github.com/satori/go.uuid"
-	"github.com/stripe/stripe-go/v72"
+	stripe "github.com/stripe/stripe-go/v72"
 	"github.com/stripe/stripe-go/v72/webhook"
 
 	"github.com/brave-intl/bat-go/libs/clients/radom"
@@ -571,40 +571,9 @@ func CreateOrderCreds(service *Service) handlers.AppHandler {
 			)
 		}
 
-		orderItem, err := service.Datastore.GetOrderItem(ctx, req.ItemID)
-		if err != nil {
-			logger.Error().Err(err).Msg("error getting the order item for creds")
-			return handlers.WrapError(err, "Error validating no credentials exist for order", http.StatusBadRequest)
-		}
+		requestID := uuid.NewV4()
 
-		// TLV2 check to see if we have credentials signed that match incoming blinded tokens
-		if orderItem.CredentialType == timeLimitedV2 {
-			alreadySubmitted, err := service.Datastore.AreTimeLimitedV2CredsSubmitted(ctx, req.BlindedCreds...)
-			if err != nil {
-				// This is an existing error message so don't want to change it incase client are relying on it.
-				return handlers.WrapError(err, "Error validating credentials exist for order", http.StatusBadRequest)
-			}
-			if alreadySubmitted {
-				// since these are already submitted, no need to create order credentials
-				// return ok
-				return handlers.RenderContent(ctx, nil, w, http.StatusOK)
-			}
-		}
-
-		// check if we already have a signing request for this order, delete order creds will
-		// delete the prior signing request.  this allows subscriptions to manage how many
-		// order creds are handed out.
-		signingOrderRequests, err := service.Datastore.GetSigningOrderRequestOutboxByOrderItem(ctx, req.ItemID)
-		if err != nil {
-			// This is an existing error message so don't want to change it incase client are relying on it.
-			return handlers.WrapError(err, "Error validating no credentials exist for order", http.StatusBadRequest)
-		}
-
-		if len(signingOrderRequests) > 0 {
-			return handlers.WrapError(err, "There are existing order credentials created for this order", http.StatusConflict)
-		}
-
-		if err := service.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, req.BlindedCreds); err != nil {
+		if err := service.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, req.BlindedCreds, requestID); err != nil {
 			logger.Error().Err(err).Msg("failed to create the order credentials")
 			return handlers.WrapError(err, "Error creating order creds", http.StatusBadRequest)
 		}

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -1815,13 +1815,13 @@ func (suite *ControllersTestSuite) TestCreateOrderCreds_SingleUse_ExistingOrderC
 		order.ID), bytes.NewBuffer(payload)).WithContext(ctx)
 
 	server.Handler.ServeHTTP(rw, r)
-	suite.Assert().Equal(http.StatusConflict, rw.Code)
+	suite.Assert().Equal(http.StatusBadRequest, rw.Code)
 
 	var appError handlers.AppError
 	err = json.NewDecoder(rw.Body).Decode(&appError)
 	suite.Require().NoError(err)
 
-	suite.Assert().Equal(http.StatusConflict, appError.Code)
+	suite.Assert().Equal(http.StatusBadRequest, appError.Code)
 	suite.Assert().Contains(appError.Error(), "There are existing order credentials created for this order")
 }
 

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -1822,7 +1822,7 @@ func (suite *ControllersTestSuite) TestCreateOrderCreds_SingleUse_ExistingOrderC
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(http.StatusBadRequest, appError.Code)
-	suite.Assert().Contains(appError.Error(), ErrExistingCredentials.Error())
+	suite.Assert().Contains(appError.Error(), ErrCredsAlreadyExist.Error())
 }
 
 // ReadSigningOrderRequestMessage reads messages from the unsigned order request topic

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -1822,7 +1822,7 @@ func (suite *ControllersTestSuite) TestCreateOrderCreds_SingleUse_ExistingOrderC
 	suite.Require().NoError(err)
 
 	suite.Assert().Equal(http.StatusBadRequest, appError.Code)
-	suite.Assert().Contains(appError.Error(), "There are existing order credentials created for this order")
+	suite.Assert().Contains(appError.Error(), ErrExistingCredentials.Error())
 }
 
 // ReadSigningOrderRequestMessage reads messages from the unsigned order request topic

--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -1000,7 +1000,7 @@ func (pg *Postgres) GetTimeLimitedV2OrderCredsByOrderItem(itemID uuid.UUID) (*Ti
 		select order_id, item_id, issuer_id, blinded_creds, signed_creds, batch_proof, public_key,
 		valid_from, valid_to
 		from time_limited_v2_order_creds
-		where item_id = $1
+		where item_id = $1 and valid_to > now()
 	`
 
 	var timeAwareSubIssuedCreds []TimeAwareSubIssuedCreds


### PR DESCRIPTION
### Summary

this PR allows for automatic single device refresh of credentials once all existing credentials have expired. to do so it:

- moves request id generation and checks for existing credentials in preparation for adding endpoint variants that operate on a request id basis. ( NOTE: this changes the response code for credential conflict - I have verified that the SKU SDK does not depend on it. )
- checks the `time_limited_v2_order_creds` table instead of `signing_order_request_outbox` when rejecting tlv2 signing attempts due to existing credentials, this allows us to easily take the credential expiry into account. ( NOTE: this creates a potential race condition between clients when submitting, however only one can succeed. I've left more thorough notes about this race in a comment within the PR. )

fixes: #2010

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
