### PR TITLE
cache output of reproducible docker build target via image tar

### DIFF
--- a/tools/payments/git-hooks/post-merge
+++ b/tools/payments/git-hooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Removing reproducible docker build target cache"
+rm $(git rev-parse --show-toplevel)/bat-go-repro.tar

--- a/tools/payments/ipython-profile/startup/00-setup.py
+++ b/tools/payments/ipython-profile/startup/00-setup.py
@@ -111,7 +111,7 @@ def _get_pcr2():
         print(line, end='', flush=True)
         lines.append(line)
 
-    measurement = json.loads(lines[-1].split(":", 2)[-1])
+    measurement = json.loads(lines[-2].split(":", 2)[-1])
     return measurement["PCR2"]
 
 if environment != "local":


### PR DESCRIPTION
### Summary

despite the improvements made to the reproducible docker build caching, it is still a bit slow - this makes it so that we end up caching the entire target on a Makefile basis and adds a git hook to clear the tar file post-merge

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
