### PR TITLE
fix: improve email handling when creating a stripe checkout session

### DIFF
--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2741,10 +2741,12 @@ func createStripeSession(ctx context.Context, cl stripeClient, req createStripeS
 		LineItems:          req.items,
 	}
 
-	if custID, ok := cl.FindCustomer(ctx, req.email); ok {
-		params.Customer = &custID.ID
-	} else {
-		if req.email != "" {
+	// Email might not be given.
+	// This could happen while recreating a session, and the email was not extracted from the old one.
+	if req.email != "" {
+		if cust, ok := cl.FindCustomer(ctx, req.email); ok && cust.Email != "" {
+			params.Customer = &cust.ID
+		} else {
 			params.CustomerEmail = &req.email
 		}
 	}


### PR DESCRIPTION
### Summary

This PR improves the way email is handled when creating a Stripe checkout session.

In rare instances, the email might not be supplied (if it was not fetched during attempts to recreate a session, which could happen either when getting an order or when setting trial days).

Otherwise, the code will continue trying to search for the customer associated with the email, and if found will additionally explicitly set the `CustomerEmail` field to have it populated on the checkout page.

If the customer was not found for the given email, then the behaviour remains the same, and the supplied email is used to populate the field on the checkout page.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
