### PR TITLE
refactor: return 409 on repeated receipt submission

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -1386,15 +1386,15 @@ func handleSubmitReceipt(svc *Service, valid *validator.Validate) handlers.AppHa
 		}
 
 		{
-			exists, err := svc.ExternalIDExists(ctx, extID)
-			if err != nil {
+			_, err := svc.orderRepo.GetByExternalID(ctx, svc.Datastore.RawDB(), extID)
+			if err != nil && !errors.Is(err, model.ErrOrderNotFound) {
 				l.Warn().Err(err).Msg("failed to lookup external id")
 
 				return handlers.WrapError(err, "failed to lookup external id", http.StatusInternalServerError)
 			}
 
-			if exists {
-				return handlers.WrapError(err, "receipt has already been submitted", http.StatusBadRequest)
+			if err == nil {
+				return handlers.WrapError(err, "receipt has already been submitted", http.StatusConflict)
 			}
 		}
 

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -1394,7 +1394,7 @@ func handleSubmitReceipt(svc *Service, valid *validator.Validate) handlers.AppHa
 			}
 
 			if err == nil {
-				return handlers.WrapError(err, "receipt has already been submitted", http.StatusConflict)
+				return handlers.WrapError(model.ErrReceiptAlreadyLinked, "receipt has already been submitted", http.StatusConflict)
 			}
 		}
 

--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -97,7 +97,6 @@ type Datastore interface {
 	AppendOrderMetadataInt(context.Context, *uuid.UUID, string, int) error
 	AppendOrderMetadataInt64(context.Context, *uuid.UUID, string, int64) error
 	GetOutboxMovAvgDurationSeconds() (int64, error)
-	ExternalIDExists(context.Context, string) (bool, error)
 }
 
 type orderStore interface {
@@ -528,10 +527,6 @@ func (pg *Postgres) CheckExpiredCheckoutSession(orderID uuid.UUID) (bool, string
 	}
 
 	return true, sessID, nil
-}
-
-func (pg *Postgres) ExternalIDExists(ctx context.Context, externalID string) (bool, error) {
-	return pg.orderRepo.HasExternalID(ctx, pg.RawDB(), externalID)
 }
 
 // IsStripeSub reports whether the order is associated with a stripe subscription, if true, subscription id is returned.

--- a/services/skus/instrumented_datastore.go
+++ b/services/skus/instrumented_datastore.go
@@ -240,20 +240,6 @@ func (_d DatastoreWithPrometheus) DeleteTimeLimitedV2OrderCredsByOrderTx(ctx con
 	return _d.base.DeleteTimeLimitedV2OrderCredsByOrderTx(ctx, tx, orderID)
 }
 
-// ExternalIDExists implements Datastore
-func (_d DatastoreWithPrometheus) ExternalIDExists(ctx context.Context, s1 string) (b1 bool, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "ExternalIDExists", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.ExternalIDExists(ctx, s1)
-}
-
 // GetIssuerByPublicKey implements Datastore
 func (_d DatastoreWithPrometheus) GetIssuerByPublicKey(publicKey string) (ip1 *Issuer, err error) {
 	_since := time.Now()

--- a/services/skus/mockdatastore.go
+++ b/services/skus/mockdatastore.go
@@ -251,21 +251,6 @@ func (mr *MockDatastoreMockRecorder) DeleteTimeLimitedV2OrderCredsByOrderTx(ctx,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTimeLimitedV2OrderCredsByOrderTx", reflect.TypeOf((*MockDatastore)(nil).DeleteTimeLimitedV2OrderCredsByOrderTx), ctx, tx, orderID)
 }
 
-// ExternalIDExists mocks base method.
-func (m *MockDatastore) ExternalIDExists(arg0 context.Context, arg1 string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExternalIDExists", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ExternalIDExists indicates an expected call of ExternalIDExists.
-func (mr *MockDatastoreMockRecorder) ExternalIDExists(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExternalIDExists", reflect.TypeOf((*MockDatastore)(nil).ExternalIDExists), arg0, arg1)
-}
-
 // GetIssuerByPublicKey mocks base method.
 func (m *MockDatastore) GetIssuerByPublicKey(publicKey string) (*Issuer, error) {
 	m.ctrl.T.Helper()

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -46,6 +46,7 @@ const (
 	ErrInvalidSKU              Error = "Invalid SKU Token provided in request"
 	ErrDifferentPaymentMethods Error = "all order items must have the same allowed payment methods"
 	ErrInvalidOrderRequest     Error = "model: no items to be created"
+	ErrReceiptAlreadyLinked    Error = "model: receipt already linked"
 
 	errInvalidNumConversion Error = "model: invalid numeric conversion"
 )

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -352,11 +352,6 @@ func InitService(ctx context.Context, datastore Datastore, walletService *wallet
 	return service, nil
 }
 
-// ExternalIDExists checks if this external id has been used on any orders
-func (s *Service) ExternalIDExists(ctx context.Context, externalID string) (bool, error) {
-	return s.Datastore.ExternalIDExists(ctx, externalID)
-}
-
 // CreateOrderFromRequest creates an order from the request
 func (s *Service) CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*Order, error) {
 	const merchantID = "brave.com"


### PR DESCRIPTION
### Summary

This PR updates the `submit-receipt` endpoint to return a 409 when an existing linked order has been found. Additionally, it removes the no longer used (nor needed) methods.

Fixes https://github.com/brave-intl/payment-services/issues/214.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
