### PR TITLE
fix: io read timeout on create item creds endpoint

### DIFF
--- a/services/grant/cmd/grant.go
+++ b/services/grant/cmd/grant.go
@@ -703,7 +703,7 @@ func GrantServer(
 	srv := http.Server{
 		Addr:         ":3333",
 		Handler:      chi.ServerBaseContext(ctx, r),
-		ReadTimeout:  3 * time.Second,
+		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 20 * time.Second,
 	}
 	err = srv.ListenAndServe()


### PR DESCRIPTION
### Summary

Use `io.ReadAll` instead of `requestutils.ReadJSON` and increase the read timeout for grants server.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
resolves https://github.com/brave-intl/bat-go/issues/2598

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
