### PR TITLE
fix: use equals check for payment id validation instead of govalidator on challenge endpoint

### DIFF
--- a/services/wallet/controllers_v3.go
+++ b/services/wallet/controllers_v3.go
@@ -519,7 +519,7 @@ func LinkSolanaAddress(s *Service) handlers.AppHandler {
 }
 
 type challengeRequest struct {
-	PaymentID uuid.UUID `json:"paymentId" valid:"required"`
+	PaymentID uuid.UUID `json:"paymentId"`
 }
 
 type challengeResponse struct {
@@ -538,8 +538,10 @@ func CreateChallenge(s *Service) handlers.AppHandler {
 			return handlers.WrapError(err, "error decoding body", http.StatusBadRequest)
 		}
 
-		if _, err := govalidator.ValidateStruct(chlReq); err != nil {
-			return handlers.WrapValidationError(err)
+		if uuid.Equal(chlReq.PaymentID, uuid.Nil) {
+			return handlers.ValidationError("request", map[string]interface{}{
+				"paymentID": "cannot be nil or empty",
+			})
 		}
 
 		ctx := r.Context()


### PR DESCRIPTION
### Summary
govalidator returns a false positive when checking the payment id so replace with an equals check.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
resolves [#2338](https://github.com/brave-intl/bat-go/issues/2338)

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
