### PR TITLE
fix: use leo annual issuer if redemption fails for regular leo

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -943,14 +943,13 @@ func MerchantTransactions(service *Service) handlers.AppHandler {
 	})
 }
 
-// VerifyCredentialV2 - version 2 of verify credential
 func VerifyCredentialV2(service *Service) handlers.AppHandler {
 	return func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
-
 		ctx := r.Context()
-		l := logging.Logger(ctx, "VerifyCredentialV2")
 
-		var req = new(VerifyCredentialRequestV2)
+		l := logging.Logger(ctx, "skus").With().Str("func", "VerifyCredentialV2").Logger()
+
+		req := &VerifyCredentialRequestV2{}
 		if err := inputs.DecodeAndValidateReader(ctx, req, r.Body); err != nil {
 			l.Error().Err(err).Msg("failed to read request")
 			return handlers.WrapError(err, "Error in request body", http.StatusBadRequest)

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1953,7 +1953,7 @@ func (s *Service) redeemBlindedCred(ctx context.Context, w http.ResponseWriter, 
 
 		// Fix for https://github.com/brave-intl/challenge-bypass-server/pull/371.
 		const leoa = "brave.com?sku=brave-leo-premium-year"
-		if err := redeemFn(ctx, leoa, cred.TokenPreimage, cred.Signature, leoa); err != nil {
+		if err := redeemFn(ctx, leoa, cred.TokenPreimage, cred.Signature, cred.Issuer); err != nil {
 			return handleRedeemFnError(ctx, w, kind, cred, err)
 		}
 	}


### PR DESCRIPTION
### Summary

If redemption failed for regular Leo because of the wrong issuer, try requesting it with the annual.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
