### PR TITLE
Avoid fingerprint verification when checking IsUserKYC

### DIFF
--- a/libs/clients/coingecko/client_test.go
+++ b/libs/clients/coingecko/client_test.go
@@ -39,10 +39,8 @@ func (suite *CoingeckoTestSuite) SetupTest() {
 	// setup the context
 	suite.ctx = context.Background()
 
-	// setup debug for client
+	// debug logging generates too much noise, so use just info
 	suite.ctx = context.WithValue(suite.ctx, appctx.DebugLoggingCTXKey, false)
-	// setup debug log level
-	suite.ctx = context.WithValue(suite.ctx, appctx.LogLevelCTXKey, "info")
 
 	// setup a logger and put on context
 	suite.ctx, _ = logutils.SetupLogger(suite.ctx)

--- a/libs/clients/coingecko/client_test.go
+++ b/libs/clients/coingecko/client_test.go
@@ -39,7 +39,7 @@ func (suite *CoingeckoTestSuite) SetupTest() {
 	// setup the context
 	suite.ctx = context.Background()
 
-	// debug logging generates too much noise, so use just info
+	// debug logging generates too much noise, so do not activate it.
 	suite.ctx = context.WithValue(suite.ctx, appctx.DebugLoggingCTXKey, false)
 
 	// setup a logger and put on context

--- a/libs/clients/stripe/client_test.go
+++ b/libs/clients/stripe/client_test.go
@@ -36,7 +36,6 @@ func (suite *StripeTestSuite) SetupTest() {
 	// setup the context
 	suite.ctx = context.Background()
 	suite.ctx = context.WithValue(suite.ctx, appctx.DebugLoggingCTXKey, false)
-	suite.ctx = context.WithValue(suite.ctx, appctx.LogLevelCTXKey, "info")
 	suite.ctx, _ = logutils.SetupLogger(suite.ctx)
 
 	stripeKey := os.Getenv("STRIPE_ONRAMP_SECRET_KEY")

--- a/libs/wallet/provider/uphold/uphold_test.go
+++ b/libs/wallet/provider/uphold/uphold_test.go
@@ -307,7 +307,7 @@ func TestFingerprintCheck(t *testing.T) {
 	var proxy func(*http.Request) (*url.URL, error)
 	wrongFingerprint := "IYSLsapSKlkofKfi6M2hmS4gzXbQKGIX/DHBWIgstw3="
 
-	client = &http.Client{
+	client := &http.Client{
 		Timeout: time.Second * 60,
 		// remove middleware calls
 		Transport: &http.Transport{

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -653,14 +653,11 @@ func (suite *ControllersTestSuite) TestE2EOrdersUpholdTransactions() {
 	ctx := context.Background()
 	// setup debug for client
 	ctx = context.WithValue(ctx, appctx.DebugLoggingCTXKey, true)
-	// setup debug log level
-	ctx = context.WithValue(ctx, appctx.LogLevelCTXKey, "debug")
 
 	// setup a new logger, add to context as well
-	_, logger := logutils.SetupLogger(ctx)
+	ctx, _ = logutils.SetupLogger(ctx)
 
 	w := uphold.Wallet{
-		Logger:  logger,
 		Info:    info,
 		PrivKey: privKey,
 		PubKey:  publicKey,
@@ -827,7 +824,11 @@ func generateWallet(ctx context.Context, t *testing.T) *uphold.Wallet {
 		t.Fatal(err)
 	}
 	info.PublicKey = hex.EncodeToString(publicKey)
-	newWallet := &uphold.Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
+	newWallet := &uphold.Wallet{
+		Info:    info,
+		PrivKey: privateKey,
+		PubKey:  publicKey,
+	}
 	err = newWallet.Register(ctx, "bat-go test card")
 	if err != nil {
 		t.Fatal(err)

--- a/tools/vault/cmd/create_wallet.go
+++ b/tools/vault/cmd/create_wallet.go
@@ -110,7 +110,7 @@ func CreateWallet(command *cobra.Command, args []string) error {
 
 		state.WalletInfo.PublicKey = signer.String()
 
-		wallet := &uphold.Wallet{Logger: logger, Info: state.WalletInfo, PrivKey: signer, PubKey: signer}
+		wallet := &uphold.Wallet{Info: state.WalletInfo, PrivKey: signer, PubKey: signer}
 
 		reg, err := wallet.PrepareRegistration(name)
 		if err != nil {
@@ -138,7 +138,7 @@ func CreateWallet(command *cobra.Command, args []string) error {
 			return err
 		}
 
-		wallet := uphold.Wallet{Logger: logger, Info: state.WalletInfo, PrivKey: ed25519.PrivateKey{}, PubKey: publicKey}
+		wallet := uphold.Wallet{Info: state.WalletInfo, PrivKey: ed25519.PrivateKey{}, PubKey: publicKey}
 
 		err = wallet.SubmitRegistration(ctx, state.Registration)
 		if err != nil {


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->

    uphold.IsUserKYC() is used only for online checks but not for payments.
    So skip certificate fingerprint checks to prevent outages in online
    checks when Uphold changes the certificate.

### Type of Change

- [ ] Product feature
- [x ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ x] Does your code build cleanly without any errors or warnings?
- [ x] Have you used auto closing keywords?
- [ x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ x] Have you squashed all intermediate commits?
- [ ]x Is there a clear title that explains what the PR does?
- [ x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
