### PR TITLE
fix: add is allowed check to allow list entry

### DIFF
--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -201,13 +201,14 @@ func GetWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *handl
 			return handlers.WrapError(err, "no such wallet", http.StatusNotFound)
 		}
 
-		if _, err := s.allowListRepo.GetAllowListEntry(ctx, s.Datastore.RawDB(), paymentID); err != nil && !errors.Is(err, model.ErrNotFound) {
+		allow, err := s.allowListRepo.GetAllowListEntry(ctx, s.Datastore.RawDB(), paymentID)
+		if err != nil && !errors.Is(err, model.ErrNotFound) {
 			return handlers.WrapError(err, "error getting allow list entry from storage", http.StatusInternalServerError)
 		}
 
-		solSelfCustody := !errors.Is(err, model.ErrNotFound)
+		isSelfCustAvail := allow.IsAllowed(paymentID)
 
-		resp := infoToResponseV4(info, solSelfCustody)
+		resp := infoToResponseV4(info, isSelfCustAvail)
 
 		return handlers.RenderContent(ctx, resp, w, http.StatusOK)
 	}

--- a/services/wallet/model/model.go
+++ b/services/wallet/model/model.go
@@ -24,6 +24,10 @@ type AllowListEntry struct {
 	CreatedAt time.Time `db:"created_at"`
 }
 
+func (a AllowListEntry) IsAllowed(paymentID uuid.UUID) bool {
+	return !uuid.Equal(a.PaymentID, uuid.Nil) && uuid.Equal(a.PaymentID, paymentID)
+}
+
 type Challenge struct {
 	PaymentID uuid.UUID `db:"payment_id"`
 	CreatedAt time.Time `db:"created_at"`

--- a/services/wallet/model/model_test.go
+++ b/services/wallet/model/model_test.go
@@ -4,8 +4,71 @@ import (
 	"testing"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestAllowListEntry_IsAllowed(t *testing.T) {
+	type tcGiven struct {
+		allow     AllowListEntry
+		paymentID uuid.UUID
+	}
+
+	type exp struct {
+		isAllowed bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   exp
+	}
+
+	tests := []testCase{
+		{
+			name: "default_allow_list_entry",
+			given: tcGiven{
+				paymentID: uuid.FromStringOrNil("dc5a802a-87e9-47a5-9d9c-af4c8f171bf3"),
+			},
+			exp: exp{isAllowed: false},
+		},
+		{
+			name: "payment_id_nil",
+			given: tcGiven{
+				paymentID: uuid.Nil,
+			},
+			exp: exp{isAllowed: false},
+		},
+		{
+			name: "payment_ids_not_equal",
+			given: tcGiven{
+				allow: AllowListEntry{
+					PaymentID: uuid.FromStringOrNil("d1359406-42f1-4364-99b7-77840e8594e8"),
+				},
+				paymentID: uuid.FromStringOrNil("dc5a802a-87e9-47a5-9d9c-af4c8f171bf3"),
+			},
+			exp: exp{isAllowed: false},
+		},
+		{
+			name: "payment_ids_are_equal",
+			given: tcGiven{
+				allow: AllowListEntry{
+					PaymentID: uuid.FromStringOrNil("356a634a-dbae-4f95-b276-f3f0f0a53509"),
+				},
+				paymentID: uuid.FromStringOrNil("356a634a-dbae-4f95-b276-f3f0f0a53509"),
+			},
+			exp: exp{isAllowed: true},
+		},
+	}
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.allow.IsAllowed(tc.given.paymentID)
+			assert.Equal(t, tc.exp.isAllowed, actual)
+		})
+	}
+}
 
 func TestChallenge_IsValid(t *testing.T) {
 	type tcGiven struct {


### PR DESCRIPTION
### Summary
This PR adds an is allowed method to the allow list entry model and use this in the `GET v4/wallets` endpoint to determine whether self custody is available.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
