### PR TITLE
feat: add sku_variant field

### DIFF
--- a/libs/datastore/postgres.go
+++ b/libs/datastore/postgres.go
@@ -41,7 +41,7 @@ var (
 	}
 	dbs = map[string]*sqlx.DB{}
 	// CurrentMigrationVersion holds the default migration version
-	CurrentMigrationVersion = uint(68)
+	CurrentMigrationVersion = uint(69)
 	// MigrationTracks holds the migration version for a given track (eyeshade, promotion, wallet)
 	MigrationTracks = map[string]uint{
 		"eyeshade": 20,

--- a/migrations/0069_order_items_add_sku_variant.down.sql
+++ b/migrations/0069_order_items_add_sku_variant.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE order_items DROP COLUMN sku_variant;

--- a/migrations/0069_order_items_add_sku_variant.up.sql
+++ b/migrations/0069_order_items_add_sku_variant.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE order_items ADD COLUMN sku_variant text NOT NULL DEFAULT '';
+
+ALTER TABLE order_items ALTER COLUMN sku_variant DROP DEFAULT;
+
+
+-- Will be executed manually.
+-- UPDATE order_items SET sku_variant=sku;

--- a/services/skus/controllers_test.go
+++ b/services/skus/controllers_test.go
@@ -1784,6 +1784,7 @@ func (suite *ControllersTestSuite) TestCreateOrder_RadomPayable() {
 			{
 				Quantity:                    1,
 				SKU:                         "sku",
+				SKUVnt:                      "sku_vnt",
 				Location:                    "https://example.com",
 				Description:                 "description",
 				CredentialType:              timeLimitedV2,

--- a/services/skus/handler/handler_pvt_test.go
+++ b/services/skus/handler/handler_pvt_test.go
@@ -45,6 +45,7 @@ func TestCollectValidationErrors_CreateOrderRequestNew(t *testing.T) {
 					{
 						Quantity:                1,
 						SKU:                     "sku",
+						SKUVnt:                  "sku_vnt",
 						Location:                "location",
 						Description:             "description",
 						CredentialType:          "credential_type",
@@ -72,6 +73,7 @@ func TestCollectValidationErrors_CreateOrderRequestNew(t *testing.T) {
 					{
 						Quantity:                1,
 						SKU:                     "sku",
+						SKUVnt:                  "sku_vnt",
 						Location:                "location",
 						Description:             "description",
 						CredentialType:          "credential_type",
@@ -100,6 +102,7 @@ func TestCollectValidationErrors_CreateOrderRequestNew(t *testing.T) {
 					{
 						Quantity:                1,
 						SKU:                     "sku",
+						SKUVnt:                  "sku_vnt",
 						Location:                "location",
 						Description:             "description",
 						CredentialType:          "credential_type",
@@ -133,6 +136,7 @@ func TestCollectValidationErrors_CreateOrderRequestNew(t *testing.T) {
 					{
 						Quantity:                1,
 						SKU:                     "sku",
+						SKUVnt:                  "sku_vnt",
 						Location:                "location",
 						Description:             "description",
 						CredentialType:          "credential_type",

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -305,6 +305,7 @@ func TestOrder_CreateNew(t *testing.T) {
 						{
 							"quantity": 1,
 							"sku": "sku",
+							"sku_variant": "sku_vnt",
 							"location": "location",
 							"description": "description",
 							"credential_type": "credential_type",
@@ -348,6 +349,7 @@ func TestOrder_CreateNew(t *testing.T) {
 						{
 							"quantity": 1,
 							"sku": "sku",
+							"sku_variant": "sku_vnt",
 							"location": "location",
 							"description": "description",
 							"credential_type": "credential_type",
@@ -384,6 +386,7 @@ func TestOrder_CreateNew(t *testing.T) {
 							Items: []model.OrderItem{
 								{
 									SKU:      "sku",
+									SKUVnt:   "sku_vnt",
 									Quantity: 1,
 									Price:    mustDecimalFromString("1"),
 									Subtotal: mustDecimalFromString("1"),
@@ -425,6 +428,7 @@ func TestOrder_CreateNew(t *testing.T) {
 						{
 							"quantity": 1,
 							"sku": "sku",
+							"sku_variant": "sku_vnt",
 							"location": "location",
 							"description": "description",
 							"credential_type": "credential_type",
@@ -448,6 +452,7 @@ func TestOrder_CreateNew(t *testing.T) {
 					Items: []model.OrderItem{
 						{
 							SKU:      "sku",
+							SKUVnt:   "sku_vnt",
 							Quantity: 1,
 							Price:    mustDecimalFromString("1"),
 							Subtotal: mustDecimalFromString("1"),

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -255,6 +255,7 @@ type OrderItem struct {
 	ID                        uuid.UUID            `json:"id" db:"id"`
 	OrderID                   uuid.UUID            `json:"orderId" db:"order_id"`
 	SKU                       string               `json:"sku" db:"sku"`
+	SKUVnt                    string               `json:"sku_variant" db:"sku_variant"`
 	CreatedAt                 *time.Time           `json:"createdAt" db:"created_at"`
 	UpdatedAt                 *time.Time           `json:"updatedAt" db:"updated_at"`
 	Currency                  string               `json:"currency" db:"currency"`
@@ -409,6 +410,7 @@ type CreateOrderRequestNew struct {
 type OrderItemRequestNew struct {
 	Quantity                    int                 `json:"quantity" validate:"required,gte=1"`
 	SKU                         string              `json:"sku" validate:"required"`
+	SKUVnt                      string              `json:"sku_variant" validate:"required"`
 	Period                      string              `json:"period"` // Not used yet.
 	Location                    string              `json:"location" validate:"required"`
 	Description                 string              `json:"description" validate:"required"`

--- a/services/skus/order.go
+++ b/services/skus/order.go
@@ -85,6 +85,10 @@ func (s *Service) CreateOrderItemFromMacaroon(ctx context.Context, sku string, q
 		switch key {
 		case "sku":
 			orderItem.SKU = value
+
+			// Legacy, non-Premium orders.
+			// Use the same value.
+			orderItem.SKUVnt = value
 		case "price", "amount":
 			orderItem.Price, err = decimal.NewFromString(value)
 			if err != nil {

--- a/services/skus/order_test.go
+++ b/services/skus/order_test.go
@@ -194,6 +194,7 @@ func (suite *OrderTestSuite) assertSuccess(item *OrderItem, apm []string, expCfg
 	suite.Assert().Equal("stripe", strings.Join(apm, ","))
 	suite.Assert().Equal("usd", item.Currency)
 	suite.Assert().Equal("sku", item.SKU)
+	suite.Assert().Equal("sku", item.SKUVnt)
 	suite.Assert().Equal("5.01", item.Price.String())
 	suite.Assert().Equal("coffee", item.Description.String)
 	suite.Assert().Equal("brave.com", item.Location.String)

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2593,7 +2593,8 @@ func createOrderItem(req *model.OrderItemRequestNew) (*model.OrderItem, error) {
 	}
 
 	result := &model.OrderItem{
-		SKU: req.SKU,
+		SKU:    req.SKU,
+		SKUVnt: req.SKUVnt,
 		// Set Currency separately as it should be at the Order level.
 		CredentialType:            req.CredentialType,
 		ValidFor:                  &validFor,

--- a/services/skus/service_test.go
+++ b/services/skus/service_test.go
@@ -226,6 +226,7 @@ func TestCreateOrderItem(t *testing.T) {
 			name: "full_example",
 			given: &model.OrderItemRequestNew{
 				SKU:                         "sku",
+				SKUVnt:                      "sku_vnt",
 				CredentialType:              "credential_type",
 				CredentialValidDuration:     "P1M",
 				CredentialValidDurationEach: ptr.To("P1D"),
@@ -242,6 +243,7 @@ func TestCreateOrderItem(t *testing.T) {
 			exp: tcExpected{
 				result: &model.OrderItem{
 					SKU:                       "sku",
+					SKUVnt:                    "sku_vnt",
 					CredentialType:            "credential_type",
 					ValidFor:                  mustDurationFromISO("P1M"),
 					ValidForISO:               ptr.To("P1M"),

--- a/services/skus/storage/repository/order_item.go
+++ b/services/skus/storage/repository/order_item.go
@@ -19,7 +19,7 @@ func NewOrderItem() *OrderItem { return &OrderItem{} }
 func (r *OrderItem) Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error) {
 	const q = `
 	SELECT
-		id, order_id, sku, created_at, updated_at, currency,
+		id, order_id, sku, sku_variant, created_at, updated_at, currency,
 		quantity, price, (quantity * price) as subtotal,
 		location, description, credential_type,metadata, valid_for_iso, issuance_interval
 	FROM order_items WHERE id = $1`
@@ -40,7 +40,7 @@ func (r *OrderItem) Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UU
 func (r *OrderItem) FindByOrderID(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error) {
 	const q = `
 	SELECT
-		id, order_id, sku, created_at, updated_at, currency,
+		id, order_id, sku, sku_variant, created_at, updated_at, currency,
 		quantity, price, (quantity * price) as subtotal,
 		location, description, credential_type, metadata, valid_for_iso, issuance_interval
 	FROM order_items WHERE order_id = $1`
@@ -61,10 +61,10 @@ func (r *OrderItem) InsertMany(ctx context.Context, dbi sqlx.ExtContext, items .
 
 	const q = `
 	INSERT INTO order_items (
-		order_id, sku, quantity, price, currency, subtotal, location, description, credential_type, metadata, valid_for, valid_for_iso, issuance_interval
+		order_id, sku, sku_variant, quantity, price, currency, subtotal, location, description, credential_type, metadata, valid_for, valid_for_iso, issuance_interval
 	) VALUES (
-		:order_id, :sku, :quantity, :price, :currency, :subtotal, :location, :description, :credential_type, :metadata, :valid_for, :valid_for_iso, :issuance_interval
-	) RETURNING id, order_id, sku, created_at, updated_at, currency, quantity, price, location, description, credential_type, (quantity * price) as subtotal, metadata, valid_for`
+		:order_id, :sku, :sku_variant, :quantity, :price, :currency, :subtotal, :location, :description, :credential_type, :metadata, :valid_for, :valid_for_iso, :issuance_interval
+	) RETURNING id, order_id, sku, sku_variant, created_at, updated_at, currency, quantity, price, location, description, credential_type, (quantity * price) as subtotal, metadata, valid_for`
 
 	rows, err := sqlx.NamedQueryContext(ctx, dbi, q, items)
 	if err != nil {

--- a/services/skus/storage/repository/order_item_test.go
+++ b/services/skus/storage/repository/order_item_test.go
@@ -45,6 +45,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 			given: []model.OrderItem{
 				{
 					SKU:            "sku_01_01",
+					SKUVnt:         "sku_vnt_01_01",
 					Quantity:       1,
 					Price:          mustDecimalFromString("2"),
 					Currency:       "USD",
@@ -56,6 +57,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 			exp: []model.OrderItem{
 				{
 					SKU:            "sku_01_01",
+					SKUVnt:         "sku_vnt_01_01",
 					Quantity:       1,
 					Price:          mustDecimalFromString("2"),
 					Currency:       "USD",
@@ -70,6 +72,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 			given: []model.OrderItem{
 				{
 					SKU:            "sku_02_01",
+					SKUVnt:         "sku_vnt_02_01",
 					Quantity:       2,
 					Price:          mustDecimalFromString("3"),
 					Currency:       "USD",
@@ -79,6 +82,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 
 				{
 					SKU:            "sku_02_02",
+					SKUVnt:         "sku_vnt_02_02",
 					Quantity:       3,
 					Price:          mustDecimalFromString("4"),
 					Currency:       "USD",
@@ -90,6 +94,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 			exp: []model.OrderItem{
 				{
 					SKU:            "sku_02_01",
+					SKUVnt:         "sku_vnt_02_01",
 					Quantity:       2,
 					Price:          mustDecimalFromString("3"),
 					Currency:       "USD",
@@ -99,6 +104,7 @@ func TestOrderItem_InsertMany(t *testing.T) {
 
 				{
 					SKU:            "sku_02_02",
+					SKUVnt:         "sku_vnt_02_02",
 					Quantity:       3,
 					Price:          mustDecimalFromString("4"),
 					Currency:       "USD",

--- a/services/skus/storage/repository/repository_test.go
+++ b/services/skus/storage/repository/repository_test.go
@@ -600,6 +600,7 @@ func TestOrder_GetExpiresAtAfterISOPeriod(t *testing.T) {
 				items: []model.OrderItem{
 					{
 						SKU:            "sku_01_01",
+						SKUVnt:         "sku_vnt_01_01",
 						Quantity:       1,
 						Price:          mustDecimalFromString("2"),
 						Currency:       "USD",
@@ -621,6 +622,7 @@ func TestOrder_GetExpiresAtAfterISOPeriod(t *testing.T) {
 				items: []model.OrderItem{
 					{
 						SKU:            "sku_02_01",
+						SKUVnt:         "sku_vnt_02_01",
 						Quantity:       2,
 						Price:          mustDecimalFromString("3"),
 						Currency:       "USD",
@@ -631,6 +633,7 @@ func TestOrder_GetExpiresAtAfterISOPeriod(t *testing.T) {
 
 					{
 						SKU:            "sku_02_02",
+						SKUVnt:         "sku_vnt_02_02",
 						Quantity:       3,
 						Price:          mustDecimalFromString("4"),
 						Currency:       "USD",
@@ -652,6 +655,7 @@ func TestOrder_GetExpiresAtAfterISOPeriod(t *testing.T) {
 				items: []model.OrderItem{
 					{
 						SKU:            "sku_02_01",
+						SKUVnt:         "sku_vnt_02_01",
 						Quantity:       2,
 						Price:          mustDecimalFromString("3"),
 						Currency:       "USD",
@@ -661,6 +665,7 @@ func TestOrder_GetExpiresAtAfterISOPeriod(t *testing.T) {
 
 					{
 						SKU:            "sku_02_02",
+						SKUVnt:         "sku_vnt_02_02",
 						Quantity:       3,
 						Price:          mustDecimalFromString("4"),
 						Currency:       "USD",

--- a/services/skus/storage/repository/tlv2_test.go
+++ b/services/skus/storage/repository/tlv2_test.go
@@ -62,8 +62,8 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'f100ded0-0000-4000-a000-000000000000', '2024-01-01 00:00:02', '2024-01-02 00:00:02', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -99,8 +99,8 @@ func TestTLV2_GetCredSubmissionReport(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'f100ded0-0000-4000-a000-000000000000', '2024-01-01 00:00:02', '2024-01-02 00:00:02', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_11", "cred_12", "cred_13"]', '["scred_11", "scred_12", "scred_13"]');`,
@@ -210,8 +210,8 @@ func TestTLV2_UniqBatches(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'f100ded0-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -247,8 +247,8 @@ func TestTLV2_UniqBatches(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'f100ded0-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -287,8 +287,8 @@ func TestTLV2_UniqBatches(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'f100ded0-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -403,8 +403,8 @@ func TestTLV2_DeleteLegacy(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -437,8 +437,8 @@ func TestTLV2_DeleteLegacy(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,
@@ -474,8 +474,8 @@ func TestTLV2_DeleteLegacy(t *testing.T) {
 						`INSERT INTO orders (id, merchant_id, status, currency, total_price, created_at, updated_at)
 							VALUES ('c0c0a000-0000-4000-a000-000000000000', 'brave.com', 'paid', 'USD', 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
-						`INSERT INTO order_items (id, order_id, sku, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
-							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
+						`INSERT INTO order_items (id, order_id, sku, sku_variant, credential_type, currency, quantity, price, subtotal, created_at, updated_at)
+							VALUES ('ad0be000-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'brave-vpn-premium', 'brave-vpn-premium', 'time-limited-v2', 'USD', 1, 9.99, 9.99, '2024-01-01 00:00:01', '2024-01-01 00:00:01');`,
 
 						`INSERT INTO time_limited_v2_order_creds (id, issuer_id, order_id, item_id, request_id, valid_from, valid_to, created_at, batch_proof, public_key, blinded_creds, signed_creds)
 							VALUES ('decade00-0000-4000-a000-000000000000', '5ca1ab1e-0000-4000-a000-000000000000', 'c0c0a000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', 'ad0be000-0000-4000-a000-000000000000', '2024-01-01 00:00:01', '2024-01-02 00:00:01', '2024-01-01 00:00:01', 'proof_01', 'public_key_01', '["cred_01", "cred_02", "cred_03"]', '["scred_01", "scred_02", "scred_03"]');`,


### PR DESCRIPTION
### Summary

This PR adds support for a new `sku_variant` field for order items. The scope of this PR is to only add the field and store it for new orders.

The migration `0069` adds the new column, but leaves the actual update to be executed manually due to the number of records. It's important to not delay the start up of the service, therefore the update will take place outside of the migration.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
