### PR TITLE
Multiple Items vs CreateOrderCreds

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -539,30 +539,26 @@ type CreateOrderCredsRequest struct {
 	BlindedCreds []string  `json:"blindedCreds" valid:"base64"`
 }
 
-// CreateOrderCreds is the handler for creating order credentials
-func CreateOrderCreds(service *Service) handlers.AppHandler {
+// CreateOrderCreds handles requests for creating credentials.
+func CreateOrderCreds(svc *Service) handlers.AppHandler {
 	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-		var (
-			req    = new(CreateOrderCredsRequest)
-			ctx    = r.Context()
-			logger = logging.Logger(ctx, "skus.CreateOrderCreds")
-		)
+		ctx := r.Context()
+		lg := logging.Logger(ctx, "skus.CreateOrderCreds")
 
-		err := requestutils.ReadJSON(ctx, r.Body, req)
-		if err != nil {
-			logger.Error().Err(err).Msg("failed to read body payload")
+		req := &CreateOrderCredsRequest{}
+		if err := requestutils.ReadJSON(ctx, r.Body, req); err != nil {
+			lg.Error().Err(err).Msg("failed to read body payload")
 			return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)
 		}
 
-		_, err = govalidator.ValidateStruct(req)
-		if err != nil {
-			logger.Error().Err(err).Msg("failed to validate struct")
+		if _, err := govalidator.ValidateStruct(req); err != nil {
+			lg.Error().Err(err).Msg("failed to validate struct")
 			return handlers.WrapValidationError(err)
 		}
 
-		var orderID = new(inputs.ID)
+		orderID := &inputs.ID{}
 		if err := inputs.DecodeAndValidateString(ctx, orderID, chi.URLParam(r, "orderID")); err != nil {
-			logger.Error().Err(err).Msg("failed to validate order id")
+			lg.Error().Err(err).Msg("failed to validate order id")
 			return handlers.ValidationError(
 				"Error validating request url parameter",
 				map[string]interface{}{
@@ -573,8 +569,8 @@ func CreateOrderCreds(service *Service) handlers.AppHandler {
 
 		requestID := uuid.NewV4()
 
-		if err := service.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, requestID, req.BlindedCreds); err != nil {
-			logger.Error().Err(err).Msg("failed to create the order credentials")
+		if err := svc.CreateOrderItemCredentials(ctx, *orderID.UUID(), req.ItemID, requestID, req.BlindedCreds); err != nil {
+			lg.Error().Err(err).Msg("failed to create the order credentials")
 			return handlers.WrapError(err, "Error creating order creds", http.StatusBadRequest)
 		}
 

--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -1118,18 +1118,15 @@ func (pg *Postgres) UpdateSigningOrderRequestOutboxTx(ctx context.Context, tx *s
 	return nil
 }
 
-// InsertSigningOrderRequestOutbox insert the signing order request into the outbox.
-func (pg *Postgres) InsertSigningOrderRequestOutbox(ctx context.Context, requestID uuid.UUID, orderID uuid.UUID,
-	itemID uuid.UUID, signingOrderRequest SigningOrderRequest) error {
-
+// InsertSigningOrderRequestOutbox inserts the signing order request into the outbox.
+func (pg *Postgres) InsertSigningOrderRequestOutbox(ctx context.Context, requestID, orderID, itemID uuid.UUID, signingOrderRequest SigningOrderRequest) error {
 	message, err := json.Marshal(signingOrderRequest)
 	if err != nil {
 		return fmt.Errorf("error marshalling signing order request: %w", err)
 	}
 
-	_, err = pg.ExecContext(ctx, `insert into signing_order_request_outbox(request_id, order_id, item_id, message_data)
-											values ($1, $2, $3, $4)`, requestID, orderID, itemID, message)
-	if err != nil {
+	const q = `INSERT INTO signing_order_request_outbox (request_id, order_id, item_id, message_data) VALUES ($1, $2, $3, $4)`
+	if _, err := pg.ExecContext(ctx, q, requestID, orderID, itemID, message); err != nil {
 		return fmt.Errorf("error inserting order request outbox row: %w", err)
 	}
 


### PR DESCRIPTION
### Summary

This PR resolves #2171. Improves #2163.

This PR initially was my feedback to #2163 but it had not been merged prior to the original PR making its way to `master`. I continued looking at `CreateOrderCreds` and `CreateOrderItemCredentials` in the lights of making sure that it supports multiple items.

As a result, I conclude the method works on a per-item basis, and it _should_ work for a multi-item order (since there will be signing requests per item). Along the way, I've tidied up the things that attracted my attention.

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [x] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
