### PR TITLE
fix query to check for request id conflict case ( mismatch )

### DIFF
--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -975,7 +975,7 @@ func areTimeLimitedV2CredsSubmitted(ctx context.Context, dbi getContext, request
 			select 1 from time_limited_v2_order_creds where blinded_creds->>0 = $1
 		) as already_submitted,
 		exists(
-			select 1 from time_limited_v2_order_creds where blinded_creds->>0 = $1 and request_id != $2
+			select 1 from time_limited_v2_order_creds where blinded_creds->>0 != $1 and request_id = $2
 		) as mismatch
 	`
 	err := dbi.GetContext(ctx, &result, query, blindedCreds[0], requestID)

--- a/services/skus/datastore_noint_test.go
+++ b/services/skus/datastore_noint_test.go
@@ -38,11 +38,31 @@ func TestAreTimeLimitedV2CredsSubmitted(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "mismatch",
+			name: "already_submitted",
 			dbi: &mockGetContext{
 				getContext: func(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
 					*dest.(*AreTimeLimitedV2CredsSubmittedResult) = AreTimeLimitedV2CredsSubmittedResult{
 						AlreadySubmitted: true,
+						Mismatch:         false,
+					}
+					return nil
+				},
+			},
+			given: uuid.Must(uuid.FromString("8f51f9ca-b593-4200-9bfb-91ac34748e09")),
+			exp: tcExpected{
+				noErr: true,
+				result: map[string]bool{
+					"alreadySubmitted": true,
+					"mismatch": false,
+				},
+			},
+		},
+		{
+			name: "mismatch",
+			dbi: &mockGetContext{
+				getContext: func(ctx context.Context, dest interface{}, query string, args ...interface{}) error {
+					*dest.(*AreTimeLimitedV2CredsSubmittedResult) = AreTimeLimitedV2CredsSubmittedResult{
+						AlreadySubmitted: false,
 						Mismatch:         true,
 					}
 					return nil
@@ -52,6 +72,7 @@ func TestAreTimeLimitedV2CredsSubmitted(t *testing.T) {
 			exp: tcExpected{
 				noErr: true,
 				result: map[string]bool{
+					"alreadySubmitted": false,
 					"mismatch": true,
 				},
 			},
@@ -63,6 +84,7 @@ func TestAreTimeLimitedV2CredsSubmitted(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := areTimeLimitedV2CredsSubmitted(context.TODO(), tc.dbi, tc.given, "")
+			should.Equal(t, tc.exp.result["alreadySubmitted"], result.AlreadySubmitted)
 			should.Equal(t, tc.exp.result["mismatch"], result.Mismatch)
 			should.Equal(t, tc.exp.noErr, err == nil)
 		})


### PR DESCRIPTION
### Summary
This is a fix for https://github.com/brave-intl/bat-go/pull/2331, when a request id is accidentally re-used - the request id will be present with a different set of credentials than the ones in the attempted submission.

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
