### PR TITLE
Add bonk mapping for ratios service

### DIFF
--- a/services/ratios/mapping.go
+++ b/services/ratios/mapping.go
@@ -39,6 +39,7 @@ var (
 		"bnb":    "binancecoin",
 		"boa":    "bosagora",
 		"bob":    "bobs_repair",
+		"bonk":   "bonk",
 		"boo":    "boo",
 		"booty":  "candybooty",
 		"box":    "box-token",


### PR DESCRIPTION
### Summary

Querying price for Bonk reports incorrect result:

```sh
$ curl -s https://ratios.rewards.brave.com/v2/relative/provider/coingecko/bonk/usd/1d | jq '.payload.bonk.usd'
0.01289504  # expected 0.00001355
```

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

Correct price and price history should be visible in Brave Wallet for Bonk Coin (BONK) token on Solana.