### PR TITLE
feat: remove expired challenges from the database

### DIFF
--- a/services/wallet/storage/storage_test.go
+++ b/services/wallet/storage/storage_test.go
@@ -313,16 +313,16 @@ func TestChallenge_DeleteAfter(t *testing.T) {
 
 			c := Challenge{}
 
-			for i := range tc.given.challenges {
-				err := c.Upsert(ctx, dbi, tc.given.challenges[i])
+			for j := range tc.given.challenges {
+				err := c.Upsert(ctx, dbi, tc.given.challenges[j])
 				must.NoError(t, err)
 			}
 
 			err := c.DeleteAfter(ctx, dbi, tc.given.interval)
 			must.Equal(t, tc.exp.errDel, err)
 
-			for i := range tc.given.challenges {
-				_, err := c.Get(ctx, dbi, tc.given.challenges[i].PaymentID)
+			for j := range tc.given.challenges {
+				_, err := c.Get(ctx, dbi, tc.given.challenges[j].PaymentID)
 				must.Equal(t, tc.exp.errGet, err)
 			}
 		})

--- a/services/wallet/storage/storage_test.go
+++ b/services/wallet/storage/storage_test.go
@@ -217,6 +217,118 @@ func TestChallenge_Delete(t *testing.T) {
 	}
 }
 
+func TestChallenge_DeleteAfter(t *testing.T) {
+	dbi, err := setupDBI()
+	must.NoError(t, err)
+
+	defer func() {
+		_, _ = dbi.Exec("TRUNCATE_TABLE challenge;")
+	}()
+
+	type tcGiven struct {
+		interval   time.Duration
+		challenges []model.Challenge
+	}
+
+	type exp struct {
+		errDel error
+		errGet error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   exp
+	}
+
+	tests := []testCase{
+		{
+			name: "delete_single",
+			given: tcGiven{
+				interval: 1,
+				challenges: []model.Challenge{
+					{
+						PaymentID: uuid.NewV4(),
+						CreatedAt: time.Now().Add(-6 * time.Minute),
+						Nonce:     "nonce-1",
+					},
+				},
+			},
+			exp: exp{
+				errDel: nil,
+				errGet: model.ErrChallengeNotFound,
+			},
+		},
+		{
+			name: "delete_multiple",
+			given: tcGiven{
+				interval: 1,
+				challenges: []model.Challenge{
+					{
+						PaymentID: uuid.NewV4(),
+						CreatedAt: time.Now().Add(-6 * time.Minute),
+						Nonce:     "nonce-1",
+					},
+					{
+						PaymentID: uuid.NewV4(),
+						CreatedAt: time.Now().Add(-10 * time.Minute),
+						Nonce:     "nonce-2",
+					},
+				},
+			},
+			exp: exp{
+				errDel: nil,
+				errGet: model.ErrChallengeNotFound,
+			},
+		},
+		{
+			name: "delete_none",
+			given: tcGiven{
+				interval: 1,
+				challenges: []model.Challenge{
+					{
+						PaymentID: uuid.NewV4(),
+						CreatedAt: time.Now(),
+						Nonce:     "nonce-1",
+					},
+					{
+						PaymentID: uuid.NewV4(),
+						CreatedAt: time.Now(),
+						Nonce:     "nonce-2",
+					},
+				},
+			},
+			exp: exp{
+				errDel: model.ErrNoRowsDeleted,
+				errGet: nil,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			c := Challenge{}
+
+			for i := range tc.given.challenges {
+				err := c.Upsert(ctx, dbi, tc.given.challenges[i])
+				must.NoError(t, err)
+			}
+
+			err := c.DeleteAfter(ctx, dbi, tc.given.interval)
+			must.Equal(t, tc.exp.errDel, err)
+
+			for i := range tc.given.challenges {
+				_, err := c.Get(ctx, dbi, tc.given.challenges[i].PaymentID)
+				must.Equal(t, tc.exp.errGet, err)
+			}
+		})
+	}
+}
+
 func TestAllowList_GetAllowListEntry(t *testing.T) {
 	dbi, err := setupDBI()
 	must.NoError(t, err)


### PR DESCRIPTION
### Summary
This PR implements a job to remove expired challenges from the database.

Currently the interval is hard codded to 5 minutes which was specified in the spec. This can be parameterised in a future PR if necessary.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
resolves [#185](https://github.com/brave-intl/payment-services/issues/185)

### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
