### PR TITLE
fix: use proper expiry time in getorder endpoint

### DIFF
--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -407,7 +407,7 @@ func (suite *ControllersTestSuite) TestGetOrder() {
 	req, err := http.NewRequest("GET", "/v1/orders/{orderID}", nil)
 	suite.Require().NoError(err)
 
-	getOrderHandler := GetOrder(suite.service)
+	getOrderHandler := handleGetOrder(suite.service)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("orderID", order.ID.String())
 	getReq := req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
@@ -435,7 +435,7 @@ func (suite *ControllersTestSuite) TestGetMissingOrder() {
 	req, err := http.NewRequest("GET", "/v1/orders/{orderID}", nil)
 	suite.Require().NoError(err)
 
-	getOrderHandler := GetOrder(suite.service)
+	getOrderHandler := handleGetOrder(suite.service)
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("orderID", "9645ca16-bc93-4e37-8edf-cb35b1763216")
 	getReq := req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
-	"github.com/stripe/stripe-go/v72"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/brave-intl/bat-go/libs/logging"
@@ -154,19 +153,4 @@ func (s *Service) CreateOrderItemFromMacaroon(ctx context.Context, sku string, q
 	orderItem.Subtotal = orderItem.Price.Mul(newQuantity)
 
 	return &orderItem, allowedPaymentMethods, issuerConfig, nil
-}
-
-func getCustEmailFromStripeCheckout(sess *stripe.CheckoutSession) string {
-	// Use the customer email if the customer has completed the payment flow.
-	if sess.Customer != nil && sess.Customer.Email != "" {
-		return sess.Customer.Email
-	}
-
-	// This is unlikely to be set, but in case it is, use it.
-	if sess.CustomerEmail != "" {
-		return sess.CustomerEmail
-	}
-
-	// Default to empty, Stripe will ask the customer.
-	return ""
 }

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -13,15 +13,16 @@ import (
 )
 
 type MockOrder struct {
-	FnGet                 func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error)
-	FnGetByExternalID     func(ctx context.Context, dbi sqlx.QueryerContext, extID string) (*model.Order, error)
-	FnCreate              func(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error)
-	FnSetStatus           func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
-	FnSetExpiresAt        func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
-	FnSetLastPaidAt       func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
-	FnAppendMetadata      func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error
-	FnAppendMetadataInt   func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error
-	FnAppendMetadataInt64 func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int64) error
+	FnGet                               func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error)
+	FnGetByExternalID                   func(ctx context.Context, dbi sqlx.QueryerContext, extID string) (*model.Order, error)
+	FnCreate                            func(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error)
+	FnSetStatus                         func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
+	FnSetExpiresAt                      func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
+	FnSetLastPaidAt                     func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
+	FnAppendMetadata                    func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error
+	FnAppendMetadataInt                 func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error
+	FnAppendMetadataInt64               func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int64) error
+	FnGetExpiredStripeCheckoutSessionID func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) (string, error)
 }
 
 func (r *MockOrder) Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
@@ -113,6 +114,14 @@ func (r *MockOrder) AppendMetadataInt64(ctx context.Context, dbi sqlx.ExecerCont
 	}
 
 	return r.FnAppendMetadataInt64(ctx, dbi, id, key, val)
+}
+
+func (r *MockOrder) GetExpiredStripeCheckoutSessionID(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) (string, error) {
+	if r.FnGetExpiredStripeCheckoutSessionID == nil {
+		return "sub_id", nil
+	}
+
+	return r.FnGetExpiredStripeCheckoutSessionID(ctx, dbi, orderID)
 }
 
 type MockOrderItem struct {

--- a/services/skus/xstripe/mock.go
+++ b/services/skus/xstripe/mock.go
@@ -1,0 +1,73 @@
+package xstripe
+
+import (
+	"context"
+
+	"github.com/stripe/stripe-go/v72"
+)
+
+type MockClient struct {
+	FnSession       func(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
+	FnCreateSession func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
+	FnSubscription  func(ctx context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error)
+	FnFindCustomer  func(ctx context.Context, email string) (*stripe.Customer, bool)
+}
+
+func (c *MockClient) Session(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+	if c.FnSession == nil {
+		result := &stripe.CheckoutSession{ID: id}
+
+		return result, nil
+	}
+
+	return c.FnSession(ctx, id, params)
+}
+
+func (c *MockClient) CreateSession(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+	if c.FnCreateSession == nil {
+		result := &stripe.CheckoutSession{
+			ID:                 "cs_test_id",
+			PaymentMethodTypes: []string{"card"},
+			Mode:               stripe.CheckoutSessionModeSubscription,
+			SuccessURL:         *params.SuccessURL,
+			CancelURL:          *params.CancelURL,
+			ClientReferenceID:  *params.ClientReferenceID,
+			Subscription: &stripe.Subscription{
+				ID: "sub_id",
+				Metadata: map[string]string{
+					"orderID": *params.ClientReferenceID,
+				},
+			},
+			AllowPromotionCodes: true,
+		}
+
+		return result, nil
+	}
+
+	return c.FnCreateSession(ctx, params)
+}
+
+func (c *MockClient) Subscription(ctx context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+	if c.FnSubscription == nil {
+		result := &stripe.Subscription{
+			ID: id,
+		}
+
+		return result, nil
+	}
+
+	return c.FnSubscription(ctx, id, params)
+}
+
+func (c *MockClient) FindCustomer(ctx context.Context, email string) (*stripe.Customer, bool) {
+	if c.FnFindCustomer == nil {
+		result := &stripe.Customer{
+			ID:    "cus_id",
+			Email: email,
+		}
+
+		return result, true
+	}
+
+	return c.FnFindCustomer(ctx, email)
+}

--- a/services/skus/xstripe/xstripe.go
+++ b/services/skus/xstripe/xstripe.go
@@ -1,0 +1,60 @@
+package xstripe
+
+import (
+	"context"
+
+	"github.com/stripe/stripe-go/v72"
+	"github.com/stripe/stripe-go/v72/client"
+	"github.com/stripe/stripe-go/v72/customer"
+)
+
+type Client struct {
+	cl *client.API
+}
+
+func NewClient(cl *client.API) *Client {
+	return &Client{cl: cl}
+}
+
+func (c *Client) Session(_ context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+	return c.cl.CheckoutSessions.Get(id, params)
+}
+
+func (c *Client) CreateSession(_ context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+	return c.cl.CheckoutSessions.New(params)
+}
+
+func (c *Client) Subscription(_ context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error) {
+	return c.cl.Subscriptions.Get(id, params)
+}
+
+func (c *Client) FindCustomer(ctx context.Context, email string) (*stripe.Customer, bool) {
+	iter := c.Customers(ctx, &stripe.CustomerListParams{
+		Email: stripe.String(email),
+	})
+
+	for iter.Next() {
+		return iter.Customer(), true
+	}
+
+	return nil, false
+}
+
+func (c *Client) Customers(_ context.Context, params *stripe.CustomerListParams) *customer.Iter {
+	return c.cl.Customers.List(params)
+}
+
+func CustomerEmailFromSession(sess *stripe.CheckoutSession) string {
+	// Use the customer email if the customer has completed the payment flow.
+	if sess.Customer != nil && sess.Customer.Email != "" {
+		return sess.Customer.Email
+	}
+
+	// This is unlikely to be set, but in case it is, use it.
+	if sess.CustomerEmail != "" {
+		return sess.CustomerEmail
+	}
+
+	// Default to empty, Stripe will ask the customer.
+	return ""
+}

--- a/services/skus/xstripe/xstripe_test.go
+++ b/services/skus/xstripe/xstripe_test.go
@@ -1,4 +1,4 @@
-package skus
+package xstripe
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/stripe/stripe-go/v72"
 )
 
-func TestGetCustEmailFromStripeCheckout(t *testing.T) {
+func TestCustomerEmailFromSession(t *testing.T) {
 	tests := []struct {
 		name  string
 		exp   string
@@ -60,7 +60,7 @@ func TestGetCustEmailFromStripeCheckout(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getCustEmailFromStripeCheckout(tc.given)
+			actual := CustomerEmailFromSession(tc.given)
 			should.Equal(t, tc.exp, actual)
 		})
 	}


### PR DESCRIPTION
### Summary

This PR fixes code that could update an order associated with Stripe purchases while getting the order. This could happen in a situation where:
- either an existing session has expired, and a new had been created;
- or when the existing or new session has been paid, which would then result in marking the order as paid, and setting it's expiry time as a consequence.

That last path is important because it used to extend an order by the hardcoded one month. This is wrong for a few reasons, mainly because:
- it can be set precisely using the end of a subscription from Stripe;
- it prevented us from sully supporting annual products in Stripe.

This PR also fixes a bug where a new session could be ignored to be checked for payment status.

This PR also refactors interactions with Stripe. The Stripe client code has been wrapped to enable testing. Some places interacting with Stripe have been updated and unified (such as session creation).

Additionally, this set of changes includes vast test coverage for the changed code (which was not covered before), as well as coverage for places which have not been possible to test before as well.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
