### PR TITLE
fix: don't move order to pending on invoice update

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -1253,7 +1253,7 @@ func handleStripeWebhook(svc *Service) handlers.AppHandler {
 		}
 
 		switch event.Type {
-		case StripeInvoiceUpdated, StripeInvoicePaid:
+		case whStripeInvoiceUpdated, whStripeInvoicePaid:
 			invoice := &stripe.Invoice{}
 			if err := json.Unmarshal(event.Data.Raw, invoice); err != nil {
 				lg.Error().Err(err).Msg("failed to parse invoice")
@@ -1296,16 +1296,16 @@ func handleStripeWebhook(svc *Service) handlers.AppHandler {
 			}
 
 			switch event.Type {
-			case StripeInvoiceUpdated:
+			case whStripeInvoiceUpdated:
 				return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
 
-			case StripeInvoicePaid:
+			case whStripeInvoicePaid:
 				if err := svc.RenewOrder(ctx, orderID); err != nil {
 					lg.Error().Err(err).Msg("failed to renew order")
 					return handlers.WrapError(err, "error renewing order", http.StatusInternalServerError)
 				}
 
-				if err := svc.Datastore.AppendOrderMetadata(ctx, &orderID, "paymentProcessor", StripePaymentMethod); err != nil {
+				if err := svc.Datastore.AppendOrderMetadata(ctx, &orderID, "paymentProcessor", model.StripePaymentMethod); err != nil {
 					lg.Error().Err(err).Msg("failed to update order metadata paymentProcessor")
 					return handlers.WrapError(err, "failed to update order metadata paymentProcessor", http.StatusInternalServerError)
 				}
@@ -1316,7 +1316,7 @@ func handleStripeWebhook(svc *Service) handlers.AppHandler {
 				handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
 			}
 
-		case StripeCustomerSubscriptionDeleted:
+		case whStripeCustSubscriptionDeleted:
 			// TODO: Enable it and handle properly.
 
 			sub := &stripe.Subscription{}

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -146,6 +146,7 @@ func CreateStripeCheckoutSession(
 	}
 
 	params := &stripe.CheckoutSessionParams{
+		// TODO: Get rid of this stripe.* nonsense, and use ptrTo instead.
 		PaymentMethodTypes: stripe.StringSlice([]string{"card"}),
 		Mode:               stripe.String(string(stripe.CheckoutSessionModeSubscription)),
 		SuccessURL:         stripe.String(successURI),

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	paymentProcessor = "paymentProcessor"
-
 	// TODO: Delete these as not in use.
 	// IOSPaymentMethod - indicating this used an ios payment method
 	IOSPaymentMethod = "ios"

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -19,28 +19,16 @@ import (
 )
 
 const (
-	// TODO: Delete these as not in use.
-	// IOSPaymentMethod - indicating this used an ios payment method
-	IOSPaymentMethod = "ios"
-	// AndroidPaymentMethod - indicating this used an android payment method
-	AndroidPaymentMethod = "android"
-)
-
-const (
-	// TODO(pavelb): Gradually replace it everywhere.
-	StripePaymentMethod = model.StripePaymentMethod
-
-	StripeInvoiceUpdated              = "invoice.updated"
-	StripeInvoicePaid                 = "invoice.paid"
-	StripeCustomerSubscriptionDeleted = "customer.subscription.deleted"
+	whStripeInvoiceUpdated          = "invoice.updated"
+	whStripeInvoicePaid             = "invoice.paid"
+	whStripeCustSubscriptionDeleted = "customer.subscription.deleted"
 )
 
 // TODO(pavelb): Gradually replace these everywhere.
 type (
-	Order                         = model.Order
-	OrderItem                     = model.OrderItem
-	CreateCheckoutSessionResponse = model.CreateCheckoutSessionResponse
-	Issuer                        = model.Issuer
+	Order     = model.Order
+	OrderItem = model.OrderItem
+	Issuer    = model.Issuer
 )
 
 func decodeAndUnmarshalSku(sku string) (*macaroon.Macaroon, error) {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -620,7 +620,7 @@ func (s *Service) TransformStripeOrder(order *Order) (*Order, error) {
 					return nil, fmt.Errorf("failed to update order to add the subscription id")
 				}
 
-				if err := s.Datastore.AppendOrderMetadata(ctx, &order.ID, "paymentProcessor", StripePaymentMethod); err != nil {
+				if err := s.Datastore.AppendOrderMetadata(ctx, &order.ID, "paymentProcessor", model.StripePaymentMethod); err != nil {
 					return nil, fmt.Errorf("failed to update order to add the payment processor")
 				}
 			}

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -620,7 +620,7 @@ func (s *Service) TransformStripeOrder(order *Order) (*Order, error) {
 					return nil, fmt.Errorf("failed to update order to add the subscription id")
 				}
 
-				if err := s.Datastore.AppendOrderMetadata(ctx, &order.ID, paymentProcessor, StripePaymentMethod); err != nil {
+				if err := s.Datastore.AppendOrderMetadata(ctx, &order.ID, "paymentProcessor", StripePaymentMethod); err != nil {
 					return nil, fmt.Errorf("failed to update order to add the payment processor")
 				}
 			}
@@ -2108,9 +2108,9 @@ func createOrderItem(req *model.OrderItemRequestNew) (*model.OrderItem, error) {
 
 func newMobileOrderMdata(req model.ReceiptRequest, extID string) datastore.Metadata {
 	result := datastore.Metadata{
-		"externalID":     extID,
-		paymentProcessor: req.Type.String(),
-		"vendor":         req.Type.String(),
+		"externalID":       extID,
+		"paymentProcessor": req.Type.String(),
+		"vendor":           req.Type.String(),
 	}
 
 	return result


### PR DESCRIPTION
### Summary

This PR prevents SKUs from moving orders to `pending` on `invoice.updated` events.

Fixes https://github.com/brave-intl/payment-services/issues/207.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
