### PR TITLE
fix: check for legacy subscription_id values in iOS receipt validation

### DIFF
--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -157,6 +157,11 @@ func skuNameByMobileName(subID string) (string, error) {
 		// Temporary: use the same sku as for monthly.
 		return "brave-vpn-premium", nil
 
+	// Legacy.
+	// Older iOS clients might still send this as subscription_id along with a receipt.
+	case "brave-firewall-vpn-premium", "brave-firewall-vpn-premium-year":
+		return "brave-vpn-premium", nil
+
 	default:
 		return "", model.ErrInvalidMobileProduct
 	}

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -124,6 +124,18 @@ func TestSKUNameByMobileName(t *testing.T) {
 			given: "something_else",
 			exp:   tcExpected{err: model.ErrInvalidMobileProduct},
 		},
+
+		{
+			name:  "legacy_ios_vpn_monthly",
+			given: "brave-firewall-vpn-premium",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
+
+		{
+			name:  "legacy_ios_vpn_annual",
+			given: "brave-firewall-vpn-premium-year",
+			exp:   tcExpected{sku: "brave-vpn-premium"},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
### Summary

This PR updates iOS receipt validation with legacy values that the iOS client might send from releases predating Leo.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
