### PR TITLE
fix: don't attempt to cancel sub in Stripe for iOS orders

### DIFF
--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -345,7 +345,7 @@ func (suite *ControllersTestSuite) TestIOSWebhookCertFail() {
 	err := suite.service.Datastore.AppendOrderMetadata(context.Background(), &order.ID, "externalID", "my external id")
 	suite.Require().NoError(err)
 
-	handler := HandleIOSWebhook(suite.service)
+	handler := handleIOSWebhook(suite.service)
 
 	// create a jws message to send
 	body := []byte{}

--- a/services/skus/input.go
+++ b/services/skus/input.go
@@ -244,12 +244,8 @@ type IOSNotification struct {
 
 // Decode - implement Decodable interface
 func (iosn *IOSNotification) Decode(ctx context.Context, data []byte) error {
-	logger := logging.Logger(ctx, "IOSNotification.Decode")
-	logger.Debug().Msg("starting IOSNotification.Decode")
-
 	// json unmarshal the notification
 	if err := json.Unmarshal(data, iosn); err != nil {
-		logger.Error().Msg("failed to json unmarshal body")
 		return errorutils.Wrap(err, "error unmarshalling body")
 	}
 
@@ -266,8 +262,6 @@ func (iosn *IOSNotification) Decode(ctx context.Context, data []byte) error {
 
 // Validate - implement Validable interface
 func (iosn *IOSNotification) Validate(ctx context.Context) error {
-	logger := logging.Logger(ctx, "IOSNotification.Validate")
-
 	// extract the public key from the jws
 	pk, err := extractPublicKey(iosn.SignedPayload)
 	if err != nil {
@@ -278,7 +272,6 @@ func (iosn *IOSNotification) Validate(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to verify jws payload in request: %w", err)
 	}
-	logger.Debug().Msg("validated ios notification")
 
 	iosn.payload = payload
 

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -64,8 +64,9 @@ const (
 )
 
 const (
-	VendorApple  Vendor = "ios"
-	VendorGoogle Vendor = "android"
+	VendorUnknown Vendor = "unknown"
+	VendorApple   Vendor = "ios"
+	VendorGoogle  Vendor = "android"
 )
 
 var (
@@ -316,6 +317,55 @@ func (o *Order) HasItem(id uuid.UUID) (*OrderItem, bool) {
 	}
 
 	return nil, false
+}
+
+func (o *Order) StripeSubID() (string, bool) {
+	sid, ok := o.Metadata["stripeSubscriptionId"].(string)
+
+	return sid, ok
+}
+
+func (o *Order) IsIOS() bool {
+	pp, ok := o.PaymentProc()
+	if !ok {
+		return false
+	}
+
+	vn, ok := o.Vendor()
+	if !ok {
+		return false
+	}
+
+	return pp == "ios" && vn == VendorApple
+}
+
+func (o *Order) IsAndroid() bool {
+	pp, ok := o.PaymentProc()
+	if !ok {
+		return false
+	}
+
+	vn, ok := o.Vendor()
+	if !ok {
+		return false
+	}
+
+	return pp == "android" && vn == VendorGoogle
+}
+
+func (o *Order) PaymentProc() (string, bool) {
+	pp, ok := o.Metadata["paymentProcessor"].(string)
+
+	return pp, ok
+}
+
+func (o *Order) Vendor() (Vendor, bool) {
+	vn, ok := o.Metadata["vendor"].(string)
+	if !ok {
+		return VendorUnknown, false
+	}
+
+	return Vendor(vn), true
 }
 
 // OrderItem represents a particular order item.

--- a/services/skus/model/model_test.go
+++ b/services/skus/model/model_test.go
@@ -698,6 +698,71 @@ func TestOrder_HasItem(t *testing.T) {
 	}
 }
 
+func TestOrder_StripeSubID(t *testing.T) {
+	type tcExpected struct {
+		val string
+		ok  bool
+	}
+
+	type testCase struct {
+		name  string
+		given model.Order
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "no_metadata",
+		},
+
+		{
+			name: "no_field",
+			given: model.Order{
+				Metadata: datastore.Metadata{"key": "value"},
+			},
+		},
+
+		{
+			name: "not_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"stripeSubscriptionId": 42,
+				},
+			},
+		},
+
+		{
+			name: "empty_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"stripeSubscriptionId": "",
+				},
+			},
+			exp: tcExpected{ok: true},
+		},
+
+		{
+			name: "sub_id",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"stripeSubscriptionId": "sub_id",
+				},
+			},
+			exp: tcExpected{val: "sub_id", ok: true},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := tc.given.StripeSubID()
+			should.Equal(t, tc.exp.ok, ok)
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
 func mustDecimalFromString(v string) decimal.Decimal {
 	result, err := decimal.NewFromString(v)
 	if err != nil {

--- a/services/skus/model/model_test.go
+++ b/services/skus/model/model_test.go
@@ -763,6 +763,323 @@ func TestOrder_StripeSubID(t *testing.T) {
 	}
 }
 
+func TestOrder_IsIOS(t *testing.T) {
+	type testCase struct {
+		name  string
+		given model.Order
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "no_metadata",
+		},
+
+		{
+			name: "no_pp",
+			given: model.Order{
+				Metadata: datastore.Metadata{"key": "value"},
+			},
+		},
+
+		{
+			name: "pp_stripe_no_vn",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+				},
+			},
+		},
+
+		{
+			name: "pp_stripe_vn_android",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+					"vendor":           "android",
+				},
+			},
+		},
+
+		{
+			name: "pp_ios_vn_android",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "ios",
+					"vendor":           "android",
+				},
+			},
+		},
+
+		{
+			name: "pp_stripe_vn_ios",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+					"vendor":           "ios",
+				},
+			},
+		},
+
+		{
+			name: "ios",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "ios",
+					"vendor":           "ios",
+				},
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.IsIOS()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestOrder_IsAndroid(t *testing.T) {
+	type testCase struct {
+		name  string
+		given model.Order
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "no_metadata",
+		},
+
+		{
+			name: "no_pp",
+			given: model.Order{
+				Metadata: datastore.Metadata{"key": "value"},
+			},
+		},
+
+		{
+			name: "pp_stripe_no_vn",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+				},
+			},
+		},
+
+		{
+			name: "pp_stripe_vn_ios",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+					"vendor":           "ios",
+				},
+			},
+		},
+
+		{
+			name: "pp_android_vn_ios",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "android",
+					"vendor":           "ios",
+				},
+			},
+		},
+
+		{
+			name: "pp_stripe_vn_android",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+					"vendor":           "android",
+				},
+			},
+		},
+
+		{
+			name: "android",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "android",
+					"vendor":           "android",
+				},
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.IsAndroid()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestOrder_PaymentProc(t *testing.T) {
+	type tcExpected struct {
+		val string
+		ok  bool
+	}
+
+	type testCase struct {
+		name  string
+		given model.Order
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "no_metadata",
+		},
+
+		{
+			name: "no_field",
+			given: model.Order{
+				Metadata: datastore.Metadata{"key": "value"},
+			},
+		},
+
+		{
+			name: "not_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": 42,
+				},
+			},
+		},
+
+		{
+			name: "empty_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "",
+				},
+			},
+			exp: tcExpected{ok: true},
+		},
+
+		{
+			name: "sub_id",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"paymentProcessor": "stripe",
+				},
+			},
+			exp: tcExpected{val: "stripe", ok: true},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := tc.given.PaymentProc()
+			should.Equal(t, tc.exp.ok, ok)
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
+func TestOrder_Vendor(t *testing.T) {
+	type tcExpected struct {
+		val model.Vendor
+		ok  bool
+	}
+
+	type testCase struct {
+		name  string
+		given model.Order
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "no_metadata",
+			exp: tcExpected{
+				val: model.VendorUnknown,
+			},
+		},
+
+		{
+			name: "no_field",
+			given: model.Order{
+				Metadata: datastore.Metadata{"key": "value"},
+			},
+			exp: tcExpected{
+				val: model.VendorUnknown,
+			},
+		},
+
+		{
+			name: "not_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"vendor": 42,
+				},
+			},
+			exp: tcExpected{
+				val: model.VendorUnknown,
+			},
+		},
+
+		{
+			name: "empty_string",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"vendor": "",
+				},
+			},
+			exp: tcExpected{
+				ok: true,
+			},
+		},
+
+		{
+			name: "something_else",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"vendor": "something_else",
+				},
+			},
+			exp: tcExpected{
+				val: model.Vendor("something_else"),
+				ok:  true,
+			},
+		},
+
+		{
+			name: "apple",
+			given: model.Order{
+				Metadata: datastore.Metadata{
+					"vendor": "ios",
+				},
+			},
+			exp: tcExpected{
+				val: model.VendorApple,
+				ok:  true,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := tc.given.Vendor()
+			should.Equal(t, tc.exp.ok, ok)
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
 func mustDecimalFromString(v string) decimal.Decimal {
 	result, err := decimal.NewFromString(v)
 	if err != nil {

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -20,6 +20,8 @@ import (
 
 const (
 	paymentProcessor = "paymentProcessor"
+
+	// TODO: Delete these as not in use.
 	// IOSPaymentMethod - indicating this used an ios payment method
 	IOSPaymentMethod = "ios"
 	// AndroidPaymentMethod - indicating this used an android payment method

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -669,7 +669,7 @@ func (s *Service) CancelOrder(orderID uuid.UUID) error {
 
 	// Try to find by order_id in Stripe.
 	params := &stripe.SubscriptionSearchParams{}
-	params.Query = fmt.Sprintf("metadata['orderID']:'%s'", orderID.String())
+	params.Query = fmt.Sprintf("status:'active' AND metadata['orderID']:'%s'", orderID.String())
 
 	ctx := context.TODO()
 


### PR DESCRIPTION
### Summary

This PR updates the processing of an iOS webhook so that it only cancels an order in SKUs, and does not attempt to cancel it in Stripe, because there is obviously no such subscription.

There are many issues with the existing code for handling iOS webhook, but for now this is only to fix the cancelation. Other improvements will be made at a different time.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
