### PR TITLE
fix: fix legacy creds by item id

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -761,7 +761,7 @@ func getOrderCredsByID(svc *Service, legacyMode bool) handlers.AppHandler {
 		if legacyMode {
 			suCreds, ok := creds.([]OrderCreds)
 			if !ok {
-				return handlers.WrapError(err, "Error getting credentials", http.StatusNotFound)
+				return handlers.WrapError(err, "Error getting credentials", http.StatusInternalServerError)
 			}
 
 			for i := range suCreds {

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -757,11 +757,20 @@ func getOrderCredsByID(svc *Service, legacyMode bool) handlers.AppHandler {
 			w.Header().Set("Retry-After", strconv.FormatInt(avg, 10))
 		}
 
-		if creds == nil {
-			return handlers.RenderContent(ctx, map[string]interface{}{}, w, status)
-		}
+		if legacyMode {
+			for _, oc := range creds.([]OrderCreds) {
+				if uuid.Equal(oc.ID, *itemID.UUID()) {
+					return handlers.RenderContent(ctx, oc, w, status)
+				}
+			}
+			return handlers.WrapError(err, "Error getting credentials", http.StatusNotFound)
+		} else {
+			if creds == nil {
+				return handlers.RenderContent(ctx, map[string]interface{}{}, w, status)
+			}
 
-		return handlers.RenderContent(ctx, creds, w, status)
+			return handlers.RenderContent(ctx, creds, w, status)
+		}
 	})
 }
 

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -764,13 +764,13 @@ func getOrderCredsByID(svc *Service, legacyMode bool) handlers.AppHandler {
 				}
 			}
 			return handlers.WrapError(err, "Error getting credentials", http.StatusNotFound)
-		} else {
-			if creds == nil {
-				return handlers.RenderContent(ctx, map[string]interface{}{}, w, status)
-			}
-
-			return handlers.RenderContent(ctx, creds, w, status)
 		}
+
+		if creds == nil {
+			return handlers.RenderContent(ctx, map[string]interface{}{}, w, status)
+		}
+
+		return handlers.RenderContent(ctx, creds, w, status)
 	})
 }
 


### PR DESCRIPTION
### Summary

fixes a bug introduced in https://github.com/brave-intl/bat-go/pull/2183, the return type for the legacy credentials by id endpoint was changed from an `OrderCreds` object to `[]OrderCreds`.

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
