### PR TITLE
feat: support VPN in creating anon orders

### DIFF
--- a/libs/wallet/provider/uphold/uphold_test.go
+++ b/libs/wallet/provider/uphold/uphold_test.go
@@ -273,13 +273,15 @@ func TestTransactions(t *testing.T) {
 	}
 
 	// wait for funds to be available
-	<-time.After(1 * time.Second)
+	<-time.After(2 * time.Second)
 	txInfo, err := destWallet.Transfer(ctx, altcurrency.BAT, submitInfo.Probi, donorWallet.ProviderID)
 	if err != nil {
 		t.Error(err)
+		t.FailNow()
 	}
+
 	if txInfo == nil {
-		t.Error("no tx information from transfer!")
+		t.Fatalf("no tx information from transfer!")
 	}
 
 	balance, err = destWallet.GetBalance(ctx, true)

--- a/libs/wallet/provider/uphold/uphold_test.go
+++ b/libs/wallet/provider/uphold/uphold_test.go
@@ -276,7 +276,8 @@ func TestTransactions(t *testing.T) {
 	<-time.After(2 * time.Second)
 	txInfo, err := destWallet.Transfer(ctx, altcurrency.BAT, submitInfo.Probi, donorWallet.ProviderID)
 	if err != nil {
-		t.Error(err)
+		t.Log(err)
+		t.Log(errors.Unwrap(err))
 		t.FailNow()
 	}
 

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1951,7 +1951,7 @@ func createOrderWithReceipt(
 		return nil, err
 	}
 
-	oreq := newCreateOrderReqNewLeo(ppcfg, itemNew)
+	oreq := newCreateOrderReqNewMobile(ppcfg, itemNew)
 
 	// 2. Craft a request for creating an order.
 	items, err := createOrderItems(&oreq)

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -318,7 +318,7 @@ func InitService(ctx context.Context, datastore Datastore, walletService *wallet
 		gcpValidator:       gcpValidator,
 
 		payProcCfg:    newPaymentProcessorConfig(env),
-		newItemReqSet: newOrderItemReqNewLeoSet(env),
+		newItemReqSet: newOrderItemReqNewMobileSet(env),
 	}
 
 	// setup runnable jobs

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -748,7 +748,7 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 			name: "error_in_newOrderItemReqForSubID",
 			given: tcGiven{
 				svc:   &mockPaidOrderCreator{},
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 				ppcfg: newPaymentProcessorConfig("development"),
 				req: model.ReceiptRequest{
 					Type:           model.VendorGoogle,
@@ -768,7 +768,7 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 						return nil, model.Error("something went wrong")
 					},
 				},
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 				ppcfg: newPaymentProcessorConfig("development"),
 				req: model.ReceiptRequest{
 					Type:           model.VendorGoogle,
@@ -792,7 +792,7 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 						return model.Error("something went wrong")
 					},
 				},
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 				ppcfg: newPaymentProcessorConfig("development"),
 				req: model.ReceiptRequest{
 					Type:           model.VendorGoogle,
@@ -819,7 +819,7 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 						return result, nil
 					},
 				},
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 				ppcfg: newPaymentProcessorConfig("development"),
 				req: model.ReceiptRequest{
 					Type:           model.VendorGoogle,

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -805,7 +805,7 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 		},
 
 		{
-			name: "successful_case",
+			name: "successful_case_android_leo_monnthly",
 			given: tcGiven{
 				svc: &mockPaidOrderCreator{
 					fnCreateOrder: func(ctx context.Context, req *model.CreateOrderRequestNew, ordNew *model.OrderNew, items []model.OrderItem) (*model.Order, error) {
@@ -826,6 +826,40 @@ func TestCreateOrderWithReceipt(t *testing.T) {
 					Blob:           "blob",
 					Package:        "package",
 					SubscriptionID: "brave.leo.monthly",
+				},
+			},
+			exp: tcExpected{
+				ord: &model.Order{
+					ID: uuid.Must(uuid.FromString("1b251573-a45a-4f57-89f7-93b7da538817")),
+					Items: []model.OrderItem{
+						{ID: uuid.Must(uuid.FromString("22482ad4-e43b-44bd-860e-99e617ad9f6d"))},
+					},
+				},
+			},
+		},
+
+		{
+			name: "successful_case_android_vpn_monnthly",
+			given: tcGiven{
+				svc: &mockPaidOrderCreator{
+					fnCreateOrder: func(ctx context.Context, req *model.CreateOrderRequestNew, ordNew *model.OrderNew, items []model.OrderItem) (*model.Order, error) {
+						result := &model.Order{
+							ID: uuid.Must(uuid.FromString("1b251573-a45a-4f57-89f7-93b7da538817")),
+							Items: []model.OrderItem{
+								{ID: uuid.Must(uuid.FromString("22482ad4-e43b-44bd-860e-99e617ad9f6d"))},
+							},
+						}
+
+						return result, nil
+					},
+				},
+				set:   newOrderItemReqNewMobileSet("development"),
+				ppcfg: newPaymentProcessorConfig("development"),
+				req: model.ReceiptRequest{
+					Type:           model.VendorGoogle,
+					Blob:           "blob",
+					Package:        "package",
+					SubscriptionID: "brave.vpn.monthly",
 				},
 			},
 			exp: tcExpected{

--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -146,8 +146,17 @@ func skuNameByMobileName(subID string) (string, error) {
 	switch subID {
 	case "brave.leo.monthly", "beta.leo.monthly", "nightly.leo.monthly", "braveleo.monthly":
 		return "brave-leo-premium", nil
+
 	case "brave.leo.yearly", "beta.leo.yearly", "nightly.leo.yearly", "braveleo.yearly":
 		return "brave-leo-premium-year", nil
+
+	case "brave.vpn.monthly", "beta.bravevpn.monthly", "nightly.bravevpn.monthly", "bravevpn.monthly":
+		return "brave-vpn-premium", nil
+
+	case "brave.vpn.yearly", "beta.bravevpn.yearly", "nightly.bravevpn.yearly", "bravevpn.yearly":
+		// Temporary: use the same sku as for monthly.
+		return "brave-vpn-premium", nil
+
 	default:
 		return "", model.ErrInvalidMobileProduct
 	}

--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -208,7 +208,7 @@ func newPaymentProcessorConfig(env string) *premiumPaymentProcConfig {
 	return result
 }
 
-func newOrderItemReqNewLeoSet(env string) map[string]model.OrderItemRequestNew {
+func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNew {
 	leom := model.OrderItemRequestNew{
 		Quantity:          1,
 		IssuerTokenBuffer: 3,

--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -217,7 +217,7 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 		Description:                 "Premium access to Leo",
 		CredentialType:              "time-limited-v2",
 		CredentialValidDuration:     "P1M",
-		Price:                       decimal.RequireFromString("15.00"),
+		Price:                       decimal.RequireFromString("14.99"),
 		CredentialValidDurationEach: ptrTo("P1D"),
 		IssuanceInterval:            ptrTo("P1D"),
 		// StripeMetadata depends on env.
@@ -237,6 +237,20 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 		// StripeMetadata depends on env.
 	}
 
+	vpnm := model.OrderItemRequestNew{
+		Quantity:           1,
+		IssuerTokenBuffer:  31,
+		IssuerTokenOverlap: 2,
+		SKU:                "brave-vpn-premium",
+		// Location depends on env.
+		Description:                 "brave-vpn-premium",
+		CredentialType:              "time-limited-v2",
+		CredentialValidDuration:     "P1M",
+		Price:                       decimal.RequireFromString("9.99"),
+		CredentialValidDurationEach: ptrTo("P1D"),
+		// StripeMetadata depends on env.
+	}
+
 	switch env {
 	case "prod", "production":
 		leom.Location = "leo.brave.com"
@@ -250,6 +264,13 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ProductID: "prod_O9uKDYsRPXNgfB",
 			ItemID:    "price_1NXmfTBSm1mtrN9nybnyolId",
 		}
+
+		vpnm.Location = "vpn.brave.com"
+		vpnm.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_Lhv8qsPsn6WHrx",
+			ItemID:    "price_1L0VHmBSm1mtrN9nT5DPmUZb",
+		}
+
 	case "sandbox", "staging":
 		leom.Location = "leo.bravesoftware.com"
 		leom.StripeMetadata = &model.ItemStripeMetadata{
@@ -262,6 +283,13 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ProductID: "prod_OKRYJ77wYOk771",
 			ItemID:    "price_1NXmfTBSm1mtrN9nybnyolId",
 		}
+
+		vpnm.Location = "vpn.bravesoftware.com"
+		vpnm.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_Lhv4OM1aAPxflY",
+			ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
+		}
+
 	case "dev", "development":
 		leom.Location = "leo.brave.software"
 		leom.StripeMetadata = &model.ItemStripeMetadata{
@@ -274,6 +302,13 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ProductID: "prod_OtZCXOCIO3AJE6",
 			ItemID:    "price_1O6re8Hof20bphG6tqdNEEAp",
 		}
+
+		vpnm.Location = "vpn.brave.software"
+		vpnm.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_K1c8W3oM4mUsGw",
+			ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+		}
+
 	default:
 		// "local", "test", etc use the same settings as development.
 		leom.Location = "leo.brave.software"
@@ -287,11 +322,18 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ProductID: "prod_OtZCXOCIO3AJE6",
 			ItemID:    "price_1O6re8Hof20bphG6tqdNEEAp",
 		}
+
+		vpnm.Location = "vpn.brave.software"
+		vpnm.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_K1c8W3oM4mUsGw",
+			ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+		}
 	}
 
 	result := map[string]model.OrderItemRequestNew{
 		leom.SKU: leom,
 		leoa.SKU: leoa,
+		vpnm.SKU: vpnm,
 	}
 
 	return result

--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -162,7 +162,7 @@ func skuNameByMobileName(subID string) (string, error) {
 	}
 }
 
-func newCreateOrderReqNewLeo(ppcfg *premiumPaymentProcConfig, item model.OrderItemRequestNew) model.CreateOrderRequestNew {
+func newCreateOrderReqNewMobile(ppcfg *premiumPaymentProcConfig, item model.OrderItemRequestNew) model.CreateOrderRequestNew {
 	result := model.CreateOrderRequestNew{
 		// No email.
 		Currency: "USD",

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -658,7 +658,7 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -683,6 +683,23 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 						ItemID:    "price_1NXmfTBSm1mtrN9nybnyolId",
 					},
 				},
+
+				"brave-vpn-premium": model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.com",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_Lhv8qsPsn6WHrx",
+						ItemID:    "price_1L0VHmBSm1mtrN9nT5DPmUZb",
+					},
+				},
 			},
 		},
 
@@ -698,7 +715,7 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -723,6 +740,23 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 						ItemID:    "price_1NXmfTBSm1mtrN9nybnyolId",
 					},
 				},
+
+				"brave-vpn-premium": model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.bravesoftware.com",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_Lhv4OM1aAPxflY",
+						ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
+					},
+				},
 			},
 		},
 
@@ -738,7 +772,7 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -761,6 +795,23 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_OtZCXOCIO3AJE6",
 						ItemID:    "price_1O6re8Hof20bphG6tqdNEEAp",
+					},
+				},
+
+				"brave-vpn-premium": model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
 					},
 				},
 			},
@@ -778,7 +829,7 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -801,6 +852,23 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_OtZCXOCIO3AJE6",
 						ItemID:    "price_1O6re8Hof20bphG6tqdNEEAp",
+					},
+				},
+
+				"brave-vpn-premium": model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
 					},
 				},
 			},

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -439,7 +439,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 						Description:                 "Premium access to Leo",
 						CredentialType:              "time-limited-v2",
 						CredentialValidDuration:     "P1M",
-						Price:                       decimal.RequireFromString("15.00"),
+						Price:                       decimal.RequireFromString("14.99"),
 						CredentialValidDurationEach: ptrTo("P1D"),
 						IssuanceInterval:            ptrTo("P1D"),
 						StripeMetadata: &model.ItemStripeMetadata{
@@ -509,12 +509,118 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 						Description:                 "Premium access to Leo",
 						CredentialType:              "time-limited-v2",
 						CredentialValidDuration:     "P1M",
-						Price:                       decimal.RequireFromString("15.00"),
+						Price:                       decimal.RequireFromString("14.99"),
 						CredentialValidDurationEach: ptrTo("P1D"),
 						IssuanceInterval:            ptrTo("P1D"),
 						StripeMetadata: &model.ItemStripeMetadata{
 							ProductID: "prod_O9uKDYsRPXNgfB",
 							ItemID:    "price_1NXmj0BSm1mtrN9nF0elIhiq",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "development_vpn_monthly",
+			given: tcGiven{
+				ppcfg: newPaymentProcessorConfig("development"),
+				item:  newOrderItemReqNewMobileSet("development")["brave-vpn-premium"],
+			},
+
+			exp: model.CreateOrderRequestNew{
+				Currency: "USD",
+
+				StripeMetadata: &model.OrderStripeMetadata{
+					SuccessURI: "https://account.brave.software/account/?intent=provision",
+					CancelURI:  "https://account.brave.software/plans/?intent=checkout",
+				},
+
+				Items: []model.OrderItemRequestNew{
+					{
+						Quantity:                    1,
+						IssuerTokenBuffer:           31,
+						IssuerTokenOverlap:          2,
+						SKU:                         "brave-vpn-premium",
+						Location:                    "vpn.brave.software",
+						Description:                 "brave-vpn-premium",
+						CredentialType:              "time-limited-v2",
+						CredentialValidDuration:     "P1M",
+						Price:                       decimal.RequireFromString("9.99"),
+						CredentialValidDurationEach: ptrTo("P1D"),
+						StripeMetadata: &model.ItemStripeMetadata{
+							ProductID: "prod_K1c8W3oM4mUsGw",
+							ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "staging_vpn_yearly",
+			given: tcGiven{
+				ppcfg: newPaymentProcessorConfig("staging"),
+				item:  newOrderItemReqNewMobileSet("staging")["brave-vpn-premium"],
+			},
+			exp: model.CreateOrderRequestNew{
+				Currency: "USD",
+
+				StripeMetadata: &model.OrderStripeMetadata{
+					SuccessURI: "https://account.bravesoftware.com/account/?intent=provision",
+					CancelURI:  "https://account.bravesoftware.com/plans/?intent=checkout",
+				},
+
+				Items: []model.OrderItemRequestNew{
+					{
+						Quantity:                    1,
+						IssuerTokenBuffer:           31,
+						IssuerTokenOverlap:          2,
+						SKU:                         "brave-vpn-premium",
+						Location:                    "vpn.bravesoftware.com",
+						Description:                 "brave-vpn-premium",
+						CredentialType:              "time-limited-v2",
+						CredentialValidDuration:     "P1M",
+						Price:                       decimal.RequireFromString("9.99"),
+						CredentialValidDurationEach: ptrTo("P1D"),
+						StripeMetadata: &model.ItemStripeMetadata{
+							ProductID: "prod_Lhv4OM1aAPxflY",
+							ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "production_vpn_monthly",
+			given: tcGiven{
+				ppcfg: newPaymentProcessorConfig("production"),
+				item:  newOrderItemReqNewMobileSet("production")["brave-vpn-premium"],
+			},
+			exp: model.CreateOrderRequestNew{
+				Currency: "USD",
+
+				StripeMetadata: &model.OrderStripeMetadata{
+					SuccessURI: "https://account.brave.com/account/?intent=provision",
+					CancelURI:  "https://account.brave.com/plans/?intent=checkout",
+				},
+
+				Items: []model.OrderItemRequestNew{
+					{
+						Quantity:                    1,
+						IssuerTokenBuffer:           31,
+						IssuerTokenOverlap:          2,
+						SKU:                         "brave-vpn-premium",
+						Location:                    "vpn.brave.com",
+						Description:                 "brave-vpn-premium",
+						CredentialType:              "time-limited-v2",
+						CredentialValidDuration:     "P1M",
+						Price:                       decimal.RequireFromString("9.99"),
+						CredentialValidDurationEach: ptrTo("P1D"),
+						StripeMetadata: &model.ItemStripeMetadata{
+							ProductID: "prod_Lhv8qsPsn6WHrx",
+							ItemID:    "price_1L0VHmBSm1mtrN9nT5DPmUZb",
 						},
 					},
 				},

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -196,7 +196,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -222,7 +222,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 					Description:                 "Premium access to Leo",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("15.00"),
+					Price:                       decimal.RequireFromString("14.99"),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					IssuanceInterval:            ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
@@ -280,6 +280,110 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_OtZCXOCIO3AJE6",
 						ItemID:    "price_1O6re8Hof20bphG6tqdNEEAp",
+					},
+				},
+			},
+		},
+
+		{
+			name: "android_release_monthly_vpn",
+			given: tcGiven{
+				subID: "brave.vpn.monthly",
+				set:   newOrderItemReqNewMobileSet("development"),
+			},
+			exp: tcExpected{
+				req: model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+					},
+				},
+			},
+		},
+
+		{
+			name: "ios_monthly_vpn",
+			given: tcGiven{
+				subID: "bravevpn.monthly",
+				set:   newOrderItemReqNewMobileSet("development"),
+			},
+			exp: tcExpected{
+				req: model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+					},
+				},
+			},
+		},
+
+		{
+			name: "android_release_yearly_vpn",
+			given: tcGiven{
+				subID: "brave.vpn.yearly",
+				set:   newOrderItemReqNewMobileSet("development"),
+			},
+			exp: tcExpected{
+				req: model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+					},
+				},
+			},
+		},
+
+		{
+			name: "ios_yearly_vpn",
+			given: tcGiven{
+				subID: "bravevpn.yearly",
+				set:   newOrderItemReqNewMobileSet("development"),
+			},
+			exp: tcExpected{
+				req: model.OrderItemRequestNew{
+					Quantity:                    1,
+					IssuerTokenBuffer:           31,
+					IssuerTokenOverlap:          2,
+					SKU:                         "brave-vpn-premium",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("9.99"),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
 					},
 				},
 			},

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -72,6 +72,54 @@ func TestSKUNameByMobileName(t *testing.T) {
 		},
 
 		{
+			name:  "android_release_monthly_vpn",
+			given: "brave.vpn.monthly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "android_beta_monthly_vpn",
+			given: "beta.bravevpn.monthly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "android_nightly_monthly_vpn",
+			given: "nightly.bravevpn.monthly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "ios_monthly_vpn",
+			given: "bravevpn.monthly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "android_release_yearly_vpn",
+			given: "brave.vpn.yearly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "android_beta_yearly_vpn",
+			given: "beta.bravevpn.yearly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "android_nightly_yearly_vpn",
+			given: "nightly.bravevpn.yearly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "ios_yearly_vpn",
+			given: "bravevpn.yearly",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
 			name:  "invalid",
 			given: "something_else",
 			exp:   tcExpected{err: model.ErrInvalidMobileProduct},

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -185,7 +185,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 			name: "android_release_monthly_leo",
 			given: tcGiven{
 				subID: "brave.leo.monthly",
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 			},
 			exp: tcExpected{
 				req: model.OrderItemRequestNew{
@@ -211,7 +211,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 			name: "ios_monthly_leo",
 			given: tcGiven{
 				subID: "braveleo.monthly",
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 			},
 			exp: tcExpected{
 				req: model.OrderItemRequestNew{
@@ -237,7 +237,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 			name: "android_release_yearly_leo",
 			given: tcGiven{
 				subID: "brave.leo.yearly",
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 			},
 			exp: tcExpected{
 				req: model.OrderItemRequestNew{
@@ -263,7 +263,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 			name: "ios_yearly_leo",
 			given: tcGiven{
 				subID: "braveleo.yearly",
-				set:   newOrderItemReqNewLeoSet("development"),
+				set:   newOrderItemReqNewMobileSet("development"),
 			},
 			exp: tcExpected{
 				req: model.OrderItemRequestNew{
@@ -315,7 +315,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 			name: "development_leo_monthly",
 			given: tcGiven{
 				ppcfg: newPaymentProcessorConfig("development"),
-				item:  newOrderItemReqNewLeoSet("development")["brave-leo-premium"],
+				item:  newOrderItemReqNewMobileSet("development")["brave-leo-premium"],
 			},
 
 			exp: model.CreateOrderRequestNew{
@@ -351,7 +351,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 			name: "staging_leo_yearly",
 			given: tcGiven{
 				ppcfg: newPaymentProcessorConfig("staging"),
-				item:  newOrderItemReqNewLeoSet("staging")["brave-leo-premium-year"],
+				item:  newOrderItemReqNewMobileSet("staging")["brave-leo-premium-year"],
 			},
 			exp: model.CreateOrderRequestNew{
 				Currency: "USD",
@@ -386,7 +386,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 			name: "production_leo_monthly",
 			given: tcGiven{
 				ppcfg: newPaymentProcessorConfig("production"),
-				item:  newOrderItemReqNewLeoSet("production")["brave-leo-premium"],
+				item:  newOrderItemReqNewMobileSet("production")["brave-leo-premium"],
 			},
 			exp: model.CreateOrderRequestNew{
 				Currency: "USD",
@@ -601,7 +601,7 @@ func TestNewOrderItemReqNewLeoSet(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual := newOrderItemReqNewLeoSet(tc.given)
+			actual := newOrderItemReqNewMobileSet(tc.given)
 			should.Equal(t, tc.exp, actual)
 		})
 	}

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -422,7 +422,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual := newCreateOrderReqNewLeo(tc.given.ppcfg, tc.given.item)
+			actual := newCreateOrderReqNewMobile(tc.given.ppcfg, tc.given.item)
 			should.Equal(t, tc.exp, actual)
 		})
 	}

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -402,7 +402,7 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 	}
 }
 
-func TestNewCreateOrderReqNewLeo(t *testing.T) {
+func TestNewCreateOrderReqNewMobile(t *testing.T) {
 	type tcGiven struct {
 		ppcfg *premiumPaymentProcConfig
 		item  model.OrderItemRequestNew
@@ -638,7 +638,7 @@ func TestNewCreateOrderReqNewLeo(t *testing.T) {
 	}
 }
 
-func TestNewOrderItemReqNewLeoSet(t *testing.T) {
+func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 	type testCase struct {
 		name  string
 		given string


### PR DESCRIPTION
### Summary

This PR adds extends functionality for creating mobile orders with support for the VPN products. This is necessary for switching the order linking for VPN from the legacy process to the new built for Leo.


### Type of Change

- [x] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
