### PR TITLE
fix: set proper expiry time for stripe orders

### DIFF
--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -8,20 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brave-intl/bat-go/libs/logging"
-	timeutils "github.com/brave-intl/bat-go/libs/time"
-	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stripe/stripe-go/v72"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/brave-intl/bat-go/services/skus/model"
-)
+	"github.com/brave-intl/bat-go/libs/logging"
+	timeutils "github.com/brave-intl/bat-go/libs/time"
 
-const (
-	whStripeInvoiceUpdated          = "invoice.updated"
-	whStripeInvoicePaid             = "invoice.paid"
-	whStripeCustSubscriptionDeleted = "customer.subscription.deleted"
+	"github.com/brave-intl/bat-go/services/skus/model"
 )
 
 // TODO(pavelb): Gradually replace these everywhere.
@@ -175,15 +169,4 @@ func getCustEmailFromStripeCheckout(sess *stripe.CheckoutSession) string {
 
 	// Default to empty, Stripe will ask the customer.
 	return ""
-}
-
-// RenewOrder updates the order status to paid and records payment history.
-//
-// Status should either be one of pending, paid, fulfilled, or canceled.
-func (s *Service) RenewOrder(ctx context.Context, orderID uuid.UUID) error {
-	if err := s.Datastore.UpdateOrder(orderID, OrderStatusPaid); err != nil {
-		return fmt.Errorf("failed to set order status to paid: %w", err)
-	}
-
-	return nil
 }

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1652,6 +1652,77 @@ func (s *Service) RunStoreSignedOrderCredentials(ctx context.Context, backoff ti
 	}
 }
 
+func (s *Service) processStripeNotification(ctx context.Context, ntf *stripeNotification) error {
+	if !ntf.shouldProcess() {
+		return nil
+	}
+
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.processStripeNotificationTx(ctx, tx, ntf); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s *Service) processStripeNotificationTx(ctx context.Context, dbi sqlx.ExtContext, ntf *stripeNotification) error {
+	switch {
+	case ntf.shouldRenew():
+		subID, err := ntf.subID()
+		if err != nil {
+			return err
+		}
+
+		oid, err := ntf.orderID()
+		if err != nil {
+			return err
+		}
+
+		ord, err := s.orderRepo.Get(ctx, dbi, oid)
+		if err != nil {
+			return err
+		}
+
+		if shouldUpdateOrderStripeSubID(ord, subID) {
+			if err := s.orderRepo.AppendMetadata(ctx, dbi, oid, "stripeSubscriptionId", subID); err != nil {
+				return err
+			}
+		}
+
+		expt, err := ntf.expiresTime()
+		if err != nil {
+			return err
+		}
+
+		// Add 1-day leeway in case next billing cycle's webhook gets delayed.
+		expt = expt.Add(24 * time.Hour)
+
+		paidt := time.Now()
+
+		if err := s.renewOrderWithExpPaidTimeTx(ctx, dbi, ord.ID, expt, paidt); err != nil {
+			return err
+		}
+
+		return s.orderRepo.AppendMetadata(ctx, dbi, ord.ID, "paymentProcessor", model.StripePaymentMethod)
+
+	case ntf.shouldCancel():
+		oid, err := ntf.orderID()
+		if err != nil {
+			return err
+		}
+
+		return s.orderRepo.SetStatus(ctx, dbi, oid, model.OrderStatusCanceled)
+
+	default:
+		return nil
+	}
+}
+
 // processAppStoreNotification determines whether ntf is worth processing, and does it if it is.
 //
 // More on ntf types https://developer.apple.com/documentation/appstoreservernotifications/notificationtype#4304524.
@@ -2428,4 +2499,12 @@ func (x *receiptValidError) Error() string {
 	}
 
 	return x.err.Error()
+}
+
+func shouldUpdateOrderStripeSubID(ord *model.Order, subID string) bool {
+	if sid, ok := ord.StripeSubID(); !ok || sid != subID {
+		return true
+	}
+
+	return false
 }

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -2243,6 +2243,458 @@ func TestService_appendOrderMetadataTx(t *testing.T) {
 	}
 }
 
+func TestService_processStripeNotificationTx(t *testing.T) {
+	type tcGiven struct {
+		ntf     *stripeNotification
+		ordRepo orderStoreSvc
+		phRepo  orderPayHistoryStore
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   error
+	}
+
+	tests := []testCase{
+		{
+			name: "skip",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw:     &stripe.Event{Type: "invoice.updated"},
+					invoice: &stripe.Invoice{},
+				},
+				ordRepo: &repository.MockOrder{},
+				phRepo:  &repository.MockOrderPayHistory{},
+			},
+		},
+
+		{
+			name: "renew_sub_id_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw:     &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{},
+				},
+				ordRepo: &repository.MockOrder{},
+				phRepo:  &repository.MockOrderPayHistory{},
+			},
+			exp: errStripeNoInvoiceSub,
+		},
+
+		{
+			name: "renew_order_id_error_no_lines",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines:        &stripe.InvoiceLineList{},
+					},
+				},
+				ordRepo: &repository.MockOrder{},
+				phRepo:  &repository.MockOrderPayHistory{},
+			},
+			exp: errStripeNoInvoiceLines,
+		},
+
+		{
+			name: "renew_get_order_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						return nil, model.Error("something_went_wrong")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "renew_should_update_sub_id_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{
+							ID: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+							Metadata: datastore.Metadata{
+								"stripeSubscriptionId": "wrong_sub_id",
+							},
+						}
+
+						return result, nil
+					},
+					FnAppendMetadata: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error {
+						return model.Error("something_went_wrong")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "renew_expires_time_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{
+							ID:       uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+							Metadata: datastore.Metadata{},
+						}
+
+						return result, nil
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: errStripeInvalidSubPeriod,
+		},
+
+		{
+			name: "renew_renew_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+									Period: &stripe.Period{
+										Start: 1719792001,
+										End:   1722470400,
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{
+							ID:       uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+							Metadata: datastore.Metadata{},
+						}
+
+						return result, nil
+					},
+
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return model.Error("something_went_wrong")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "renew_update_payment_proc_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+									Period: &stripe.Period{
+										Start: 1719792001,
+										End:   1722470400,
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{
+							ID:       uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+							Metadata: datastore.Metadata{},
+						}
+
+						return result, nil
+					},
+
+					FnAppendMetadata: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error {
+						if key == "paymentProcessor" && val == model.StripePaymentMethod {
+							return model.Error("something_went_wrong")
+						}
+
+						return nil
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "renew_success",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "invoice.paid"},
+					invoice: &stripe.Invoice{
+						Subscription: &stripe.Subscription{ID: "sub_id"},
+						Lines: &stripe.InvoiceLineList{
+							Data: []*stripe.InvoiceLine{
+								{
+									Metadata: map[string]string{
+										"orderID": "facade00-0000-4000-a000-000000000000",
+									},
+									Period: &stripe.Period{
+										Start: 1719792001,
+										End:   1722470400,
+									},
+								},
+							},
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{
+							ID:       uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+							Metadata: datastore.Metadata{},
+						}
+
+						return result, nil
+					},
+
+					FnAppendMetadata: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error {
+						if key == "stripeSubscriptionId" && val == "sub_id" {
+							return nil
+						}
+
+						if key == "paymentProcessor" && val == model.StripePaymentMethod {
+							return nil
+						}
+
+						return model.Error("unexpected_metadata")
+					},
+
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						if uuid.Equal(id, uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000"))) && status == model.OrderStatusPaid {
+							return nil
+						}
+
+						return model.Error("unexpected_status")
+					},
+
+					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
+						if uuid.Equal(id, uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000"))) && when.Equal(time.Unix(1722470400, 0).UTC().Add(24*time.Hour)) {
+							return nil
+						}
+
+						return model.Error("unexpected_expt")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+		},
+
+		{
+			name: "cancel_order_id_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "customer.subscription.deleted"},
+					sub: &stripe.Subscription{
+						ID: "sub_id",
+					},
+				},
+				ordRepo: &repository.MockOrder{},
+				phRepo:  &repository.MockOrderPayHistory{},
+			},
+			exp: errStripeOrderIDMissing,
+		},
+
+		{
+			name: "cancel_update_status_error",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "customer.subscription.deleted"},
+					sub: &stripe.Subscription{
+						ID: "sub_id",
+						Metadata: map[string]string{
+							"orderID": "facade00-0000-4000-a000-000000000000",
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return model.Error("something_went_wrong")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "cancel_success",
+			given: tcGiven{
+				ntf: &stripeNotification{
+					raw: &stripe.Event{Type: "customer.subscription.deleted"},
+					sub: &stripe.Subscription{
+						ID: "sub_id",
+						Metadata: map[string]string{
+							"orderID": "facade00-0000-4000-a000-000000000000",
+						},
+					},
+				},
+				ordRepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						if uuid.Equal(id, uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000"))) && status == model.OrderStatusCanceled {
+							return nil
+						}
+
+						return model.Error("unexpected_status")
+					},
+				},
+				phRepo: &repository.MockOrderPayHistory{},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			svc := &Service{orderRepo: tc.given.ordRepo, payHistRepo: tc.given.phRepo}
+
+			ctx := context.Background()
+
+			actual := svc.processStripeNotificationTx(ctx, nil, tc.given.ntf)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestShouldUpdateOrderStripeSubID(t *testing.T) {
+	type tcGiven struct {
+		ord   *model.Order
+		subID string
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "true_sub_id_not_set",
+			given: tcGiven{
+				ord:   &model.Order{},
+				subID: "sub_id",
+			},
+			exp: true,
+		},
+
+		{
+			name: "true_sub_id_empty",
+			given: tcGiven{
+				ord: &model.Order{
+					Metadata: datastore.Metadata{
+						"stripeSubscriptionId": "",
+					},
+				},
+				subID: "sub_id",
+			},
+			exp: true,
+		},
+
+		{
+			name: "true_sub_id_different",
+			given: tcGiven{
+				ord: &model.Order{
+					Metadata: datastore.Metadata{
+						"stripeSubscriptionId": "old_sub_id",
+					},
+				},
+				subID: "sub_id",
+			},
+			exp: true,
+		},
+
+		{
+			name: "false_sub_id_same",
+			given: tcGiven{
+				ord: &model.Order{
+					Metadata: datastore.Metadata{
+						"stripeSubscriptionId": "sub_id",
+					},
+				},
+				subID: "sub_id",
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := shouldUpdateOrderStripeSubID(tc.given.ord, tc.given.subID)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
 type mockPaidOrderCreator struct {
 	fnCreateOrderPremium        func(ctx context.Context, req *model.CreateOrderRequestNew, ordNew *model.OrderNew, items []model.OrderItem) (*model.Order, error)
 	fnRenewOrderWithExpPaidTime func(ctx context.Context, id uuid.UUID, expt, paidt time.Time) error

--- a/services/skus/stripe.go
+++ b/services/skus/stripe.go
@@ -1,0 +1,169 @@
+package skus
+
+import (
+	"encoding/json"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stripe/stripe-go/v72"
+
+	"github.com/brave-intl/bat-go/services/skus/model"
+)
+
+const (
+	errStripeSkipEvent        = model.Error("stripe: skip webhook event")
+	errStripeUnsupportedEvent = model.Error("stripe: unsupported webhook event")
+	errStripeNoInvoiceSub     = model.Error("strupe: no invoice subscription")
+	errStripeNoInvoiceLines   = model.Error("stripe: no invoice lines")
+	errStripeOrderIDMissing   = model.Error("stripe: order_id missing")
+	errStripeInvalidSubPeriod = model.Error("stripe: invalid subscription period")
+)
+
+type stripeNotification struct {
+	raw     *stripe.Event
+	invoice *stripe.Invoice
+	sub     *stripe.Subscription
+}
+
+func parseStripeNotification(raw *stripe.Event) (*stripeNotification, error) {
+	result := &stripeNotification{
+		raw: raw,
+	}
+
+	switch raw.Type {
+	case "invoice.paid":
+		val, err := parseStripeEventData[stripe.Invoice](raw.Data.Raw)
+		if err != nil {
+			return nil, err
+		}
+
+		result.invoice = val
+
+		return result, nil
+
+	case "customer.subscription.deleted":
+		val, err := parseStripeEventData[stripe.Subscription](raw.Data.Raw)
+		if err != nil {
+			return nil, err
+		}
+
+		result.sub = val
+
+		return result, nil
+
+	default:
+		return nil, errStripeSkipEvent
+	}
+}
+
+func (x *stripeNotification) shouldProcess() bool {
+	return x.shouldRenew() || x.shouldCancel()
+}
+
+func (x *stripeNotification) shouldRenew() bool {
+	return x.invoice != nil && x.raw.Type == "invoice.paid"
+}
+
+func (x *stripeNotification) shouldCancel() bool {
+	return x.sub != nil && x.raw.Type == "customer.subscription.deleted"
+}
+
+func (x *stripeNotification) ntfType() string {
+	return x.raw.Type
+}
+
+func (x *stripeNotification) ntfSubType() string {
+	switch {
+	case x.invoice != nil && x.sub == nil:
+		return "invoice"
+
+	case x.sub != nil && x.invoice == nil:
+		return "subscription"
+
+	default:
+		return "unknown"
+	}
+}
+
+func (x *stripeNotification) effect() string {
+	switch {
+	case x.shouldRenew():
+		return "renew"
+
+	case x.shouldCancel():
+		return "cancel"
+
+	default:
+		return "skip"
+	}
+}
+
+func (x *stripeNotification) subID() (string, error) {
+	switch {
+	case x.invoice != nil:
+		if x.invoice.Subscription == nil {
+			return "", errStripeNoInvoiceSub
+		}
+
+		return x.invoice.Subscription.ID, nil
+
+	case x.sub != nil:
+		return x.sub.ID, nil
+
+	default:
+		return "", errStripeUnsupportedEvent
+	}
+}
+
+func (x *stripeNotification) orderID() (uuid.UUID, error) {
+	switch {
+	case x.invoice != nil:
+		if x.invoice.Lines == nil || len(x.invoice.Lines.Data) == 0 {
+			return uuid.Nil, errStripeNoInvoiceLines
+		}
+
+		id, ok := x.invoice.Lines.Data[0].Metadata["orderID"]
+		if !ok {
+			return uuid.Nil, errStripeOrderIDMissing
+		}
+
+		return uuid.FromString(id)
+
+	case x.sub != nil:
+		id, ok := x.sub.Metadata["orderID"]
+		if !ok {
+			return uuid.Nil, errStripeOrderIDMissing
+		}
+
+		return uuid.FromString(id)
+
+	default:
+		return uuid.Nil, errStripeUnsupportedEvent
+	}
+}
+
+func (x *stripeNotification) expiresTime() (time.Time, error) {
+	if x.invoice == nil {
+		return time.Time{}, errStripeUnsupportedEvent
+	}
+
+	if x.invoice.Lines == nil || len(x.invoice.Lines.Data) == 0 {
+		return time.Time{}, errStripeNoInvoiceLines
+	}
+
+	sub := x.invoice.Lines.Data[0]
+	if sub.Period == nil || sub.Period.End == 0 {
+		return time.Time{}, errStripeInvalidSubPeriod
+	}
+
+	return time.Unix(sub.Period.End, 0).UTC(), nil
+}
+
+func parseStripeEventData[T any](data []byte) (*T, error) {
+	var result T
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}

--- a/services/skus/stripe_test.go
+++ b/services/skus/stripe_test.go
@@ -1,0 +1,665 @@
+package skus
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+	should "github.com/stretchr/testify/assert"
+	must "github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v72"
+)
+
+func TestParseStripeNotification(t *testing.T) {
+	// WARNING: The main purpose of this test is to check if parsing works.
+	//
+	// It's been discovered that SKUs uses v72 which corresponds to the API version 2020-08-27.
+	// Stripe sends us webhooks in the 2020-03-02 format (v70 and v71).
+	//
+	// So the code in handleStripeWebhook has been unreliable all this time.
+	//
+	// This test makes sure that the data we need can still be obtained despite the version mismatch.
+	// After the version has been updated, this test should still pass.
+	t.Run("invoice_paid", func(t *testing.T) {
+		raw, err := os.ReadFile(filepath.Join("testdata", "stripe_invoice_paid.json"))
+		must.Equal(t, nil, err)
+
+		event := &stripe.Event{}
+
+		{
+			err := json.Unmarshal(raw, event)
+			must.Equal(t, nil, err)
+		}
+
+		should.Equal(t, "invoice.paid", event.Type)
+
+		ntf, err := parseStripeNotification(event)
+		must.Equal(t, nil, err)
+
+		should.Equal(t, "sub_1PZ6NTBSm1mtrN9nhOEgB0jm", ntf.invoice.Subscription.ID)
+
+		must.Equal(t, 1, len(ntf.invoice.Lines.Data))
+
+		sub := ntf.invoice.Lines.Data[0]
+
+		should.Equal(t, "subscription", string(sub.Type))
+		should.Equal(t, "sub_1PZ6NTBSm1mtrN9nhOEgB0jm", sub.Subscription)
+		should.Equal(t, "f0eb952b-90df-4fd3-b079-c4ea1effb38d", sub.Metadata["orderID"])
+
+		must.Equal(t, true, sub.Period != nil)
+		should.Equal(t, int64(1720163778), sub.Period.Start)
+		should.Equal(t, time.Date(2024, time.July, 5, 07, 16, 18, 0, time.UTC), time.Unix(sub.Period.Start, 0).UTC())
+
+		should.Equal(t, int64(1720768578), sub.Period.End)
+		should.Equal(t, time.Date(2024, time.July, 12, 07, 16, 18, 0, time.UTC), time.Unix(sub.Period.End, 0).UTC())
+	})
+
+	t.Run("customer_subscription_deleted", func(t *testing.T) {
+		raw, err := os.ReadFile(filepath.Join("testdata", "stripe_sub_deleted.json"))
+		must.Equal(t, nil, err)
+
+		event := &stripe.Event{}
+
+		{
+			err := json.Unmarshal(raw, event)
+			must.Equal(t, nil, err)
+		}
+
+		should.Equal(t, "customer.subscription.deleted", event.Type)
+
+		ntf, err := parseStripeNotification(event)
+		must.Equal(t, nil, err)
+
+		should.Equal(t, "sub_1PZ6NTBSm1mtrN9nhOEgB0jm", ntf.sub.ID)
+		should.Equal(t, "f0eb952b-90df-4fd3-b079-c4ea1effb38d", ntf.sub.Metadata["orderID"])
+	})
+}
+
+func TestStripeNotification_shouldProcess(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   bool
+	}{
+		{
+			name: "renew",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: true,
+		},
+
+		{
+			name: "cancel",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{},
+			},
+			exp: true,
+		},
+
+		{
+			name: "skip",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.updated"},
+				invoice: &stripe.Invoice{},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.shouldProcess()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_shouldRenew(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   bool
+	}{
+		{
+			name: "no_invoice_wrong_type",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "something_else"},
+			},
+		},
+
+		{
+			name: "invoice_wrong_type",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "something_else"},
+				invoice: &stripe.Invoice{},
+			},
+		},
+
+		{
+			name: "no_invoice_correct_type",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+			},
+		},
+
+		{
+			name: "renew",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.shouldRenew()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_shouldCancel(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   bool
+	}{
+		{
+			name: "no_sub_wrong_type",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "something_else"},
+			},
+		},
+
+		{
+			name: "sub_wrong_type",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "something_else"},
+				sub: &stripe.Subscription{},
+			},
+		},
+
+		{
+			name: "no_sub_correct_type",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+			},
+		},
+
+		{
+			name: "cancel",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{},
+			},
+			exp: true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.shouldCancel()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_ntfType(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   string
+	}{
+		{
+			name: "invoice_paid",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+			},
+			exp: "invoice.paid",
+		},
+
+		{
+			name: "customer_subscription_deleted",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+			},
+			exp: "customer.subscription.deleted",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.ntfType()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_ntfSubType(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   string
+	}{
+		{
+			name: "invoice",
+			given: &stripeNotification{
+				invoice: &stripe.Invoice{},
+			},
+			exp: "invoice",
+		},
+
+		{
+			name: "subscription",
+			given: &stripeNotification{
+				sub: &stripe.Subscription{},
+			},
+			exp: "subscription",
+		},
+
+		{
+			name: "unknown_both",
+			given: &stripeNotification{
+				invoice: &stripe.Invoice{},
+				sub:     &stripe.Subscription{},
+			},
+			exp: "unknown",
+		},
+
+		{
+			name:  "unknown_neither",
+			given: &stripeNotification{},
+			exp:   "unknown",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.ntfSubType()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_effect(t *testing.T) {
+	tests := []struct {
+		name  string
+		given *stripeNotification
+		exp   string
+	}{
+		{
+			name: "renew",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: "renew",
+		},
+
+		{
+			name: "cancel",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{},
+			},
+			exp: "cancel",
+		},
+
+		{
+			name: "skip",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.updated"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: "skip",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.effect()
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestStripeNotification_subID(t *testing.T) {
+	type tcExpected struct {
+		val string
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given *stripeNotification
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invoice_no_sub",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: tcExpected{
+				err: errStripeNoInvoiceSub,
+			},
+		},
+
+		{
+			name: "invoice_sub",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Subscription: &stripe.Subscription{ID: "sub_id"},
+				},
+			},
+			exp: tcExpected{
+				val: "sub_id",
+			},
+		},
+
+		{
+			name: "sub",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{ID: "sub_id"},
+			},
+			exp: tcExpected{
+				val: "sub_id",
+			},
+		},
+
+		{
+			name: "unsupported",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "unsupported"},
+			},
+			exp: tcExpected{
+				err: errStripeUnsupportedEvent,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.subID()
+			must.Equal(t, tc.exp.err, err)
+
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
+func TestStripeNotification_orderID(t *testing.T) {
+	type tcExpected struct {
+		val uuid.UUID
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given *stripeNotification
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invoice_no_lines",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: tcExpected{
+				val: uuid.Nil,
+				err: errStripeNoInvoiceLines,
+			},
+		},
+
+		{
+			name: "invoice_no_empty_lintes",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{},
+				},
+			},
+			exp: tcExpected{
+				val: uuid.Nil,
+				err: errStripeNoInvoiceLines,
+			},
+		},
+
+		{
+			name: "invoice_no_order_id",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{
+						Data: []*stripe.InvoiceLine{
+							{
+								Metadata: map[string]string{"key": "value"},
+							},
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: uuid.Nil,
+				err: errStripeOrderIDMissing,
+			},
+		},
+
+		{
+			name: "invoice_valid",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{
+						Data: []*stripe.InvoiceLine{
+							{
+								Metadata: map[string]string{
+									"orderID": "f100ded0-0000-4000-a000-000000000000",
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
+			},
+		},
+
+		{
+			name: "sub_no_order_id",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{
+					ID:       "sub_id",
+					Metadata: map[string]string{"key": "value"},
+				},
+			},
+			exp: tcExpected{
+				val: uuid.Nil,
+				err: errStripeOrderIDMissing,
+			},
+		},
+
+		{
+			name: "sub_valid",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "customer.subscription.deleted"},
+				sub: &stripe.Subscription{
+					ID: "sub_id",
+					Metadata: map[string]string{
+						"orderID": "f100ded0-0000-4000-a000-000000000000",
+					},
+				},
+			},
+			exp: tcExpected{
+				val: uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
+			},
+		},
+
+		{
+			name: "unsupported",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "unsupported"},
+			},
+			exp: tcExpected{
+				val: uuid.Nil,
+				err: errStripeUnsupportedEvent,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.orderID()
+			must.Equal(t, tc.exp.err, err)
+
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}
+
+func TestStripeNotification_expiresTime(t *testing.T) {
+	type tcExpected struct {
+		val time.Time
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given *stripeNotification
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "no_invoice",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+			},
+			exp: tcExpected{
+				err: errStripeUnsupportedEvent,
+			},
+		},
+
+		{
+			name: "invoice_no_lines",
+			given: &stripeNotification{
+				raw:     &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{},
+			},
+			exp: tcExpected{
+				err: errStripeNoInvoiceLines,
+			},
+		},
+
+		{
+			name: "invoice_no_empty_lintes",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{},
+				},
+			},
+			exp: tcExpected{
+				err: errStripeNoInvoiceLines,
+			},
+		},
+
+		{
+			name: "invoice_no_period",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{
+						Data: []*stripe.InvoiceLine{&stripe.InvoiceLine{}},
+					},
+				},
+			},
+			exp: tcExpected{
+				err: errStripeInvalidSubPeriod,
+			},
+		},
+
+		{
+			name: "invoice_zero_period",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{
+						Data: []*stripe.InvoiceLine{
+							&stripe.InvoiceLine{
+								Period: &stripe.Period{},
+							},
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				err: errStripeInvalidSubPeriod,
+			},
+		},
+
+		{
+			name: "valid",
+			given: &stripeNotification{
+				raw: &stripe.Event{Type: "invoice.paid"},
+				invoice: &stripe.Invoice{
+					Lines: &stripe.InvoiceLineList{
+						Data: []*stripe.InvoiceLine{
+							&stripe.InvoiceLine{
+								Period: &stripe.Period{
+									Start: 1719792000,
+									End:   1722470400,
+								},
+							},
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: time.Date(2024, time.August, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := tc.given.expiresTime()
+			must.Equal(t, tc.exp.err, err)
+
+			should.Equal(t, tc.exp.val, actual)
+		})
+	}
+}

--- a/services/skus/testdata/stripe_invoice_paid.json
+++ b/services/skus/testdata/stripe_invoice_paid.json
@@ -1,0 +1,227 @@
+{
+    "id": "evt_1PZ6NaBSm1mtrN9nAQykRYwm",
+    "object": "event",
+    "api_version": "2020-03-02",
+    "created": 1720163784,
+    "data": {
+        "object": {
+            "id": "in_1PZ6NUBSm1mtrN9n7GFLtsrN",
+            "object": "invoice",
+            "account_country": "US",
+            "account_name": "Brave Software, Inc.",
+            "account_tax_ids": null,
+            "amount_due": 0,
+            "amount_paid": 0,
+            "amount_remaining": 0,
+            "amount_shipping": 0,
+            "application": null,
+            "application_fee_amount": null,
+            "attempt_count": 0,
+            "attempted": true,
+            "auto_advance": false,
+            "automatic_tax": {
+                "enabled": false,
+                "liability": null,
+                "status": null
+            },
+            "billing_reason": "subscription_create",
+            "charge": null,
+            "collection_method": "charge_automatically",
+            "created": 1720163780,
+            "currency": "usd",
+            "custom_fields": null,
+            "customer": "cus_QPwFwyINLgIcPd",
+            "customer_address": {
+                "city": null,
+                "country": "AU",
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+            },
+            "customer_email": "facade00-0000-4000-a000-000000000000@mailinator.com",
+            "customer_name": "69",
+            "customer_phone": null,
+            "customer_shipping": null,
+            "customer_tax_exempt": "none",
+            "customer_tax_ids": [],
+            "default_payment_method": null,
+            "default_source": null,
+            "default_tax_rates": [],
+            "description": null,
+            "discount": null,
+            "discounts": [],
+            "due_date": null,
+            "effective_at": 1720163780,
+            "ending_balance": 0,
+            "footer": "Brave Premium products are paid services and at your sole discretion, you can pay to subscribe to any or all of them. They include Brave Leo, Brave Firewall + VPN, Brave Talk Premium, and Brave Search Premium.\n\nPaid subscriptions automatically renew until canceled on the Account Site at https://account.brave.com/. Subscriptions can be canceled at any time unless specified otherwise. You can find more information on the Brave Help Center, including how to cancel subscriptions to Brave Premium products and services: https://support.brave.com",
+            "from_invoice": null,
+            "hosted_invoice_url": "https://invoice.stripe.com/i/acct_1G6QBvBSm1mtrN9n/test_YWNjdF8xRzZRQnZCU20xbXRyTjluLF9RUHdHN3pYd2h5SG9vcnBDajhIdVpmSjBHYXBycmxVLDExMDcwNDU4Ng0200MxEBeWj6?s=ap",
+            "invoice_pdf": "https://pay.stripe.com/invoice/acct_1G6QBvBSm1mtrN9n/test_YWNjdF8xRzZRQnZCU20xbXRyTjluLF9RUHdHN3pYd2h5SG9vcnBDajhIdVpmSjBHYXBycmxVLDExMDcwNDU4Ng0200MxEBeWj6/pdf?s=ap",
+            "issuer": {
+                "type": "self"
+            },
+            "last_finalization_error": null,
+            "latest_revision": null,
+            "lines": {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "il_1PZ6NUBSm1mtrN9nga12A4jy",
+                        "object": "line_item",
+                        "amount": 0,
+                        "amount_excluding_tax": 0,
+                        "currency": "usd",
+                        "description": "Trial period for Brave Talk",
+                        "discount_amounts": [],
+                        "discountable": true,
+                        "discounts": [],
+                        "invoice": "in_1PZ6NUBSm1mtrN9n7GFLtsrN",
+                        "livemode": false,
+                        "metadata": {
+                            "orderID": "f0eb952b-90df-4fd3-b079-c4ea1effb38d"
+                        },
+                        "period": {
+                            "end": 1720768578,
+                            "start": 1720163778
+                        },
+                        "plan": {
+                            "id": "price_1JooWTBSm1mtrN9ng3CpG4m4",
+                            "object": "plan",
+                            "active": true,
+                            "aggregate_usage": null,
+                            "amount": 700,
+                            "amount_decimal": "700",
+                            "billing_scheme": "per_unit",
+                            "created": 1635250377,
+                            "currency": "usd",
+                            "interval": "month",
+                            "interval_count": 1,
+                            "livemode": false,
+                            "metadata": {},
+                            "meter": null,
+                            "nickname": null,
+                            "product": "prod_KTm4FtcniuTAOb",
+                            "tiers": null,
+                            "tiers_mode": null,
+                            "transform_usage": null,
+                            "trial_period_days": null,
+                            "usage_type": "licensed"
+                        },
+                        "price": {
+                            "id": "price_1JooWTBSm1mtrN9ng3CpG4m4",
+                            "object": "price",
+                            "active": true,
+                            "billing_scheme": "per_unit",
+                            "created": 1635250377,
+                            "currency": "usd",
+                            "custom_unit_amount": null,
+                            "livemode": false,
+                            "lookup_key": null,
+                            "metadata": {},
+                            "nickname": null,
+                            "product": "prod_KTm4FtcniuTAOb",
+                            "recurring": {
+                                "aggregate_usage": null,
+                                "interval": "month",
+                                "interval_count": 1,
+                                "meter": null,
+                                "trial_period_days": null,
+                                "usage_type": "licensed"
+                            },
+                            "tax_behavior": "unspecified",
+                            "tiers_mode": null,
+                            "transform_quantity": null,
+                            "type": "recurring",
+                            "unit_amount": 700,
+                            "unit_amount_decimal": "700"
+                        },
+                        "proration": false,
+                        "proration_details": {
+                            "credited_items": null
+                        },
+                        "quantity": 1,
+                        "subscription": "sub_1PZ6NTBSm1mtrN9nhOEgB0jm",
+                        "subscription_item": "si_QPwFMHw06E9UQl",
+                        "tax_amounts": [],
+                        "tax_rates": [],
+                        "type": "subscription",
+                        "unit_amount_excluding_tax": "0"
+                    }
+                ],
+                "has_more": false,
+                "total_count": 1,
+                "url": "/v1/invoices/in_1PZ6NUBSm1mtrN9n7GFLtsrN/lines"
+            },
+            "livemode": false,
+            "metadata": {},
+            "next_payment_attempt": null,
+            "number": "55E9035F-0001",
+            "on_behalf_of": null,
+            "paid": true,
+            "paid_out_of_band": false,
+            "payment_intent": null,
+            "payment_settings": {
+                "default_mandate": null,
+                "payment_method_options": {
+                    "acss_debit": null,
+                    "bancontact": null,
+                    "card": {
+                        "request_three_d_secure": "automatic"
+                    },
+                    "customer_balance": null,
+                    "konbini": null,
+                    "sepa_debit": null,
+                    "us_bank_account": null
+                },
+                "payment_method_types": null
+            },
+            "period_end": 1720163778,
+            "period_start": 1720163778,
+            "post_payment_credit_notes_amount": 0,
+            "pre_payment_credit_notes_amount": 0,
+            "quote": null,
+            "receipt_number": null,
+            "rendering": {
+                "amount_tax_display": null,
+                "pdf": null
+            },
+            "rendering_options": null,
+            "shipping_cost": null,
+            "shipping_details": null,
+            "starting_balance": 0,
+            "statement_descriptor": null,
+            "status": "paid",
+            "status_transitions": {
+                "finalized_at": 1720163780,
+                "marked_uncollectible_at": null,
+                "paid_at": 1720163778,
+                "voided_at": null
+            },
+            "subscription": "sub_1PZ6NTBSm1mtrN9nhOEgB0jm",
+            "subscription_details": {
+                "metadata": {
+                    "orderID": "f0eb952b-90df-4fd3-b079-c4ea1effb38d"
+                }
+            },
+            "subtotal": 0,
+            "subtotal_excluding_tax": 0,
+            "tax": null,
+            "tax_percent": null,
+            "test_clock": null,
+            "total": 0,
+            "total_discount_amounts": [],
+            "total_excluding_tax": 0,
+            "total_tax_amounts": [],
+            "transfer_data": null,
+            "webhooks_delivered_at": 1720163780
+        }
+    },
+    "livemode": false,
+    "pending_webhooks": 1,
+    "request": {
+        "id": null,
+        "idempotency_key": null
+    },
+    "type": "invoice.paid"
+}

--- a/services/skus/testdata/stripe_sub_deleted.json
+++ b/services/skus/testdata/stripe_sub_deleted.json
@@ -1,0 +1,190 @@
+{
+    "id": "evt_1PaDa9BSm1mtrN9ntKuZf3bO",
+    "object": "event",
+    "api_version": "2020-03-02",
+    "created": 1720429801,
+    "data": {
+        "object": {
+            "id": "sub_1PZ6NTBSm1mtrN9nhOEgB0jm",
+            "object": "subscription",
+            "application": null,
+            "application_fee_percent": null,
+            "automatic_tax": {
+                "enabled": false,
+                "liability": null
+            },
+            "billing_cycle_anchor": 1720768578,
+            "billing_cycle_anchor_config": null,
+            "billing_thresholds": null,
+            "cancel_at": null,
+            "cancel_at_period_end": false,
+            "canceled_at": 1720429801,
+            "cancellation_details": {
+                "comment": null,
+                "feedback": null,
+                "reason": "cancellation_requested"
+            },
+            "collection_method": "charge_automatically",
+            "created": 1720163778,
+            "currency": "usd",
+            "current_period_end": 1720768578,
+            "current_period_start": 1720163778,
+            "customer": "cus_QPwFwyINLgIcPd",
+            "days_until_due": null,
+            "default_payment_method": "pm_1PZ6NOBSm1mtrN9nPjVkEml6",
+            "default_source": null,
+            "default_tax_rates": [],
+            "description": null,
+            "discount": null,
+            "discounts": [],
+            "ended_at": 1720429801,
+            "invoice_settings": {
+                "account_tax_ids": null,
+                "issuer": {
+                    "type": "self"
+                }
+            },
+            "items": {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "si_QPwFMHw06E9UQl",
+                        "object": "subscription_item",
+                        "billing_thresholds": null,
+                        "created": 1720163780,
+                        "discounts": [],
+                        "metadata": {},
+                        "plan": {
+                            "id": "price_1JooWTBSm1mtrN9ng3CpG4m4",
+                            "object": "plan",
+                            "active": true,
+                            "aggregate_usage": null,
+                            "amount": 700,
+                            "amount_decimal": "700",
+                            "billing_scheme": "per_unit",
+                            "created": 1635250377,
+                            "currency": "usd",
+                            "interval": "month",
+                            "interval_count": 1,
+                            "livemode": false,
+                            "metadata": {},
+                            "meter": null,
+                            "nickname": null,
+                            "product": "prod_KTm4FtcniuTAOb",
+                            "tiers": null,
+                            "tiers_mode": null,
+                            "transform_usage": null,
+                            "trial_period_days": null,
+                            "usage_type": "licensed"
+                        },
+                        "price": {
+                            "id": "price_1JooWTBSm1mtrN9ng3CpG4m4",
+                            "object": "price",
+                            "active": true,
+                            "billing_scheme": "per_unit",
+                            "created": 1635250377,
+                            "currency": "usd",
+                            "custom_unit_amount": null,
+                            "livemode": false,
+                            "lookup_key": null,
+                            "metadata": {},
+                            "nickname": null,
+                            "product": "prod_KTm4FtcniuTAOb",
+                            "recurring": {
+                                "aggregate_usage": null,
+                                "interval": "month",
+                                "interval_count": 1,
+                                "meter": null,
+                                "trial_period_days": null,
+                                "usage_type": "licensed"
+                            },
+                            "tax_behavior": "unspecified",
+                            "tiers_mode": null,
+                            "transform_quantity": null,
+                            "type": "recurring",
+                            "unit_amount": 700,
+                            "unit_amount_decimal": "700"
+                        },
+                        "quantity": 1,
+                        "subscription": "sub_1PZ6NTBSm1mtrN9nhOEgB0jm",
+                        "tax_rates": []
+                    }
+                ],
+                "has_more": false,
+                "total_count": 1,
+                "url": "/v1/subscription_items?subscription=sub_1PZ6NTBSm1mtrN9nhOEgB0jm"
+            },
+            "latest_invoice": "in_1PZ6NUBSm1mtrN9n7GFLtsrN",
+            "livemode": false,
+            "metadata": {
+                "orderID": "f0eb952b-90df-4fd3-b079-c4ea1effb38d"
+            },
+            "next_pending_invoice_item_invoice": null,
+            "on_behalf_of": null,
+            "pause_collection": null,
+            "payment_settings": {
+                "payment_method_options": {
+                    "acss_debit": null,
+                    "bancontact": null,
+                    "card": {
+                        "network": null,
+                        "request_three_d_secure": "automatic"
+                    },
+                    "customer_balance": null,
+                    "konbini": null,
+                    "sepa_debit": null,
+                    "us_bank_account": null
+                },
+                "payment_method_types": null,
+                "save_default_payment_method": "off"
+            },
+            "pending_invoice_item_interval": null,
+            "pending_setup_intent": null,
+            "pending_update": null,
+            "plan": {
+                "id": "price_1JooWTBSm1mtrN9ng3CpG4m4",
+                "object": "plan",
+                "active": true,
+                "aggregate_usage": null,
+                "amount": 700,
+                "amount_decimal": "700",
+                "billing_scheme": "per_unit",
+                "created": 1635250377,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": false,
+                "metadata": {},
+                "meter": null,
+                "nickname": null,
+                "product": "prod_KTm4FtcniuTAOb",
+                "tiers": null,
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "schedule": null,
+            "start_date": 1720163778,
+            "status": "canceled",
+            "tax_percent": null,
+            "test_clock": null,
+            "transfer_data": null,
+            "trial_end": 1720768578,
+            "trial_settings": {
+                "end_behavior": {
+                    "missing_payment_method": "create_invoice"
+                }
+            },
+            "trial_start": 1720163778
+        }
+    },
+    "livemode": false,
+    "pending_webhooks": 1,
+    "request": {
+        "id": "req_5YXNegiDpL0NML",
+        "idempotency_key": null
+    },
+    "type": "customer.subscription.deleted"
+}


### PR DESCRIPTION
### Summary

This PR updates the handling of the Stripe webhooks, improving on how it's done as well as setting the expiry time on orders more accurately.

### Main Changes

- the `invoice.updated` webhook is now completely ignored, as it has never had any useful processing;
- the order expiry date is now set up to the expiry date from an `invoice.paid` event plus a leeway (for the case if the next billing cycle's event has been delayed for whatever reason);
- the code is prepared for handling the subscription cancellation events.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->

---

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZDJlcXJ4N2N4d3oydXpkZmZnYWVlMHg2ZnJxcmd1Y2diMjQ5c2t1OSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UTktOcalNjIAoGDRdk/giphy.gif)
