### PR TITLE
fix: address inconsistency in ios client with vpn linking

### DIFF
--- a/services/skus/receipt.go
+++ b/services/skus/receipt.go
@@ -144,6 +144,20 @@ func (v *receiptVerifier) validateApple(ctx context.Context, req model.ReceiptRe
 		return item.OriginalTransactionID, nil
 	}
 
+	// Special case for VPN.
+	// Theclient may send bravevpn.monthly as subscription_id for bravevpn.yearly product.
+	if req.SubscriptionID == "bravevpn.monthly" {
+		item, ok := findInAppBySubID(resp.Receipt.InApp, "bravevpn.yearly")
+		if ok {
+			return item.OriginalTransactionID, nil
+		}
+
+		item, ok = findInAppBySubID(resp.LatestReceiptInfo, "bravevpn.yearly")
+		if ok {
+			return item.OriginalTransactionID, nil
+		}
+	}
+
 	// Handle legacy iOS versions predating the release that started using proper values for subscription_id.
 	// This only applies to VPN.
 	item, ok = findInAppBySubIDLegacy(resp, req.SubscriptionID)

--- a/services/skus/receipt.go
+++ b/services/skus/receipt.go
@@ -145,7 +145,7 @@ func (v *receiptVerifier) validateApple(ctx context.Context, req model.ReceiptRe
 	}
 
 	// Special case for VPN.
-	// Theclient may send bravevpn.monthly as subscription_id for bravevpn.yearly product.
+	// The client may send bravevpn.monthly as subscription_id for bravevpn.yearly product.
 	if req.SubscriptionID == "bravevpn.monthly" {
 		item, ok := findInAppBySubID(resp.Receipt.InApp, "bravevpn.yearly")
 		if ok {

--- a/services/skus/receipt_test.go
+++ b/services/skus/receipt_test.go
@@ -110,10 +110,10 @@ func TestReceiptVerifier_validateApple(t *testing.T) {
 								ProductID:             "braveleo.monthly",
 							},
 
-							{
-								OriginalTransactionID: "720000000000002",
-								ProductID:             "bravevpn.yearly",
-							},
+							// {
+							// 	OriginalTransactionID: "720000000000002",
+							// 	ProductID:             "bravevpn.yearly",
+							// },
 						}
 
 						return nil
@@ -321,6 +321,37 @@ func TestReceiptVerifier_validateApple(t *testing.T) {
 				},
 			},
 			exp: tcExpected{val: "720000000000002"},
+		},
+
+		{
+			name: "ios_vpn_bug_monthly_yearly",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Package:        "com.brave.ios.browser",
+					Blob:           "blob",
+					SubscriptionID: "bravevpn.monthly",
+				},
+
+				cl: &mockASClient{
+					fnVerify: func(ctx context.Context, req appstore.IAPRequest, result interface{}) error {
+						resp, ok := result.(*appstore.IAPResponse)
+						if !ok {
+							return model.Error("invalid response type")
+						}
+
+						resp.Receipt.BundleID = "com.brave.ios.browser"
+						resp.Receipt.InApp = []appstore.InApp{
+							{
+								OriginalTransactionID: "720000000000001",
+								ProductID:             "bravevpn.yearly",
+							},
+						}
+
+						return nil
+					},
+				},
+			},
+			exp: tcExpected{val: "720000000000001"},
 		},
 	}
 


### PR DESCRIPTION
### Summary

This PR addresses the problem when the iOS client sends `bravevpn.monthly` when linking a `bravevpn.yearly` product.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
