### PR TITLE
feat: add endpoint for cancelling orders

### DIFF
--- a/services/grant/cmd/grant.go
+++ b/services/grant/cmd/grant.go
@@ -507,6 +507,17 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 			)
 		}
 
+		corsMwrDelete := skus.NewCORSMwr(corsOpts, http.MethodDelete)
+
+		subr.Method(
+			http.MethodDelete,
+			"/{orderID}",
+			middleware.InstrumentHandler(
+				"CancelOrderNew",
+				corsMwrDelete(authMwr(handlers.AppHandler(orderh.Cancel))),
+			),
+		)
+
 		r.Mount("/v1/orders-new", subr)
 	}
 

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -365,7 +365,7 @@ func CancelOrder(service *Service) handlers.AppHandler {
 			return handlers.WrapError(err, "Error validating auth merchant and caveats", http.StatusForbidden)
 		}
 
-		if err := service.CancelOrder(oid); err != nil {
+		if err := service.CancelOrderLegacy(oid); err != nil {
 			return handlers.WrapError(err, "Error retrieving the order", http.StatusInternalServerError)
 		}
 

--- a/services/skus/handler/cred.go
+++ b/services/skus/handler/cred.go
@@ -38,7 +38,7 @@ func (h *Cred) CountBatches(w http.ResponseWriter, r *http.Request) *handlers.Ap
 	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled):
-			return handlers.WrapError(err, "cliend ended request", model.StatusClientClosedConn)
+			return handlers.WrapError(err, "client ended request", model.StatusClientClosedConn)
 
 		case errors.Is(err, model.ErrOrderNotFound), errors.Is(err, model.ErrInvalidOrderNoItems), errors.Is(err, model.ErrOrderItemNotFound):
 			return handlers.WrapError(err, "order not found", http.StatusNotFound)

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -82,7 +82,7 @@ func TestCred_CountBatches(t *testing.T) {
 				},
 			},
 			exp: tcExpected{
-				err: handlers.WrapError(context.Canceled, "cliend ended request", model.StatusClientClosedConn),
+				err: handlers.WrapError(context.Canceled, "client ended request", model.StatusClientClosedConn),
 			},
 		},
 

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -134,7 +134,7 @@ func (h *Order) Cancel(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 		lg.Err(err).Str("order_id", orderID.String()).Msg("failed to cancel order")
 
 		if errors.Is(err, context.Canceled) {
-			return handlers.WrapError(model.ErrSomethingWentWrong, "request has been cancelled", model.StatusClientClosedConn)
+			return handlers.WrapError(model.ErrSomethingWentWrong, "client ended request", model.StatusClientClosedConn)
 		}
 
 		return handlers.WrapError(model.ErrSomethingWentWrong, "could not cancel order", http.StatusInternalServerError)

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -125,7 +125,7 @@ func (h *Order) Cancel(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 
 	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
 	if err != nil {
-		return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+		return handlers.ValidationError("request", map[string]interface{}{"orderID": model.ErrInvalidUUID})
 	}
 
 	lg := logging.Logger(ctx, "skus").With().Str("func", "CancelOrderNew").Logger()

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 
 	"github.com/asaskevich/govalidator"
+	"github.com/go-chi/chi"
 	"github.com/go-playground/validator/v10"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/libs/logging"
@@ -24,6 +26,7 @@ const (
 type orderService interface {
 	CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 	CreateOrder(ctx context.Context, req *model.CreateOrderRequestNew) (*model.Order, error)
+	CancelOrder(ctx context.Context, id uuid.UUID) error
 }
 
 type Order struct {
@@ -115,6 +118,29 @@ func (h *Order) CreateNew(w http.ResponseWriter, r *http.Request) *handlers.AppE
 	}
 
 	return handlers.RenderContent(ctx, result, w, http.StatusCreated)
+}
+
+func (h *Order) Cancel(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+	}
+
+	lg := logging.Logger(ctx, "skus").With().Str("func", "CancelOrderNew").Logger()
+
+	if err := h.svc.CancelOrder(ctx, orderID); err != nil {
+		lg.Err(err).Str("order_id", orderID.String()).Msg("failed to cancel order")
+
+		if errors.Is(err, context.Canceled) {
+			return handlers.WrapError(model.ErrSomethingWentWrong, "request has been cancelled", model.StatusClientClosedConn)
+		}
+
+		return handlers.WrapError(model.ErrSomethingWentWrong, "could not cancel order", http.StatusInternalServerError)
+	}
+
+	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
 }
 
 func collectValidationErrors(err error) (map[string]string, bool) {

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/rs/zerolog"
+	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
 	should "github.com/stretchr/testify/assert"
 	must "github.com/stretchr/testify/require"
@@ -30,6 +31,7 @@ func TestMain(m *testing.M) {
 type mockOrderService struct {
 	fnCreateOrderFromRequest func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 	fnCreateOrder            func(ctx context.Context, req *model.CreateOrderRequestNew) (*model.Order, error)
+	fnCancelOrder            func(ctx context.Context, id uuid.UUID) error
 }
 
 func (s *mockOrderService) CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
@@ -46,6 +48,14 @@ func (s *mockOrderService) CreateOrder(ctx context.Context, req *model.CreateOrd
 	}
 
 	return s.fnCreateOrder(ctx, req)
+}
+
+func (s *mockOrderService) CancelOrder(ctx context.Context, id uuid.UUID) error {
+	if s.fnCancelOrder == nil {
+		return nil
+	}
+
+	return s.fnCancelOrder(ctx, id)
 }
 
 func TestOrder_Create(t *testing.T) {

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -629,7 +629,7 @@ func TestOrder_Cancel(t *testing.T) {
 				resp := rw.Body.Bytes()
 
 				exp, err := json.Marshal(tc.exp.err)
-				must.Equal(t, nil, err)
+				must.NoError(t, err)
 
 				should.Equal(t, exp, bytes.TrimSpace(resp))
 				return

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -546,7 +546,7 @@ func TestOrder_Cancel(t *testing.T) {
 				oid: uuid.Nil,
 			},
 			exp: tcExpected{
-				err: handlers.ValidationError("request", map[string]interface{}{"orderID": "uuid: incorrect UUID length: invalid_id"}),
+				err: handlers.ValidationError("request", map[string]interface{}{"orderID": model.ErrInvalidUUID}),
 			},
 		},
 

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -28,6 +28,7 @@ const (
 	ErrInvalidOrderNoItems                    Error = "model: invalid order: no items"
 	ErrNoStripeCheckoutSessID                 Error = "model: order: no stripe checkout session id"
 	ErrInvalidOrderMetadataType               Error = "model: order: invalid metadata type"
+	ErrInvalidUUID                            Error = "model: invalid uuid"
 
 	ErrNumPerIntervalNotSet  Error = "model: invalid order: numPerInterval must be set"
 	ErrNumIntervalsNotSet    Error = "model: invalid order: numIntervals must be set"

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -676,10 +676,12 @@ func (s *Service) updateOrderStripeSession(ctx context.Context, dbi sqlx.ExtCont
 	return s.renewOrderStripe(ctx, dbi, ord, sub.ID, expt, paidt)
 }
 
-// CancelOrder cancels an order, propagates to stripe if needed.
-//
-// TODO(pavelb): Refactor this.
-func (s *Service) CancelOrder(orderID uuid.UUID) error {
+func (s *Service) CancelOrder(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+// CancelOrderLegacy cancels an order, propagates to stripe if needed.
+func (s *Service) CancelOrderLegacy(orderID uuid.UUID) error {
 	// TODO: Refactor this later. Now here's a quick fix.
 	ord, err := s.Datastore.GetOrder(orderID)
 	if err != nil {


### PR DESCRIPTION
### Summary

This PR adds a new endpoint which works similar to the existing one for cancelling orders expect for it does not handle subscription cancellations in Stripe. Instead, it just updates the order status to `canceled`.

I've considered going with `PUT` and/or using `204` response, but rejected those options because they did not fit this use case. So had to stick with `DELETE` and `200` in response, with an empty body.

Also, for some tests `.ErrorIs` and `.Nil` for errors were not applicable, details for which I could provide if needed. Had to use the simple `.Equal` because it simply works, and does the comparison the way I need it.

Hopefully the points above provide the necessary context during review.


### Type of Change

- [x] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
