### PR TITLE
fix: link annual vpn to annual sku

### DIFF
--- a/services/skus/skus.go
+++ b/services/skus/skus.go
@@ -170,18 +170,21 @@ func skuVntByMobileName(subID string) (string, error) {
 
 	// Android VPN Annual.
 	case "brave.vpn.yearly", "beta.bravevpn.yearly", "nightly.bravevpn.yearly":
-		// Temporary: use the same sku as for monthly.
-		return "brave-vpn-premium", nil
+		return "brave-vpn-premium-year", nil
 
 	// iOS VPN Annual.
 	case "bravevpn.yearly":
-		// Temporary: use the same sku as for monthly.
+		return "brave-vpn-premium-year", nil
+
+	// Legacy.
+	// Older iOS clients might still send this as subscription_id along with a receipt.
+	case "brave-firewall-vpn-premium":
 		return "brave-vpn-premium", nil
 
 	// Legacy.
 	// Older iOS clients might still send this as subscription_id along with a receipt.
-	case "brave-firewall-vpn-premium", "brave-firewall-vpn-premium-year":
-		return "brave-vpn-premium", nil
+	case "brave-firewall-vpn-premium-year":
+		return "brave-vpn-premium-year", nil
 
 	default:
 		return "", model.ErrInvalidMobileProduct
@@ -280,6 +283,21 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 		// StripeMetadata depends on env.
 	}
 
+	vpna := model.OrderItemRequestNew{
+		Quantity: 1,
+		SKU:      "brave-vpn-premium",
+		SKUVnt:   "brave-vpn-premium-year",
+		// Location depends on env.
+		Description:                 "brave-vpn-premium-year",
+		CredentialType:              "time-limited-v2",
+		CredentialValidDuration:     "P1M",
+		Price:                       decimal.RequireFromString("99.99"),
+		IssuerTokenBuffer:           ptrTo(31),
+		IssuerTokenOverlap:          ptrTo(2),
+		CredentialValidDurationEach: ptrTo("P1D"),
+		// StripeMetadata depends on env.
+	}
+
 	switch env {
 	case "prod", "production":
 		leom.Location = "leo.brave.com"
@@ -298,6 +316,12 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 		vpnm.StripeMetadata = &model.ItemStripeMetadata{
 			ProductID: "prod_Lhv8qsPsn6WHrx",
 			ItemID:    "price_1L0VHmBSm1mtrN9nT5DPmUZb",
+		}
+
+		vpna.Location = "vpn.brave.com"
+		vpna.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_Lhv8qsPsn6WHrx",
+			ItemID:    "price_1L7lgCBSm1mtrN9nDlAz8WT2",
 		}
 
 	case "sandbox", "staging":
@@ -319,6 +343,12 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
 		}
 
+		vpna.Location = "vpn.bravesoftware.com"
+		vpna.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_Lhv4OM1aAPxflY",
+			ItemID:    "price_1L8O6dBSm1mtrN9nOYyDqe0F",
+		}
+
 	case "dev", "development":
 		leom.Location = "leo.brave.software"
 		leom.StripeMetadata = &model.ItemStripeMetadata{
@@ -336,6 +366,12 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 		vpnm.StripeMetadata = &model.ItemStripeMetadata{
 			ProductID: "prod_K1c8W3oM4mUsGw",
 			ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+		}
+
+		vpna.Location = "vpn.brave.software"
+		vpna.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_K1c8W3oM4mUsGw",
+			ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
 		}
 
 	default:
@@ -357,12 +393,19 @@ func newOrderItemReqNewMobileSet(env string) map[string]model.OrderItemRequestNe
 			ProductID: "prod_K1c8W3oM4mUsGw",
 			ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
 		}
+
+		vpna.Location = "vpn.brave.software"
+		vpna.StripeMetadata = &model.ItemStripeMetadata{
+			ProductID: "prod_K1c8W3oM4mUsGw",
+			ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
+		}
 	}
 
 	result := map[string]model.OrderItemRequestNew{
 		leom.SKUVnt: leom,
 		leoa.SKUVnt: leoa,
 		vpnm.SKUVnt: vpnm,
+		vpna.SKUVnt: vpna,
 	}
 
 	return result

--- a/services/skus/skus_test.go
+++ b/services/skus/skus_test.go
@@ -122,25 +122,25 @@ func TestSKUNameByMobileName(t *testing.T) {
 		{
 			name:  "android_vpn_annual_release",
 			given: "brave.vpn.yearly",
-			exp:   tcExpected{skuVnt: "brave-vpn-premium"},
+			exp:   tcExpected{skuVnt: "brave-vpn-premium-year"},
 		},
 
 		{
 			name:  "android_vpn_annual_beta",
 			given: "beta.bravevpn.yearly",
-			exp:   tcExpected{skuVnt: "brave-vpn-premium"},
+			exp:   tcExpected{skuVnt: "brave-vpn-premium-year"},
 		},
 
 		{
 			name:  "android_vpn_annual_nightly",
 			given: "nightly.bravevpn.yearly",
-			exp:   tcExpected{skuVnt: "brave-vpn-premium"},
+			exp:   tcExpected{skuVnt: "brave-vpn-premium-year"},
 		},
 
 		{
 			name:  "ios_vpn_annual_release",
 			given: "bravevpn.yearly",
-			exp:   tcExpected{skuVnt: "brave-vpn-premium"},
+			exp:   tcExpected{skuVnt: "brave-vpn-premium-year"},
 		},
 
 		{
@@ -158,7 +158,7 @@ func TestSKUNameByMobileName(t *testing.T) {
 		{
 			name:  "ios_vpn_annual_legacy",
 			given: "brave-firewall-vpn-premium-year",
-			exp:   tcExpected{skuVnt: "brave-vpn-premium"},
+			exp:   tcExpected{skuVnt: "brave-vpn-premium-year"},
 		},
 	}
 
@@ -390,18 +390,18 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 				req: model.OrderItemRequestNew{
 					Quantity:                    1,
 					SKU:                         "brave-vpn-premium",
-					SKUVnt:                      "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
 					Location:                    "vpn.brave.software",
-					Description:                 "brave-vpn-premium",
+					Description:                 "brave-vpn-premium-year",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("9.99"),
+					Price:                       decimal.RequireFromString("99.99"),
 					IssuerTokenBuffer:           ptrTo(31),
 					IssuerTokenOverlap:          ptrTo(2),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_K1c8W3oM4mUsGw",
-						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+						ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
 					},
 				},
 			},
@@ -417,18 +417,18 @@ func TestNewOrderItemReqForSubID(t *testing.T) {
 				req: model.OrderItemRequestNew{
 					Quantity:                    1,
 					SKU:                         "brave-vpn-premium",
-					SKUVnt:                      "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
 					Location:                    "vpn.brave.software",
-					Description:                 "brave-vpn-premium",
+					Description:                 "brave-vpn-premium-year",
 					CredentialType:              "time-limited-v2",
 					CredentialValidDuration:     "P1M",
-					Price:                       decimal.RequireFromString("9.99"),
+					Price:                       decimal.RequireFromString("99.99"),
 					IssuerTokenBuffer:           ptrTo(31),
 					IssuerTokenOverlap:          ptrTo(2),
 					CredentialValidDurationEach: ptrTo("P1D"),
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_K1c8W3oM4mUsGw",
-						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+						ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
 					},
 				},
 			},
@@ -610,7 +610,7 @@ func TestNewCreateOrderReqNewMobile(t *testing.T) {
 			name: "staging_vpn_yearly",
 			given: tcGiven{
 				ppcfg: newPaymentProcessorConfig("staging"),
-				item:  newOrderItemReqNewMobileSet("staging")["brave-vpn-premium"],
+				item:  newOrderItemReqNewMobileSet("staging")["brave-vpn-premium-year"],
 			},
 			exp: model.CreateOrderRequestNew{
 				Currency: "USD",
@@ -624,18 +624,18 @@ func TestNewCreateOrderReqNewMobile(t *testing.T) {
 					{
 						Quantity:                    1,
 						SKU:                         "brave-vpn-premium",
-						SKUVnt:                      "brave-vpn-premium",
+						SKUVnt:                      "brave-vpn-premium-year",
 						Location:                    "vpn.bravesoftware.com",
-						Description:                 "brave-vpn-premium",
+						Description:                 "brave-vpn-premium-year",
 						CredentialType:              "time-limited-v2",
 						CredentialValidDuration:     "P1M",
-						Price:                       decimal.RequireFromString("9.99"),
+						Price:                       decimal.RequireFromString("99.99"),
 						IssuerTokenBuffer:           ptrTo(31),
 						IssuerTokenOverlap:          ptrTo(2),
 						CredentialValidDurationEach: ptrTo("P1D"),
 						StripeMetadata: &model.ItemStripeMetadata{
 							ProductID: "prod_Lhv4OM1aAPxflY",
-							ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
+							ItemID:    "price_1L8O6dBSm1mtrN9nOYyDqe0F",
 						},
 					},
 				},
@@ -754,6 +754,24 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 						ItemID:    "price_1L0VHmBSm1mtrN9nT5DPmUZb",
 					},
 				},
+
+				"brave-vpn-premium-year": model.OrderItemRequestNew{
+					Quantity:                    1,
+					SKU:                         "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
+					Location:                    "vpn.brave.com",
+					Description:                 "brave-vpn-premium-year",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("99.99"),
+					IssuerTokenBuffer:           ptrTo(31),
+					IssuerTokenOverlap:          ptrTo(2),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_Lhv8qsPsn6WHrx",
+						ItemID:    "price_1L7lgCBSm1mtrN9nDlAz8WT2",
+					},
+				},
 			},
 		},
 
@@ -812,6 +830,24 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_Lhv4OM1aAPxflY",
 						ItemID:    "price_1L0VEhBSm1mtrN9nGB4kZkfh",
+					},
+				},
+
+				"brave-vpn-premium-year": model.OrderItemRequestNew{
+					Quantity:                    1,
+					SKU:                         "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
+					Location:                    "vpn.bravesoftware.com",
+					Description:                 "brave-vpn-premium-year",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("99.99"),
+					IssuerTokenBuffer:           ptrTo(31),
+					IssuerTokenOverlap:          ptrTo(2),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_Lhv4OM1aAPxflY",
+						ItemID:    "price_1L8O6dBSm1mtrN9nOYyDqe0F",
 					},
 				},
 			},
@@ -874,6 +910,24 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
 					},
 				},
+
+				"brave-vpn-premium-year": model.OrderItemRequestNew{
+					Quantity:                    1,
+					SKU:                         "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium-year",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("99.99"),
+					IssuerTokenBuffer:           ptrTo(31),
+					IssuerTokenOverlap:          ptrTo(2),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
+					},
+				},
 			},
 		},
 
@@ -932,6 +986,24 @@ func TestNewOrderItemReqNewMobileSet(t *testing.T) {
 					StripeMetadata: &model.ItemStripeMetadata{
 						ProductID: "prod_K1c8W3oM4mUsGw",
 						ItemID:    "price_1JNYuNHof20bphG6BvgeYEnt",
+					},
+				},
+
+				"brave-vpn-premium-year": model.OrderItemRequestNew{
+					Quantity:                    1,
+					SKU:                         "brave-vpn-premium",
+					SKUVnt:                      "brave-vpn-premium-year",
+					Location:                    "vpn.brave.software",
+					Description:                 "brave-vpn-premium-year",
+					CredentialType:              "time-limited-v2",
+					CredentialValidDuration:     "P1M",
+					Price:                       decimal.RequireFromString("99.99"),
+					IssuerTokenBuffer:           ptrTo(31),
+					IssuerTokenOverlap:          ptrTo(2),
+					CredentialValidDurationEach: ptrTo("P1D"),
+					StripeMetadata: &model.ItemStripeMetadata{
+						ProductID: "prod_K1c8W3oM4mUsGw",
+						ItemID:    "price_1L7m0CHof20bphG6AYaCd9OU",
 					},
 				},
 			},


### PR DESCRIPTION
### Summary

Subj. Annual VPN on mobile has historically been linked to a monthly VPN SKU due to the absence of the annual SKU to link with. As the annual product has been created, now it's possible to link it correctly.

This might also be needed to avoid issues with detecting and displaying linked subscriptions on the Premium website.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
