### PR TITLE
fix: use order id and item id in get_signing_order_request

### DIFF
--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -362,7 +362,7 @@ func (s *Service) doCredsExist(ctx context.Context, item *model.OrderItem) error
 	// Check if we already have a signing request for this order, delete order creds will
 	// delete the prior signing request.
 	// This allows subscriptions to manage how many order creds are handed out.
-	signingOrderRequests, err := s.Datastore.GetSigningOrderRequestOutboxByOrderItem(ctx, item.ID)
+	signingOrderRequests, err := s.Datastore.GetSigningOrderRequestOutboxByOrderItem(ctx, item.OrderID, item.ID)
 	if err != nil {
 		return fmt.Errorf("error validating no credentials exist for order item: %w", err)
 	}

--- a/services/skus/datastore_test.go
+++ b/services/skus/datastore_test.go
@@ -446,7 +446,7 @@ func (suite *PostgresTestSuite) TestInsertSigningOrderRequestOutbox() {
 	err := suite.storage.InsertSigningOrderRequestOutbox(ctx, requestID, orderID, itemID, signingOrderRequest)
 	suite.Require().NoError(err)
 
-	signingOrderRequests, err := suite.storage.GetSigningOrderRequestOutboxByOrderItem(ctx, itemID)
+	signingOrderRequests, err := suite.storage.GetSigningOrderRequestOutboxByOrderItem(ctx, orderID, itemID)
 	suite.Require().NoError(err)
 
 	suite.Require().Len(signingOrderRequests, 1)

--- a/services/skus/instrumented_datastore.go
+++ b/services/skus/instrumented_datastore.go
@@ -353,7 +353,7 @@ func (_d DatastoreWithPrometheus) GetSigningOrderRequestOutboxByOrder(ctx contex
 }
 
 // GetSigningOrderRequestOutboxByOrderItem implements Datastore
-func (_d DatastoreWithPrometheus) GetSigningOrderRequestOutboxByOrderItem(ctx context.Context, itemID uuid.UUID) (sa1 []SigningOrderRequestOutbox, err error) {
+func (_d DatastoreWithPrometheus) GetSigningOrderRequestOutboxByOrderItem(ctx context.Context, orderID, itemID uuid.UUID) (sa1 []SigningOrderRequestOutbox, err error) {
 	_since := time.Now()
 	defer func() {
 		result := "ok"
@@ -363,7 +363,7 @@ func (_d DatastoreWithPrometheus) GetSigningOrderRequestOutboxByOrderItem(ctx co
 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetSigningOrderRequestOutboxByOrderItem", result).Observe(time.Since(_since).Seconds())
 	}()
-	return _d.base.GetSigningOrderRequestOutboxByOrderItem(ctx, itemID)
+	return _d.base.GetSigningOrderRequestOutboxByOrderItem(ctx, orderID, itemID)
 }
 
 // GetSigningOrderRequestOutboxByRequestID implements Datastore

--- a/services/skus/mockdatastore.go
+++ b/services/skus/mockdatastore.go
@@ -370,18 +370,18 @@ func (mr *MockDatastoreMockRecorder) GetSigningOrderRequestOutboxByOrder(ctx, or
 }
 
 // GetSigningOrderRequestOutboxByOrderItem mocks base method.
-func (m *MockDatastore) GetSigningOrderRequestOutboxByOrderItem(ctx context.Context, itemID go_uuid.UUID) ([]SigningOrderRequestOutbox, error) {
+func (m *MockDatastore) GetSigningOrderRequestOutboxByOrderItem(ctx context.Context, orderID, itemID go_uuid.UUID) ([]SigningOrderRequestOutbox, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSigningOrderRequestOutboxByOrderItem", ctx, itemID)
+	ret := m.ctrl.Call(m, "GetSigningOrderRequestOutboxByOrderItem", ctx, orderID, itemID)
 	ret0, _ := ret[0].([]SigningOrderRequestOutbox)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSigningOrderRequestOutboxByOrderItem indicates an expected call of GetSigningOrderRequestOutboxByOrderItem.
-func (mr *MockDatastoreMockRecorder) GetSigningOrderRequestOutboxByOrderItem(ctx, itemID interface{}) *gomock.Call {
+func (mr *MockDatastoreMockRecorder) GetSigningOrderRequestOutboxByOrderItem(ctx, orderID, itemID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSigningOrderRequestOutboxByOrderItem", reflect.TypeOf((*MockDatastore)(nil).GetSigningOrderRequestOutboxByOrderItem), ctx, itemID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSigningOrderRequestOutboxByOrderItem", reflect.TypeOf((*MockDatastore)(nil).GetSigningOrderRequestOutboxByOrderItem), ctx, orderID, itemID)
 }
 
 // GetSigningOrderRequestOutboxByRequestID mocks base method.


### PR DESCRIPTION
### Summary

This PR makes the original query to use `order_id` as well as `item_id`, because it's readily available at the call site, and there is a compound index by order and item id on the table. The query currently uses only item id, which is not indexed on, and the query takes quite a bit of DB resources.

The original query was:

```sql
select request_id, order_id, item_id, completed_at, message_data from signing_order_request_outbox where item_id = $1
```

And now it's:

```sql
SELECT request_id, order_id, item_id, completed_at, message_data FROM signing_order_request_outbox WHERE order_id=$1 AND item_id=$2
```


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [x] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
