### PR TITLE
fix: LookupVerifier returns interface (#2631)

### DIFF
--- a/libs/httpsignature/httpsignature.go
+++ b/libs/httpsignature/httpsignature.go
@@ -56,7 +56,7 @@ type ParameterizedSignator struct {
 // Keystore provides a way to lookup a public key based on the keyID a request was signed with
 type Keystore interface {
 	// LookupVerifier based on the keyID
-	LookupVerifier(ctx context.Context, keyID string) (context.Context, *Verifier, error)
+	LookupVerifier(ctx context.Context, keyID string) (context.Context, Verifier, error)
 }
 
 // StaticKeystore is a keystore that always returns a static verifier independent of keyID
@@ -85,8 +85,8 @@ var (
 )
 
 // LookupVerifier by returning a static verifier
-func (sk *StaticKeystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, *Verifier, error) {
-	return ctx, &sk.Verifier, nil
+func (sk *StaticKeystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, Verifier, error) {
+	return ctx, sk.Verifier, nil
 }
 
 // TODO Add New function
@@ -236,7 +236,7 @@ func (pkv *ParameterizedKeystoreVerifier) VerifyRequest(req *http.Request) (cont
 	sp.Algorithm = pkv.SignatureParams.Algorithm
 	sp.Headers = pkv.SignatureParams.Headers
 
-	valid, err := sp.Verify(*verifier, pkv.Opts, req)
+	valid, err := sp.Verify(verifier, pkv.Opts, req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/libs/middleware/http_signed_test.go
+++ b/libs/middleware/http_signed_test.go
@@ -19,9 +19,9 @@ type mockKeystore struct {
 	httpsignature.Verifier
 }
 
-func (m *mockKeystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, *httpsignature.Verifier, error) {
+func (m *mockKeystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, httpsignature.Verifier, error) {
 	if keyID == "primary" {
-		return ctx, &m.Verifier, nil
+		return ctx, m.Verifier, nil
 	}
 	return nil, nil, nil
 }

--- a/services/promotion/controllers.go
+++ b/services/promotion/controllers.go
@@ -121,7 +121,7 @@ func WalletEventRouter(service *Service, vbatExpires time.Time) chi.Router {
 }
 
 // LookupVerifier based on the HTTP signing keyID, which in our case is the walletID
-func (service *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, *httpsignature.Verifier, error) {
+func (service *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, httpsignature.Verifier, error) {
 	walletID, err := uuid.FromString(keyID)
 	if err != nil {
 		return nil, nil, errorutils.Wrap(err, "KeyID format is invalid")
@@ -144,8 +144,7 @@ func (service *Service) LookupVerifier(ctx context.Context, keyID string) (conte
 			return nil, nil, err
 		}
 	}
-	tmp := httpsignature.Verifier(publicKey)
-	return ctx, &tmp, nil
+	return ctx, publicKey, nil
 }
 
 // PromotionsResponse is a list of known promotions to be consumed by the browser

--- a/services/skus/key.go
+++ b/services/skus/key.go
@@ -102,7 +102,7 @@ func GenerateSecret() (secret string, nonce string, err error) {
 }
 
 // LookupVerifier returns the merchant key corresponding to the keyID used for verifying requests
-func (s *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, *httpsignature.Verifier, error) {
+func (s *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, httpsignature.Verifier, error) {
 	rootKeyIDStr, caveats, err := cryptography.DecodeKeyID(keyID)
 	if err != nil {
 		return nil, nil, err
@@ -139,8 +139,7 @@ func (s *Service) LookupVerifier(ctx context.Context, keyID string) (context.Con
 
 	ctx = context.WithValue(ctx, merchantCtxKey{}, key.Merchant)
 
-	verifier := httpsignature.Verifier(httpsignature.HMACKey(secretKeyStr))
-	return ctx, &verifier, nil
+	return ctx, httpsignature.HMACKey(secretKeyStr), nil
 }
 
 // caveatsFromCtx returns authorized caveats from ctx.

--- a/services/wallet/keystore.go
+++ b/services/wallet/keystore.go
@@ -12,7 +12,7 @@ import (
 )
 
 // LookupVerifier based on the HTTP signing keyID, which in our case is the walletID
-func (service *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, *httpsignature.Verifier, error) {
+func (service *Service) LookupVerifier(ctx context.Context, keyID string) (context.Context, httpsignature.Verifier, error) {
 	walletID, err := uuid.FromString(keyID)
 	if err != nil {
 		return nil, nil, errorutils.Wrap(err, "KeyID format is invalid")
@@ -35,15 +35,14 @@ func (service *Service) LookupVerifier(ctx context.Context, keyID string) (conte
 			return nil, nil, err
 		}
 	}
-	tmp := httpsignature.Verifier(publicKey)
-	return ctx, &tmp, nil
+	return ctx, publicKey, nil
 }
 
 // DecodeEd25519Keystore is a keystore that "looks up" a verifier by attempting to decode the keyID as a base64 encoded ed25519 public key
 type DecodeEd25519Keystore struct{}
 
 // LookupVerifier by decoding keyID
-func (d *DecodeEd25519Keystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, *httpsignature.Verifier, error) {
+func (d *DecodeEd25519Keystore) LookupVerifier(ctx context.Context, keyID string) (context.Context, httpsignature.Verifier, error) {
 	var publicKey httpsignature.Ed25519PubKey
 	if len(keyID) > 0 {
 		var err error
@@ -54,6 +53,5 @@ func (d *DecodeEd25519Keystore) LookupVerifier(ctx context.Context, keyID string
 	} else {
 		return nil, nil, errors.New("empty KeyId is not valid")
 	}
-	verifier := httpsignature.Verifier(publicKey)
-	return ctx, &verifier, nil
+	return ctx, publicKey, nil
 }


### PR DESCRIPTION
Fix the signature of the LookupVerifier method of the Keystore interface to return Verifier interface directly, not a pointer to it to simplify implementations of the method.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
