### PR TITLE
Add self custody available field to get wallet endpoint

### DIFF
--- a/services/wallet/controller_v3_test.go
+++ b/services/wallet/controller_v3_test.go
@@ -595,51 +595,6 @@ func (suite *WalletControllersTestSuite) getWallet(service *wallet.Service, paym
 	return rr.Body.String()
 }
 
-func (suite *WalletControllersTestSuite) TestGetWalletV4() {
-	pg, _, err := wallet.NewPostgres()
-	suite.Require().NoError(err)
-
-	pub, _, err := ed25519.GenerateKey(nil)
-	suite.Require().NoError(err)
-
-	paymentID := uuid.NewV4()
-	w := &walletutils.Info{
-		ID:          paymentID.String(),
-		Provider:    "brave",
-		PublicKey:   hex.EncodeToString(pub),
-		AltCurrency: ptrTo(altcurrency.BAT),
-	}
-	err = pg.InsertWallet(context.TODO(), w)
-	suite.Require().NoError(err)
-
-	whitelistWallet(suite.T(), pg, w.ID)
-
-	allowList := storage.NewAllowList()
-
-	service, _ := wallet.InitService(pg, nil, nil, allowList, nil, nil, nil, nil, nil, nil, wallet.DAppConfig{})
-
-	handler := handlers.AppHandler(wallet.GetWalletV4(service))
-
-	req, err := http.NewRequest("GET", "/v4/wallets/"+paymentID.String(), nil)
-	suite.Require().NoError(err, "a request should be created")
-
-	req = req.WithContext(context.WithValue(req.Context(), appctx.NoUnlinkPriorToDurationCTXKey, "-P1D"))
-	rctx := chi.NewRouteContext()
-	rctx.URLParams.Add("paymentID", paymentID.String())
-	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	suite.Assert().Equal(http.StatusOK, rr.Code)
-
-	var resp wallet.ResponseV4
-	err = json.Unmarshal(rr.Body.Bytes(), &resp)
-	suite.Require().NoError(err)
-
-	suite.Assert().Equal(true, resp.SelfCustodyAvailable["solana"])
-}
-
 func (suite *WalletControllersTestSuite) createBraveWalletV3(
 	service *wallet.Service,
 	body string,

--- a/services/wallet/controller_v3_test.go
+++ b/services/wallet/controller_v3_test.go
@@ -595,6 +595,51 @@ func (suite *WalletControllersTestSuite) getWallet(service *wallet.Service, paym
 	return rr.Body.String()
 }
 
+func (suite *WalletControllersTestSuite) TestGetWalletV4() {
+	pg, _, err := wallet.NewPostgres()
+	suite.Require().NoError(err)
+
+	pub, _, err := ed25519.GenerateKey(nil)
+	suite.Require().NoError(err)
+
+	paymentID := uuid.NewV4()
+	w := &walletutils.Info{
+		ID:          paymentID.String(),
+		Provider:    "brave",
+		PublicKey:   hex.EncodeToString(pub),
+		AltCurrency: ptrTo(altcurrency.BAT),
+	}
+	err = pg.InsertWallet(context.TODO(), w)
+	suite.Require().NoError(err)
+
+	whitelistWallet(suite.T(), pg, w.ID)
+
+	allowList := storage.NewAllowList()
+
+	service, _ := wallet.InitService(pg, nil, nil, allowList, nil, nil, nil, nil, nil, nil, wallet.DAppConfig{})
+
+	handler := handlers.AppHandler(wallet.GetWalletV4(service))
+
+	req, err := http.NewRequest("GET", "/v4/wallets/"+paymentID.String(), nil)
+	suite.Require().NoError(err, "a request should be created")
+
+	req = req.WithContext(context.WithValue(req.Context(), appctx.NoUnlinkPriorToDurationCTXKey, "-P1D"))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("paymentID", paymentID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	suite.Assert().Equal(http.StatusOK, rr.Code)
+
+	var resp wallet.ResponseV4
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(true, resp.SelfCustodyAvailable["solana"])
+}
+
 func (suite *WalletControllersTestSuite) createBraveWalletV3(
 	service *wallet.Service,
 	body string,

--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -11,8 +11,10 @@ import (
 	errorutils "github.com/brave-intl/bat-go/libs/errors"
 	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/libs/httpsignature"
+	"github.com/brave-intl/bat-go/libs/inputs"
 	"github.com/brave-intl/bat-go/libs/logging"
 	"github.com/brave-intl/bat-go/libs/middleware"
+	"github.com/brave-intl/bat-go/services/wallet/model"
 	"github.com/go-chi/chi"
 )
 
@@ -167,12 +169,46 @@ func UpdateWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *ha
 	}
 }
 
-// GetWalletV4 is the same as get wallet v3, but we are now requiring http signatures for get wallet requests
-func GetWalletV4(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-	return GetWalletV3(w, r)
-}
-
 // GetUpholdWalletBalanceV4 produces an http handler for the service s which handles balance inquiries of uphold wallets
 func GetUpholdWalletBalanceV4(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	return GetUpholdWalletBalanceV3(w, r)
+}
+
+func GetWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		var ctx = r.Context()
+
+		l := logging.Logger(ctx, "wallet")
+
+		var id inputs.ID
+		if err := inputs.DecodeAndValidateString(ctx, &id, chi.URLParam(r, "paymentID")); err != nil {
+			l.Warn().Err(err).Str("paymentID", id.String()).Msg("failed to decode and validate paymentID from url")
+			return handlers.ValidationError("Error validating paymentID url parameter", map[string]interface{}{
+				"paymentId": err.Error(),
+			})
+		}
+
+		paymentID := *id.UUID()
+
+		info, err := s.Datastore.GetWallet(ctx, paymentID)
+		if err != nil {
+			l.Error().Err(err).Str("paymentID", id.String()).Msg("error getting wallet")
+			return handlers.WrapError(err, "error getting wallet from storage", http.StatusInternalServerError)
+		}
+
+		if info == nil {
+			l.Info().Interface("paymentID", paymentID).Msg("wallet not found")
+			return handlers.WrapError(err, "no such wallet", http.StatusNotFound)
+		}
+
+		if _, err := s.allowListRepo.GetAllowListEntry(ctx, s.Datastore.RawDB(), paymentID); err != nil && !errors.Is(err, model.ErrNotFound) {
+			return handlers.WrapError(err, "error getting allow list entry from storage", http.StatusInternalServerError)
+		}
+
+		solSelfCustody := !errors.Is(err, model.ErrNotFound)
+
+		resp := infoToResponseV4(info, solSelfCustody)
+
+		return handlers.RenderContent(ctx, resp, w, http.StatusOK)
+	}
 }

--- a/services/wallet/controllers_v4_test.go
+++ b/services/wallet/controllers_v4_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ed25519"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,8 +15,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	appctx "github.com/brave-intl/bat-go/libs/context"
 	errorutils "github.com/brave-intl/bat-go/libs/errors"
 	"github.com/brave-intl/bat-go/libs/middleware"
+	"github.com/brave-intl/bat-go/services/wallet/storage"
 
 	"github.com/brave-intl/bat-go/libs/clients"
 
@@ -556,6 +559,51 @@ func (suite *WalletControllersV4TestSuite) TestUpdateBraveWalletV4_ReputationCal
 	server.Handler.ServeHTTP(rw, request)
 
 	suite.Require().Equal(http.StatusInternalServerError, rw.Code)
+}
+
+func (suite *WalletControllersTestSuite) TestGetWalletV4() {
+	pg, _, err := wallet.NewPostgres()
+	suite.Require().NoError(err)
+
+	pub, _, err := ed25519.GenerateKey(nil)
+	suite.Require().NoError(err)
+
+	paymentID := uuid.NewV4()
+	w := &walletutils.Info{
+		ID:          paymentID.String(),
+		Provider:    "brave",
+		PublicKey:   hex.EncodeToString(pub),
+		AltCurrency: ptrTo(altcurrency.BAT),
+	}
+	err = pg.InsertWallet(context.TODO(), w)
+	suite.Require().NoError(err)
+
+	whitelistWallet(suite.T(), pg, w.ID)
+
+	allowList := storage.NewAllowList()
+
+	service, _ := wallet.InitService(pg, nil, nil, allowList, nil, nil, nil, nil, nil, nil, wallet.DAppConfig{})
+
+	handler := handlers.AppHandler(wallet.GetWalletV4(service))
+
+	req, err := http.NewRequest("GET", "/v4/wallets/"+paymentID.String(), nil)
+	suite.Require().NoError(err, "a request should be created")
+
+	req = req.WithContext(context.WithValue(req.Context(), appctx.NoUnlinkPriorToDurationCTXKey, "-P1D"))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("paymentID", paymentID.String())
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	suite.Assert().Equal(http.StatusOK, rr.Code)
+
+	var resp wallet.ResponseV4
+	err = json.Unmarshal(rr.Body.Bytes(), &resp)
+	suite.Require().NoError(err)
+
+	suite.Assert().Equal(true, resp.SelfCustodyAvailable["solana"])
 }
 
 func signUpdateRequest(req *http.Request, paymentID string, privateKey ed25519.PrivateKey) error {

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -386,7 +386,7 @@ func RegisterRoutes(ctx context.Context, s *Service, r *chi.Mux, metricsMw middl
 			"UpdateWalletV4", UpdateWalletV4(s))).ServeHTTP)
 		r.Get("/{paymentID}",
 			middleware.HTTPSignedOnly(s)(middleware.InstrumentHandlerFunc(
-				"GetWalletV4", GetWalletV4)).ServeHTTP)
+				"GetWalletV4", GetWalletV4(s))).ServeHTTP)
 		// get wallet balance routes
 		r.Get("/uphold/{paymentID}",
 			middleware.HTTPSignedOnly(s)(middleware.InstrumentHandlerFunc(


### PR DESCRIPTION
### Summary
This PR adds the self custody available field to get wallet endpoint.

The endpoint should the below response with the new `selfCustodyAvailable` field. 
```
{
  "paymentId": "af5f35a5-1809-4e73-91c4-59b8dbe3a42f",
  "walletProvider": {
    "id": "",
    "name": "brave"
  },
  "altcurrency": "BAT",
  "publicKey": "485c991e35fea0a174786eb9062a76ba6aa7c8bedf1d438a200205475f73db4f",
  "selfCustodyAvailable": {
    "solana": true
  }
}
```
this is a map of providers, currently we only have one Solana.

Please see the spec in the linked issue for more detail.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
resolves [168](https://github.com/brave-intl/payment-services/issues/168)

### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
