### PR TITLE
feat: add new get cards endpoint

### DIFF
--- a/services/rewards/controllers_test.go
+++ b/services/rewards/controllers_test.go
@@ -84,7 +84,7 @@ func TestGetParametersController(t *testing.T) {
 	})
 
 	s := &Service{
-		cfg:      Config{TOSVersion: 1},
+		cfg:      &Config{TOSVersion: 1},
 		ratios:   mockRatios,
 		s3Client: mockS3,
 		cacheMu:  new(sync.RWMutex),

--- a/services/rewards/handler/handler.go
+++ b/services/rewards/handler/handler.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/brave-intl/bat-go/libs/handlers"
+	"github.com/brave-intl/bat-go/libs/logging"
+	"github.com/brave-intl/bat-go/services/rewards"
+	"github.com/brave-intl/bat-go/services/rewards/model"
+)
+
+type cardService interface {
+	GetCardsAsBytes(ctx context.Context) (rewards.CardBytes, error)
+}
+
+type CardsHandler struct {
+	cardSvc cardService
+}
+
+func NewCardsHandler(cardSvc cardService) *CardsHandler {
+	return &CardsHandler{
+		cardSvc: cardSvc,
+	}
+}
+
+const errSomethingWentWrong model.Error = "something went wrong"
+
+func (c *CardsHandler) GetCardsHandler(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	l := logging.Logger(ctx, "handler").With().Str("func", "GetCardsHandler").Logger()
+
+	cards, err := c.cardSvc.GetCardsAsBytes(ctx)
+	if err != nil {
+		l.Err(err).Msg("failed to get cards as bytes")
+
+		return handlers.WrapError(errSomethingWentWrong, errSomethingWentWrong.Error(), http.StatusInternalServerError)
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if _, err := w.Write(cards); err != nil {
+		l.Err(err).Msg("failed to write response")
+
+		return handlers.WrapError(errSomethingWentWrong, errSomethingWentWrong.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}

--- a/services/rewards/handler/handler_test.go
+++ b/services/rewards/handler/handler_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/brave-intl/bat-go/libs/handlers"
+	"github.com/brave-intl/bat-go/services/rewards"
+	"github.com/brave-intl/bat-go/services/rewards/model"
+)
+
+func TestService_GetCards(t *testing.T) {
+	type card struct {
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		URL         string `json:"url"`
+		Thumbnail   string `json:"thumbnail"`
+	}
+
+	type cards struct {
+		CommunityCard  []card `json:"community-card"`
+		MerchStoreCard []card `json:"merch-store-card"`
+	}
+
+	type tcGiven struct {
+		cardSvc cardService
+	}
+
+	type tcExpected struct {
+		code  int
+		cards cards
+		err   *handlers.AppError
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "error_cards_as_bytes",
+			given: tcGiven{
+				cardSvc: &mockCardService{
+					fnGetCards: func(ctx context.Context) (rewards.CardBytes, error) {
+						return nil, model.Error("error")
+					},
+				},
+			},
+			exp: tcExpected{
+				code: http.StatusInternalServerError,
+				err: &handlers.AppError{
+					Message: errSomethingWentWrong.Error(),
+					Code:    http.StatusInternalServerError,
+					Cause:   errSomethingWentWrong,
+				},
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				cardSvc: &mockCardService{
+					fnGetCards: func(ctx context.Context) (rewards.CardBytes, error) {
+						cards := rewards.CardBytes(`{ "community-card": [{"title": "<string>", "description": "<string>", "url": "<string>", "thumbnail": "<string>"}], "merch-store-card": [{"title": "<string>", "description": "<string>", "url": "<string>", "thumbnail": "<string>"}] }`)
+
+						return cards, nil
+					},
+				},
+			},
+			exp: tcExpected{
+				code: http.StatusOK,
+				cards: cards{
+					CommunityCard: []card{
+						{
+							Title:       "<string>",
+							Description: "<string>",
+							URL:         "<string>",
+							Thumbnail:   "<string>",
+						},
+					},
+					MerchStoreCard: []card{
+						{
+							Title:       "<string>",
+							Description: "<string>",
+							URL:         "<string>",
+							Thumbnail:   "<string>",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/cards", nil)
+
+			rw := httptest.NewRecorder()
+
+			ch := NewCardsHandler(tc.given.cardSvc)
+
+			actual := ch.GetCardsHandler(rw, r)
+
+			if actual != nil {
+				actual.ServeHTTP(rw, r)
+				assert.Equal(t, tc.exp.code, rw.Code)
+				assert.Equal(t, tc.exp.err.Code, actual.Code)
+				assert.Equal(t, tc.exp.err.Cause, actual.Cause)
+				assert.Contains(t, actual.Message, tc.exp.err.Message)
+				return
+			}
+
+			assert.Equal(t, tc.exp.code, rw.Code)
+
+			var body cards
+			err := json.Unmarshal(rw.Body.Bytes(), &body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.exp.cards, body)
+		})
+	}
+}
+
+type mockCardService struct {
+	fnGetCards func(ctx context.Context) (rewards.CardBytes, error)
+}
+
+func (m *mockCardService) GetCardsAsBytes(ctx context.Context) (rewards.CardBytes, error) {
+	if m.fnGetCards == nil {
+		return rewards.CardBytes{}, nil
+	}
+
+	return m.fnGetCards(ctx)
+}

--- a/services/rewards/model/model.go
+++ b/services/rewards/model/model.go
@@ -1,0 +1,7 @@
+package model
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}

--- a/services/rewards/service_test.go
+++ b/services/rewards/service_test.go
@@ -1,0 +1,103 @@
+package rewards
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/brave-intl/bat-go/services/rewards/model"
+)
+
+func TestService_GetCards(t *testing.T) {
+	type tcGiven struct {
+		cfg   *Config
+		s3Svc s3Service
+	}
+
+	type tcExpected struct {
+		cards CardBytes
+		err   error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "error_get_object",
+			given: tcGiven{
+				cfg: &Config{
+					Cards: &CardsConfig{},
+				},
+				s3Svc: &mockS3Service{
+					fnGetObject: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+						return nil, model.Error("error")
+					},
+				},
+			},
+			exp: tcExpected{
+				err: model.Error("error"),
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				cfg: &Config{
+					Cards: &CardsConfig{},
+				},
+				s3Svc: &mockS3Service{
+					fnGetObject: func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+						cards := CardBytes(`{ "card": [{"title": "<string>", "description": "<string>", "url": "<string>", "thumbnail": "<string>"}] }`)
+
+						out := &s3.GetObjectOutput{
+							Body: io.NopCloser(bytes.NewReader(cards)),
+						}
+
+						return out, nil
+					},
+				},
+			},
+			exp: tcExpected{
+				cards: CardBytes(`{ "card": [{"title": "<string>", "description": "<string>", "url": "<string>", "thumbnail": "<string>"}] }`),
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{
+				cfg:   tc.given.cfg,
+				s3Svc: tc.given.s3Svc,
+			}
+
+			ctx := context.Background()
+
+			actual, err := s.GetCardsAsBytes(ctx)
+
+			assert.ErrorIs(t, err, tc.exp.err)
+			assert.Equal(t, tc.exp.cards, actual)
+		})
+	}
+}
+
+type mockS3Service struct {
+	fnGetObject func(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+func (m *mockS3Service) GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.fnGetObject == nil {
+		return &s3.GetObjectOutput{}, nil
+	}
+
+	return m.fnGetObject(ctx, params, optFns...)
+}


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR adds a new endpoint `GET v1/cards`.

It will return the json stored in S3 bucket with the key `cards.json`.

N.B. caching will be added in a subsequent PR.

resolves https://github.com/brave-intl/bat-go/issues/2688

### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
