### PR TITLE
feat: change request_id to disallow null and update index

### DIFF
--- a/libs/datastore/postgres.go
+++ b/libs/datastore/postgres.go
@@ -41,7 +41,7 @@ var (
 	}
 	dbs = map[string]*sqlx.DB{}
 	// CurrentMigrationVersion holds the default migration version
-	CurrentMigrationVersion = uint(66)
+	CurrentMigrationVersion = uint(68)
 	// MigrationTracks holds the migration version for a given track (eyeshade, promotion, wallet)
 	MigrationTracks = map[string]uint{
 		"eyeshade": 20,

--- a/migrations/0067_tlv2_request_id_not_null.down.sql
+++ b/migrations/0067_tlv2_request_id_not_null.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE time_limited_v2_order_creds ALTER COLUMN request_id DROP NOT NULL;

--- a/migrations/0067_tlv2_request_id_not_null.up.sql
+++ b/migrations/0067_tlv2_request_id_not_null.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE time_limited_v2_order_creds ALTER COLUMN request_id SET NOT NULL;

--- a/migrations/0068_tlv2_request_id_uniq.down.sql
+++ b/migrations/0068_tlv2_request_id_uniq.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE time_limited_v2_order_creds DROP CONSTRAINT IF EXISTS time_limited_v2_order_creds_unique;
+
+ALTER TABLE time_limited_v2_order_creds ADD CONSTRAINT time_limited_v2_order_creds_unique UNIQUE (order_id, item_id, valid_to, valid_from);

--- a/migrations/0068_tlv2_request_id_uniq.up.sql
+++ b/migrations/0068_tlv2_request_id_uniq.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE time_limited_v2_order_creds DROP CONSTRAINT IF EXISTS time_limited_v2_order_creds_unique;
+
+ALTER TABLE time_limited_v2_order_creds ADD CONSTRAINT time_limited_v2_order_creds_unique UNIQUE (order_id, item_id, request_id, valid_to, valid_from);

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -273,6 +273,10 @@ func (suite *ControllersTestSuite) AfterTest(sn, tn string) {
 	suite.mockCtrl.Finish()
 }
 
+func (s *ControllersTestSuite) TearDownSuite(sn, tn string) {
+	skustest.CleanDB(s.T(), s.storage.RawDB())
+}
+
 func (suite *ControllersTestSuite) setupCreateOrder(skuToken string, token macaroon.Token, quantity int) (Order, *Issuer) {
 	issuerID, err := encodeIssuerID(token.Location, token.FirstPartyCaveats[0]["sku"])
 	suite.Require().NoError(err)

--- a/services/skus/credentials_test.go
+++ b/services/skus/credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -56,6 +57,10 @@ func (suite *CredentialsTestSuite) SetupSuite() {
 
 func (suite *CredentialsTestSuite) AfterTest() {
 	skustest.CleanDB(suite.T(), suite.storage.RawDB())
+}
+
+func (s *CredentialsTestSuite) TearDownSuite() {
+	skustest.CleanDB(s.T(), s.storage.RawDB())
 }
 
 func (suite *CredentialsTestSuite) TestSignedOrderCredentialsHandler_KafkaDuplicates() {
@@ -126,45 +131,48 @@ func (suite *CredentialsTestSuite) TestSignedOrderCredentialsHandler_KafkaDuplic
 }
 
 func (suite *CredentialsTestSuite) TestSignedOrderCredentialsHandler_RequestDuplicates() {
-	// Create an issuer and a paid order with one order item and a time limited v2 credential type.
 	ctx := context.WithValue(context.Background(), appctx.WhitelistSKUsCTXKey, []string{devFreeTimeLimitedV2})
 	order, issuer := createOrderAndIssuer(suite.T(), ctx, suite.storage, devFreeTimeLimitedV2)
 
-	// Insert a ten signing order requests for the same order and item id
-	var requestIDs []uuid.UUID
-	for i := 0; i < 10; i++ {
-		requestIDs = append(requestIDs, uuid.NewV4())
-		err := suite.storage.InsertSigningOrderRequestOutbox(context.Background(), requestIDs[i], order.ID,
-			order.Items[0].ID, SigningOrderRequest{})
+	reqIDs := []uuid.UUID{
+		uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+		uuid.Must(uuid.FromString("decade00-0000-4000-a000-000000000000")),
+		uuid.Must(uuid.FromString("ad0be000-0000-4000-a000-000000000000")),
+		uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+		uuid.Must(uuid.FromString("5ca1ab1e-0000-4000-a000-000000000000")),
+		uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
+	}
+
+	for i := range reqIDs {
+		err := suite.storage.InsertSigningOrderRequestOutbox(ctx, reqIDs[i], order.ID, order.Items[0].ID, SigningOrderRequest{})
 		suite.Require().NoError(err)
 	}
 
-	validTo := time.Now().Add(time.Hour)
-	validFrom := time.Now().Local()
+	now := time.Now().UTC()
 
-	// Create signed order results for all the request with the same order, order item and valid to and valid from.
-	var signedOrderResults []SigningOrderResult
-	for i := 0; i < len(requestIDs); i++ {
-		signedOrderResults = append(signedOrderResults, suite.makeMsg(requestIDs[i], order.ID, order.Items[0].ID,
-			issuer.ID, validTo, validFrom))
+	validFrom := now
+	validTo := now.Add(1 * time.Hour)
+
+	results := make([]SigningOrderResult, 0, len(reqIDs))
+	for i := range reqIDs {
+		results = append(results, suite.makeMsg(reqIDs[i], order.ID, order.Items[0].ID, issuer.ID, validTo, validFrom))
 	}
 
-	// Create Kafka messages from the signed order results.
 	codec, err := goavro.NewCodec(signingOrderResultSchema)
 	suite.Require().NoError(err)
 
-	var kafkaMessages []kafka.Message
-	for i := 0; i < len(signedOrderResults); i++ {
-		b, err := json.Marshal(signedOrderResults[i])
+	msgs := make([]kafka.Message, 0, len(results))
+	for i := range results {
+		data, err := json.Marshal(results[i])
 		suite.Require().NoError(err)
 
-		native, _, err := codec.NativeFromTextual(b)
+		native, _, err := codec.NativeFromTextual(data)
 		suite.Require().NoError(err)
 
 		binary, err := codec.BinaryFromNative(nil, native)
 		suite.Require().NoError(err)
 
-		kafkaMessages = append(kafkaMessages, kafka.Message{
+		msgs = append(msgs, kafka.Message{
 			Topic: kafkaUnsignedOrderCredsTopic,
 			Value: binary,
 		})
@@ -177,22 +185,40 @@ func (suite *CredentialsTestSuite) TestSignedOrderCredentialsHandler_RequestDupl
 
 	// Send them to handler with varied times and routines to mock different consumers.
 	var wg sync.WaitGroup
-	for i := 0; i < len(kafkaMessages); i++ {
+	for i := range msgs {
 		wg.Add(1)
+
 		go func(index int) {
 			defer wg.Done()
 			time.Sleep(time.Millisecond * time.Duration(test.RandomIntWithMax(100)))
-			_ = handler.Handle(context.Background(), kafkaMessages[index])
+			_ = handler.Handle(ctx, msgs[index])
 		}(i)
 	}
+
 	wg.Wait()
 
 	creds, err := suite.storage.GetTimeLimitedV2OrderCredsByOrder(order.ID)
 	suite.NoError(err)
 
-	suite.Require().NotNil(creds)
-	suite.Assert().Len(creds.Credentials, 1)
-	suite.Assert().Equal(order.Items[0].ID, creds.Credentials[0].ItemID)
+	suite.Require().Equal(true, creds != nil)
+	suite.Require().Equal(6, len(reqIDs))
+	suite.Require().Equal(6, len(creds.Credentials))
+
+	sort.Slice(reqIDs, func(i, j int) bool {
+		return reqIDs[i].String() < reqIDs[j].String()
+	})
+
+	sort.Slice(creds.Credentials, func(i, j int) bool {
+		return creds.Credentials[i].RequestID < creds.Credentials[j].RequestID
+	})
+
+	for i := range reqIDs {
+		suite.Assert().Equal(order.ID, creds.Credentials[i].OrderID)
+		suite.Assert().Equal(order.Items[0].ID, creds.Credentials[i].ItemID)
+
+		// Add later.
+		// suite.Assert().Equal(reqIDs[i].String(), creds.Credentials[i].RequestID)
+	}
 }
 
 func TestCreateIssuer_NewIssuer(t *testing.T) {

--- a/services/skus/datastore_test.go
+++ b/services/skus/datastore_test.go
@@ -59,6 +59,10 @@ func (suite *PostgresTestSuite) SetupTest() {
 	skustest.CleanDB(suite.T(), suite.storage.RawDB())
 }
 
+func (s *PostgresTestSuite) TearDownSuite(sn, tn string) {
+	skustest.CleanDB(s.T(), s.storage.RawDB())
+}
+
 func TestGetPagedMerchantTransactions(t *testing.T) {
 	ctx := context.Background()
 	// setup mock DB we will inject into our pg
@@ -498,7 +502,7 @@ func createOrderAndIssuer(t *testing.T, ctx context.Context, storage Datastore, 
 
 	repo := repository.NewIssuer()
 	issuer, err := repo.Create(ctx, storage.RawDB(), model.IssuerNew{
-		MerchantID: test.RandomString(),
+		MerchantID: model.MerchID,
 		PublicKey:  test.RandomString(),
 	})
 	must.NoError(t, err)

--- a/services/skus/skustest/skustest.go
+++ b/services/skus/skustest/skustest.go
@@ -7,60 +7,46 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jmoiron/sqlx"
+	"github.com/segmentio/kafka-go"
+	must "github.com/stretchr/testify/require"
+
 	appctx "github.com/brave-intl/bat-go/libs/context"
 	"github.com/brave-intl/bat-go/libs/datastore"
 	kafkautils "github.com/brave-intl/bat-go/libs/kafka"
-	"github.com/jmoiron/sqlx"
-	"github.com/segmentio/kafka-go"
-	"github.com/stretchr/testify/assert"
 )
 
-var tables = []string{"vote_drain", "api_keys", "transactions", "signing_order_request_outbox",
-	"time_limited_v2_order_creds", "order_creds", "order_cred_issuers", "order_items", "orders"}
-
-// Migrate - perform a migration for skus
 func Migrate(t *testing.T) {
-	postgres, err := datastore.NewPostgres("", false, "skus_db")
-	assert.NoError(t, err)
+	pg, err := datastore.NewPostgres("", false, "skus_db")
+	must.NoError(t, err)
 
-	migrate, err := postgres.NewMigrate()
-	assert.NoError(t, err)
+	m, err := pg.NewMigrate()
+	must.NoError(t, err)
 
-	version, dirty, _ := migrate.Version()
-	if dirty {
-		assert.NoError(t, migrate.Force(int(version)))
+	if ver, dirty, _ := m.Version(); dirty {
+		must.NoError(t, m.Force(int(ver)))
 	}
 
-	if version > 0 {
-		assert.NoError(t, migrate.Down())
-	}
-
-	err = postgres.Migrate()
-	assert.NoError(t, err)
+	must.NoError(t, pg.Migrate())
 }
 
-// CleanDB - clean up the test db fixtures
-func CleanDB(t *testing.T, datastore *sqlx.DB) {
-	for _, table := range tables {
-		_, err := datastore.Exec("delete from " + table)
-		assert.NoError(t, err)
-	}
+func CleanDB(t *testing.T, dbi *sqlx.DB) {
+	_, err := dbi.Exec("TRUNCATE TABLE vote_drain, api_keys, transactions, signing_order_request_outbox, time_limited_v2_order_creds, order_items, order_creds, order_cred_issuers, orders")
+	must.Equal(t, nil, err)
 }
 
-// SetupKafka is a test helper to setup kafka brokers and topic
 func SetupKafka(ctx context.Context, t *testing.T, topics ...string) context.Context {
 	kafkaBrokers := os.Getenv("KAFKA_BROKERS")
 	ctx = context.WithValue(ctx, appctx.KafkaBrokersCTXKey, kafkaBrokers)
 
 	dialer, _, err := kafkautils.TLSDialer()
-	assert.NoError(t, err)
+	must.NoError(t, err)
 
 	for _, topic := range topics {
 		conn, err := dialer.DialLeader(ctx, "tcp", strings.Split(kafkaBrokers, ",")[0], topic, 0)
-		assert.NoError(t, err)
+		must.NoError(t, err)
 
-		err = conn.CreateTopics(kafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1})
-		assert.NoError(t, err)
+		must.NoError(t, conn.CreateTopics(kafka.TopicConfig{Topic: topic, NumPartitions: 1, ReplicationFactor: 1}))
 	}
 
 	return ctx

--- a/services/skus/storage/repository/order_item_test.go
+++ b/services/skus/storage/repository/order_item_test.go
@@ -159,19 +159,8 @@ func setupDBI() (*sqlx.DB, error) {
 		return nil, err
 	}
 
-	ver, dirty, err := mg.Version()
-	if err != nil {
-		return nil, err
-	}
-
-	if dirty {
+	if ver, dirty, _ := mg.Version(); dirty {
 		if err := mg.Force(int(ver)); err != nil {
-			return nil, err
-		}
-	}
-
-	if ver > 0 {
-		if err := mg.Down(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### Summary

This PR updates the `time_limited_v2_order_creds_unique` constraint on the `time_limited_v2_order_creds` table, thus allowing credentials for multiple unique batches within the same period, which is necessary for Multi Device Refresh.


### Type of Change

- [x] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
