### PR TITLE
Fix: Set Proper Type for Android Vendor

### DIFF
--- a/services/skus/input.go
+++ b/services/skus/input.go
@@ -130,7 +130,7 @@ func credentialOpaqueFromString(s string) (*VerifyCredentialOpaque, error) {
 
 const (
 	appleVendor  Vendor = "ios"
-	googleVendor        = "android"
+	googleVendor Vendor = "android"
 )
 
 var errInvalidVendor = errors.New("invalid vendor")


### PR DESCRIPTION
### Summary

The `googleVendor` constant has been improperly typed – instead of being given `Vendor` type, as the other constant, it was left untyped. The code worked anyway as untyped constants do automatically get a type, if possible, when are passed.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
