### PR TITLE
fix: search latest receipt info first

### DIFF
--- a/services/skus/appstore.go
+++ b/services/skus/appstore.go
@@ -75,9 +75,9 @@ func (x *appStoreSrvNotification) shouldProcess() bool {
 // TODO: Update to a lookup table instead.
 func (x *appStoreSrvNotification) shouldRenew() bool {
 	switch {
-	// Initial buy.
-	case x.val.NotificationType == appstore.NotificationTypeV2Subscribed && x.val.Subtype == appstore.SubTypeV2InitialBuy:
-		return true
+	// // Initial buy.
+	// case x.val.NotificationType == appstore.NotificationTypeV2Subscribed && x.val.Subtype == appstore.SubTypeV2InitialBuy:
+	// 	return true
 
 	// Auto-renew.
 	case x.val.NotificationType == appstore.NotificationTypeV2DidRenew && x.val.Subtype == "":

--- a/services/skus/appstore.go
+++ b/services/skus/appstore.go
@@ -75,6 +75,10 @@ func (x *appStoreSrvNotification) shouldProcess() bool {
 // TODO: Update to a lookup table instead.
 func (x *appStoreSrvNotification) shouldRenew() bool {
 	switch {
+	// Initial buy.
+	case x.val.NotificationType == appstore.NotificationTypeV2Subscribed && x.val.Subtype == appstore.SubTypeV2InitialBuy:
+		return true
+
 	// Auto-renew.
 	case x.val.NotificationType == appstore.NotificationTypeV2DidRenew && x.val.Subtype == "":
 		return true

--- a/services/skus/appstore_test.go
+++ b/services/skus/appstore_test.go
@@ -70,6 +70,17 @@ func TestAppStoreSrvNotification_shouldRenew(t *testing.T) {
 
 	tests := []testCase{
 		{
+			name: "initial_buy",
+			given: &appStoreSrvNotification{
+				val: &appstore.SubscriptionNotificationV2DecodedPayload{
+					NotificationType: appstore.NotificationTypeV2Subscribed,
+					Subtype:          appstore.SubTypeV2InitialBuy,
+				},
+			},
+			exp: true,
+		},
+
+		{
 			name: "auto_renew",
 			given: &appStoreSrvNotification{
 				val: &appstore.SubscriptionNotificationV2DecodedPayload{

--- a/services/skus/appstore_test.go
+++ b/services/skus/appstore_test.go
@@ -69,16 +69,16 @@ func TestAppStoreSrvNotification_shouldRenew(t *testing.T) {
 	}
 
 	tests := []testCase{
-		{
-			name: "initial_buy",
-			given: &appStoreSrvNotification{
-				val: &appstore.SubscriptionNotificationV2DecodedPayload{
-					NotificationType: appstore.NotificationTypeV2Subscribed,
-					Subtype:          appstore.SubTypeV2InitialBuy,
-				},
-			},
-			exp: true,
-		},
+		// {
+		// 	name: "initial_buy",
+		// 	given: &appStoreSrvNotification{
+		// 		val: &appstore.SubscriptionNotificationV2DecodedPayload{
+		// 			NotificationType: appstore.NotificationTypeV2Subscribed,
+		// 			Subtype:          appstore.SubTypeV2InitialBuy,
+		// 		},
+		// 	},
+		// 	exp: true,
+		// },
 
 		{
 			name: "auto_renew",


### PR DESCRIPTION
### Summary

This PR updates the receipt handling for iOS such that `latest_receipt_info` is checked before the given `receipt`. This is because the latter might contain outdated information, the latest has to be consulted with first.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
