### PR TITLE
fix: use correct value for numPerInterval for leo annual

### DIFF
--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -279,7 +279,7 @@ func (x *OrderItem) IsLeo() bool {
 		return false
 	}
 
-	return x.SKU == "brave-leo-premium"
+	return x.SKU == "brave-leo-premium" || x.SKU == "brave-leo-premium-year"
 }
 
 func (x *OrderItem) StripeItemID() (string, bool) {


### PR DESCRIPTION
### Summary

Subj. The code was not updated for the annual version which results in wrong number of credentials per day.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
