### PR TITLE
feat: use aws image registry instead of docker

### DIFF
--- a/docker-compose.dev-refresh.yml
+++ b/docker-compose.dev-refresh.yml
@@ -8,7 +8,7 @@ services:
   # every time a file changes.
   dev-refresh:
     container_name: grant-dev-refresh
-    image: golang:1.19
+    image: public.ecr.aws/docker/library/golang:1.19
     ports:
       - "3335:3333"
       - "6061:6061"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,7 +308,7 @@ services:
 
   dynamodb:
     container_name: dynamodb
-    image: amazon/dynamodb-local:1.21.0
+    image: public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local:1.21.0
     networks:
       - grant
     ports:


### PR DESCRIPTION
### Summary

Subj. Docker rate limiting is very annoying, but logging in is not going to be implemented any time soon, so our only hope is to use the AWS Image Registry where possible.

NOTE: Not all images are found in the AWS Registry.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [x] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
