### PR TITLE
feat: eliminate crypto.SignerOpts from Sign/Verify

### DIFF
--- a/libs/httpsignature/ed25519.go
+++ b/libs/httpsignature/ed25519.go
@@ -2,33 +2,59 @@ package httpsignature
 
 import (
 	"crypto"
+	"crypto/ed25519"
 	"encoding/hex"
-	"errors"
-	"io"
-	"strconv"
-
-	"golang.org/x/crypto/ed25519"
+	"fmt"
 )
 
 // Ed25519PubKey a wrapper type around ed25519.PublicKey to fulfill interface Verifier
 type Ed25519PubKey ed25519.PublicKey
 
+// Ed25519PubKey a wrapper type around ed25519.PublicKey to fulfill interface Signator
+type Ed25519PrivKey ed25519.PrivateKey
+
+// ED25519-specific signator with access to the corresponding public key
+type Ed25519Signator interface {
+	Signator
+	Public() Ed25519PubKey
+}
+
 // Verify the signature sig for message using the ed25519 public key pk
 // Returns true if the signature is valid, false if not and error if the key provided is not valid
-func (pk Ed25519PubKey) Verify(message, sig []byte, opts crypto.SignerOpts) (bool, error) {
+func (pk Ed25519PubKey) VerifySignature(message, sig []byte) error {
 	if l := len(pk); l != ed25519.PublicKeySize {
-		return false, errors.New("ed25519: bad public key length: " + strconv.Itoa(l))
+		return fmt.Errorf("ed25519: bad public key length: %d", l)
 	}
 
-	return ed25519.Verify(ed25519.PublicKey(pk), message, sig), nil
+	if !ed25519.Verify(ed25519.PublicKey(pk), message, sig) {
+		return ErrBadSignature
+	}
+	return nil
 }
 
 func (pk Ed25519PubKey) String() string {
 	return hex.EncodeToString(pk)
 }
 
-// GenerateEd25519Key generate an ed25519 keypair and return it
-func GenerateEd25519Key(rand io.Reader) (Ed25519PubKey, ed25519.PrivateKey, error) {
-	publicKey, privateKey, err := ed25519.GenerateKey(nil)
-	return Ed25519PubKey(publicKey), privateKey, err
+func (privKey Ed25519PrivKey) SignMessage(
+	message []byte,
+) (signature []byte, err error) {
+	return ed25519.PrivateKey(privKey).Sign(nil, message, crypto.Hash(0))
+}
+
+func (privKey Ed25519PrivKey) Public() Ed25519PubKey {
+	pubKey := ed25519.PrivateKey(privKey).Public().(ed25519.PublicKey)
+	return Ed25519PubKey(pubKey)
+}
+
+// Get the public key encoded as hexadecimal string
+func (privKey Ed25519PrivKey) PublicHex() string {
+	pubKey := ed25519.PrivateKey(privKey).Public().(ed25519.PublicKey)
+	return hex.EncodeToString(pubKey)
+}
+
+// GenerateEd25519Key generate an ed25519 private key
+func GenerateEd25519Key() (Ed25519PrivKey, error) {
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	return Ed25519PrivKey(privateKey), err
 }

--- a/libs/middleware/http_signed.go
+++ b/libs/middleware/http_signed.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"crypto"
 	"errors"
 	"net/http"
 	"time"
@@ -43,7 +42,6 @@ func HTTPSignedOnly(ks httpsignature.Keystore) func(http.Handler) http.Handler {
 			Headers:   []string{"digest", "(request-target)"},
 		},
 		Keystore: ks,
-		Opts:     crypto.Hash(0),
 	}
 
 	return VerifyHTTPSignedOnly(verifier)

--- a/libs/requestutils/requestutils.go
+++ b/libs/requestutils/requestutils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/brave-intl/bat-go/libs/closers"
@@ -30,7 +29,7 @@ var (
 // ReadWithLimit reads an io reader with a limit and closes
 func ReadWithLimit(ctx context.Context, body io.Reader, limit int64) ([]byte, error) {
 	defer closers.Panic(ctx, body.(io.Closer))
-	return ioutil.ReadAll(io.LimitReader(body, limit))
+	return io.ReadAll(io.LimitReader(body, limit))
 }
 
 // Read an io reader

--- a/libs/wallet/provider/uphold/uphold_test.go
+++ b/libs/wallet/provider/uphold/uphold_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/brave-intl/bat-go/libs/wallet"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
-	"golang.org/x/crypto/ed25519"
 	"gotest.tools/assert"
 )
 
@@ -61,12 +60,12 @@ func TestRegister(t *testing.T) {
 		info.AltCurrency = &tmp
 	}
 
-	publicKey, privateKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	destWallet := &Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
+	destWallet := &Wallet{Info: info, PrivKey: key, PubKey: key.Public()}
 	err = destWallet.Register(ctx, "bat-go test card")
 	if err != nil {
 		t.Error(err)
@@ -156,19 +155,13 @@ func TestTransactions(t *testing.T) {
 		donorInfo.AltCurrency = &tmp
 	}
 
-	donorWalletPublicKeyHex := os.Getenv("DONOR_WALLET_PUBLIC_KEY")
 	donorWalletPrivateKeyHex := os.Getenv("DONOR_WALLET_PRIVATE_KEY")
-	var donorPublicKey httpsignature.Ed25519PubKey
-	var donorPrivateKey ed25519.PrivateKey
-	donorPublicKey, err := hex.DecodeString(donorWalletPublicKeyHex)
+	var donorPrivateKey httpsignature.Ed25519PrivKey
+	donorPrivateKey, err := hex.DecodeString(donorWalletPrivateKeyHex)
 	if err != nil {
 		t.Fatal(err)
 	}
-	donorPrivateKey, err = hex.DecodeString(donorWalletPrivateKeyHex)
-	if err != nil {
-		t.Fatal(err)
-	}
-	donorWallet := &Wallet{Info: donorInfo, PrivKey: donorPrivateKey, PubKey: donorPublicKey}
+	donorWallet := &Wallet{Info: donorInfo, PrivKey: donorPrivateKey, PubKey: donorPrivateKey.Public()}
 
 	var info wallet.Info
 	info.Provider = "uphold"
@@ -178,12 +171,12 @@ func TestTransactions(t *testing.T) {
 		info.AltCurrency = &tmp
 	}
 
-	publicKey, privateKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	destWallet := &Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
+	destWallet := &Wallet{Info: info, PrivKey: key, PubKey: key.Public()}
 	err = destWallet.Register(ctx, "bat-go test transaction card")
 	if err != nil {
 		t.Error(err)
@@ -344,10 +337,10 @@ func requireDonorWallet(t *testing.T) *Wallet {
 		info.AltCurrency = &tmp
 	}
 
-	publicKey, privateKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	return &Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
+	return &Wallet{Info: info, PrivKey: key, PubKey: key.Public()}
 }

--- a/services/payments/security_review_statemachine_uphold_test.go
+++ b/services/payments/security_review_statemachine_uphold_test.go
@@ -2,7 +2,6 @@ package payments
 
 import (
 	"context"
-	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,8 +24,8 @@ var (
 			Provider:   "uphold",
 			PublicKey:  "",
 		},
-		PrivKey: ed25519.PrivateKey([]byte("")),
-		PubKey:  httpsignature.Ed25519PubKey([]byte("")),
+		PrivKey: httpsignature.Ed25519PrivKey(""),
+		PubKey:  httpsignature.Ed25519PubKey(""),
 	}
 	upholdSucceedTransaction = custodian.Transaction{ProviderID: "1234"}
 )

--- a/services/promotion/controllers_test.go
+++ b/services/promotion/controllers_test.go
@@ -5,7 +5,6 @@ package promotion
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -273,7 +272,7 @@ func (suite *ControllersTestSuite) TestGetPromotions() {
 }
 
 // ClaimPromotion helper that calls promotion endpoint and does assertions
-func (suite *ControllersTestSuite) ClaimPromotion(service *Service, w walletutils.Info, privKey crypto.Signer,
+func (suite *ControllersTestSuite) ClaimPromotion(service *Service, w walletutils.Info, privKey httpsignature.Signator,
 	promotion *Promotion, blindedCreds []string, claimStatus int) *uuid.UUID {
 
 	handler := middleware.HTTPSignedOnly(service)(ClaimPromotion(service))
@@ -297,7 +296,7 @@ func (suite *ControllersTestSuite) ClaimPromotion(service *Service, w walletutil
 	s.KeyID = w.ID
 	s.Headers = []string{"digest", "(request-target)"}
 
-	err = s.Sign(privKey, crypto.Hash(0), req)
+	err = s.SignRequest(privKey, req)
 	suite.Require().NoError(err)
 
 	rctx := chi.NewRouteContext()

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -576,7 +576,7 @@ func (suite *ControllersTestSuite) TestE2EOrdersUpholdTransactions() {
 	handler := CreateUpholdTransaction(suite.service)
 
 	// create an uphold wallet
-	publicKey, privKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	suite.Require().NoError(err, "Failed to create wallet keypair")
 
 	walletID := uuid.NewV4()
@@ -586,7 +586,7 @@ func (suite *ControllersTestSuite) TestE2EOrdersUpholdTransactions() {
 		Provider:    "uphold",
 		ProviderID:  "-",
 		AltCurrency: &bat,
-		PublicKey:   hex.EncodeToString(publicKey),
+		PublicKey:   key.PublicHex(),
 		LastBalance: nil,
 	}
 
@@ -599,8 +599,8 @@ func (suite *ControllersTestSuite) TestE2EOrdersUpholdTransactions() {
 
 	w := uphold.Wallet{
 		Info:    info,
-		PrivKey: privKey,
-		PubKey:  publicKey,
+		PrivKey: key,
+		PubKey:  key.Public(),
 	}
 	err = w.Register(ctx, "drain-card-test")
 	suite.Require().NoError(err, "Failed to register wallet")
@@ -759,15 +759,15 @@ func generateWallet(ctx context.Context, t *testing.T) *uphold.Wallet {
 		info.AltCurrency = &tmp
 	}
 
-	publicKey, privateKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	if err != nil {
 		t.Fatal(err)
 	}
-	info.PublicKey = hex.EncodeToString(publicKey)
+	info.PublicKey = key.PublicHex()
 	newWallet := &uphold.Wallet{
 		Info:    info,
-		PrivKey: privateKey,
-		PubKey:  publicKey,
+		PrivKey: key,
+		PubKey:  key.Public(),
 	}
 	err = newWallet.Register(ctx, "bat-go test card")
 	if err != nil {

--- a/services/skus/key.go
+++ b/services/skus/key.go
@@ -2,7 +2,6 @@ package skus
 
 import (
 	"context"
-	"crypto"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
@@ -197,7 +196,6 @@ func NewAuthMwr(ks httpsignature.Keystore) func(http.Handler) http.Handler {
 			},
 		},
 		Keystore: ks,
-		Opts:     crypto.Hash(0),
 	}
 
 	// TODO: Keep only VerifyHTTPSignedOnly after migrating Subscriptions to this method.

--- a/services/skus/key_test.go
+++ b/services/skus/key_test.go
@@ -2,7 +2,6 @@ package skus
 
 import (
 	"context"
-	"crypto"
 	"database/sql"
 	"encoding/base64"
 	"encoding/hex"
@@ -221,7 +220,6 @@ func TestMerchantSignedMiddleware(t *testing.T) {
 	ps := httpsignature.ParameterizedSignator{
 		SignatureParams: sp,
 		Signator:        httpsignature.HMACKey(attenuatedSecret),
-		Opts:            crypto.Hash(0),
 	}
 	req, err = http.NewRequest("GET", "/hello-world", nil)
 	req.Header.Set("Date", time.Now().Format(time.RFC1123))

--- a/services/wallet/controllers_v3.go
+++ b/services/wallet/controllers_v3.go
@@ -1,8 +1,6 @@
 package wallet
 
 import (
-	"crypto"
-	"crypto/ed25519"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -81,8 +79,8 @@ func CreateUpholdWalletV3(w http.ResponseWriter, r *http.Request) *handlers.AppE
 
 	uwallet := uphold.Wallet{
 		Info:    *info,
-		PrivKey: ed25519.PrivateKey{},
-		PubKey:  httpsignature.Ed25519PubKey([]byte(publicKey)),
+		PrivKey: httpsignature.Ed25519PrivKey{},
+		PubKey:  httpsignature.Ed25519PubKey(publicKey),
 	}
 	if err := uwallet.SubmitRegistration(ctx, ucReq.SignedCreationRequest); err != nil {
 		return handlers.WrapError(
@@ -109,7 +107,6 @@ func CreateBraveWalletV3(w http.ResponseWriter, r *http.Request) *handlers.AppEr
 			Headers:   []string{"digest", "(request-target)"},
 		},
 		Keystore: &DecodeEd25519Keystore{},
-		Opts:     crypto.Hash(0),
 	}
 
 	// perform validation based on public key that the user submits
@@ -428,8 +425,8 @@ func LinkUpholdDepositAccountV3(s *Service) func(w http.ResponseWriter, r *http.
 		}
 		uwallet := uphold.Wallet{
 			Info:    *wallet,
-			PrivKey: ed25519.PrivateKey{},
-			PubKey:  httpsignature.Ed25519PubKey([]byte(publicKey)),
+			PrivKey: httpsignature.Ed25519PrivKey{},
+			PubKey:  httpsignature.Ed25519PubKey(publicKey),
 		}
 
 		country, err := s.LinkUpholdWallet(ctx, uwallet, cuw.SignedLinkingRequest, &aa)

--- a/services/wallet/controllers_v4.go
+++ b/services/wallet/controllers_v4.go
@@ -1,7 +1,6 @@
 package wallet
 
 import (
-	"crypto"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -46,7 +45,6 @@ func CreateWalletV4(s *Service) func(w http.ResponseWriter, r *http.Request) *ha
 				Headers:   []string{"digest", "(request-target)"},
 			},
 			Keystore: &DecodeEd25519Keystore{},
-			Opts:     crypto.Hash(0),
 		}
 
 		ctx, publicKey, err := verifier.VerifyRequest(r)

--- a/tools/settlement/settlement_test.go
+++ b/tools/settlement/settlement_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/brave-intl/bat-go/libs/wallet"
 	"github.com/brave-intl/bat-go/libs/wallet/provider/uphold"
 	"github.com/shopspring/decimal"
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestTransactions(t *testing.T) {
@@ -48,7 +47,7 @@ func TestTransactions(t *testing.T) {
 	donorWalletPublicKeyHex := os.Getenv("DONOR_WALLET_PUBLIC_KEY")
 	donorWalletPrivateKeyHex := os.Getenv("DONOR_WALLET_PRIVATE_KEY")
 	var donorPublicKey httpsignature.Ed25519PubKey
-	var donorPrivateKey ed25519.PrivateKey
+	var donorPrivateKey httpsignature.Ed25519PrivKey
 	donorPublicKey, err := hex.DecodeString(donorWalletPublicKeyHex)
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +150,7 @@ func TestDeterministicSigning(t *testing.T) {
 	donorWalletPublicKeyHex := "10ba999b2b7b9eabc0f44fa26bf122ebbfa98dc6fef31e6251a9c1c58d60bb8d"
 	donorWalletPrivateKeyHex := "8d6a620a566e094cebaec67edca32a68efce962890570157f0b8a5389cc5f6df10ba999b2b7b9eabc0f44fa26bf122ebbfa98dc6fef31e6251a9c1c58d60bb8d"
 	var donorPublicKey httpsignature.Ed25519PubKey
-	var donorPrivateKey ed25519.PrivateKey
+	var donorPrivateKey httpsignature.Ed25519PrivKey
 	donorPublicKey, err := hex.DecodeString(donorWalletPublicKeyHex)
 	if err != nil {
 		t.Fatal(err)

--- a/tools/vault/cmd/create_wallet.go
+++ b/tools/vault/cmd/create_wallet.go
@@ -15,7 +15,6 @@ import (
 	"github.com/brave-intl/bat-go/libs/wallet/provider/uphold"
 	vaultsigner "github.com/brave-intl/bat-go/tools/vault/signer"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ed25519"
 )
 
 // State contains the current state of the registration
@@ -138,7 +137,7 @@ func CreateWallet(command *cobra.Command, args []string) error {
 			return err
 		}
 
-		wallet := uphold.Wallet{Info: state.WalletInfo, PrivKey: ed25519.PrivateKey{}, PubKey: publicKey}
+		wallet := uphold.Wallet{Info: state.WalletInfo, PrivKey: httpsignature.Ed25519PrivKey{}, PubKey: publicKey}
 
 		err = wallet.SubmitRegistration(ctx, state.Registration)
 		if err != nil {

--- a/tools/vault/signer/vaultsigner.go
+++ b/tools/vault/signer/vaultsigner.go
@@ -5,11 +5,11 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/brave-intl/bat-go/libs/httpsignature"
 	"github.com/hashicorp/vault/api"
 	util "github.com/hashicorp/vault/command/config"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/hashicorp/vault/sdk/helper/keysutil"
-	"golang.org/x/crypto/ed25519"
 )
 
 // WrappedClient holds an api client for interacting with vault
@@ -17,14 +17,14 @@ type WrappedClient struct {
 	Client *api.Client
 }
 
-// FromKeypair create a new vault transit key by importing privKey and pubKey under importName
-func (wc *WrappedClient) FromKeypair(privKey ed25519.PrivateKey, pubKey ed25519.PublicKey, importName string) (*Ed25519Signer, error) {
+// FromKey create a new vault transit key by importing privKey under importName
+func (wc *WrappedClient) FromKey(privKey httpsignature.Ed25519PrivKey, importName string) (*Ed25519Signer, error) {
 	client := wc.Client
 	key := keysutil.KeyEntry{}
 
 	key.Key = privKey
 
-	pk := base64.StdEncoding.EncodeToString(pubKey)
+	pk := base64.StdEncoding.EncodeToString(privKey.Public())
 	key.FormattedPublicKey = pk
 
 	{

--- a/tools/wallet/cmd/create.go
+++ b/tools/wallet/cmd/create.go
@@ -69,13 +69,13 @@ func CreateOnUphold(ctx context.Context, name string) error {
 		_, logger = logging.SetupLogger(ctx)
 	}
 
-	publicKey, privateKey, err := httpsignature.GenerateEd25519Key(nil)
+	key, err := httpsignature.GenerateEd25519Key()
 	if err != nil {
 		return err
 	}
-	publicKeyHex := hex.EncodeToString([]byte(publicKey))
+	publicKeyHex := key.PublicHex()
 
-	privateKeyHex := hex.EncodeToString([]byte(privateKey))
+	privateKeyHex := hex.EncodeToString(key)
 	logger.Info().
 		Str("public_key", publicKeyHex).
 		Str("private_key", privateKeyHex).
@@ -91,7 +91,7 @@ func CreateOnUphold(ctx context.Context, name string) error {
 	}
 	info.PublicKey = publicKeyHex
 
-	wallet := &uphold.Wallet{Info: info, PrivKey: privateKey, PubKey: publicKey}
+	wallet := &uphold.Wallet{Info: info, PrivKey: key, PubKey: key.Public()}
 
 	err = wallet.Register(ctx, name)
 	if err != nil {


### PR DESCRIPTION
Eliminate io.Reader and crypto.SignerOpts arguments from the Signator/Verifier interfaces to avoid the need to pass crypto.hash(0) in multiple places.

For symmetry with httpsignature.Ed25519PubKey add Ed25519PrivKey wrapper for ed25519.PrivateKey that implements the updated Verifier interface. In addition the wrapper provides Public() and PublicHex() methods to simplify the common operations.

Close #2635

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
