### PR TITLE
fix: use order id and item id in submission report

### DIFF
--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -331,7 +331,7 @@ func (s *Service) doTLV2ExistTxTime(ctx context.Context, dbi sqlx.QueryerContext
 	}
 
 	// Check TLV2 to see if we have credentials signed that match incoming blinded tokens.
-	report, err := s.tlv2Repo.GetCredSubmissionReport(ctx, dbi, reqID, bcreds...)
+	report, err := s.tlv2Repo.GetCredSubmissionReport(ctx, dbi, item.OrderID, item.ID, reqID, bcreds...)
 	if err != nil {
 		return err
 	}

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -105,7 +105,7 @@ type orderStoreSvc interface {
 }
 
 type tlv2Store interface {
-	GetCredSubmissionReport(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error)
+	GetCredSubmissionReport(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error)
 	UniqBatches(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID uuid.UUID, from, to time.Time) (int, error)
 	DeleteLegacy(ctx context.Context, dbi sqlx.ExecerContext, orderID uuid.UUID) error
 }

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -1883,7 +1883,7 @@ func TestService_doTLV2ExistTxTime(t *testing.T) {
 				from:  time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				to:    time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				repo: &repository.MockTLV2{
-					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
+					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
 						return model.TLV2CredSubmissionReport{}, model.Error("something_went_wrong")
 					},
 				},
@@ -1904,7 +1904,7 @@ func TestService_doTLV2ExistTxTime(t *testing.T) {
 				from:  time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				to:    time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				repo: &repository.MockTLV2{
-					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
+					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
 						return model.TLV2CredSubmissionReport{Submitted: true}, nil
 					},
 				},
@@ -1925,7 +1925,7 @@ func TestService_doTLV2ExistTxTime(t *testing.T) {
 				from:  time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				to:    time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
 				repo: &repository.MockTLV2{
-					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
+					FnGetCredSubmissionReport: func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
 						return model.TLV2CredSubmissionReport{ReqIDMismatch: true}, nil
 					},
 				},

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -218,17 +218,17 @@ func (r *MockOrderPayHistory) Insert(ctx context.Context, dbi sqlx.ExecerContext
 }
 
 type MockTLV2 struct {
-	FnGetCredSubmissionReport func(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error)
+	FnGetCredSubmissionReport func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error)
 	FnUniqBatches             func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID uuid.UUID, from, to time.Time) (int, error)
 	FnDeleteLegacy            func(ctx context.Context, dbi sqlx.ExecerContext, orderID uuid.UUID) error
 }
 
-func (r *MockTLV2) GetCredSubmissionReport(ctx context.Context, dbi sqlx.QueryerContext, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
+func (r *MockTLV2) GetCredSubmissionReport(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID, reqID uuid.UUID, creds ...string) (model.TLV2CredSubmissionReport, error) {
 	if r.FnGetCredSubmissionReport == nil {
 		return model.TLV2CredSubmissionReport{}, nil
 	}
 
-	return r.FnGetCredSubmissionReport(ctx, dbi, reqID, creds...)
+	return r.FnGetCredSubmissionReport(ctx, dbi, orderID, itemID, reqID, creds...)
 }
 
 func (r *MockTLV2) UniqBatches(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID uuid.UUID, from, to time.Time) (int, error) {

--- a/services/skus/storage/repository/tlv2_test.go
+++ b/services/skus/storage/repository/tlv2_test.go
@@ -26,8 +26,10 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 	}()
 
 	type tcGiven struct {
-		reqID uuid.UUID
-		creds []string
+		orderID uuid.UUID
+		itemID  uuid.UUID
+		reqID   uuid.UUID
+		creds   []string
 
 		fnBefore func(ctx context.Context, dbi sqlx.ExtContext) error
 	}
@@ -47,6 +49,8 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 		{
 			name: "invalid_param",
 			given: tcGiven{
+				orderID:  uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+				itemID:   uuid.Must(uuid.FromString("decade00-0000-4000-a000-000000000000")),
 				reqID:    uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
 				fnBefore: func(ctx context.Context, dbi sqlx.ExtContext) error { return nil },
 			},
@@ -56,8 +60,10 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 		{
 			name: "submitted",
 			given: tcGiven{
-				reqID: uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
-				creds: []string{"cred_01", "cred_02", "cred_03"},
+				orderID: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				itemID:  uuid.Must(uuid.FromString("ad0be000-0000-4000-a000-000000000000")),
+				reqID:   uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
+				creds:   []string{"cred_01", "cred_02", "cred_03"},
 
 				fnBefore: func(ctx context.Context, dbi sqlx.ExtContext) error {
 					qs := []string{
@@ -91,8 +97,10 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 		{
 			name: "mismatch",
 			given: tcGiven{
-				reqID: uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
-				creds: []string{"cred_01", "cred_02", "cred_03"},
+				orderID: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				itemID:  uuid.Must(uuid.FromString("ad0be000-0000-4000-a000-000000000000")),
+				reqID:   uuid.Must(uuid.FromString("f100ded0-0000-4000-a000-000000000000")),
+				creds:   []string{"cred_01", "cred_02", "cred_03"},
 
 				fnBefore: func(ctx context.Context, dbi sqlx.ExtContext) error {
 					qs := []string{
@@ -143,7 +151,7 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 				must.Equal(t, nil, err)
 			}
 
-			actual, err := repo.GetCredSubmissionReport(ctx, tx, tc.given.reqID, tc.given.creds...)
+			actual, err := repo.GetCredSubmissionReport(ctx, tx, tc.given.orderID, tc.given.itemID, tc.given.reqID, tc.given.creds...)
 			must.Equal(t, tc.exp.err, err)
 
 			if tc.exp.err != nil {


### PR DESCRIPTION
### Summary

Subj. This optimises the query performance by limiting the size of the dataset we're searching in.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [x] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [x] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
