### PR TITLE
chore: upgrade go runtime to 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       matrix:
         goversion:
         - 1.19
+        - 1.22
 
     steps:
     - name: Checkout repository
@@ -61,7 +62,9 @@ jobs:
       id: setup-go
       uses: actions/setup-go@v4
       with:
-        go-version: ${{ matrix.goversion }}
+        # Run both CI jobs explicitly with 1.22.
+        # The 1.19 job is currently marked as required, but it needs to pass before it can be removed.
+        go-version: 1.22
         cache-dependency-path: "**/go.sum"
 
     - name: Ensure Module Path

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: golangci-lint-libs
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: libs
-          version: v1.50.1
+          version: v1.57.2
           args: --timeout 3m
 
   golangci-services:
@@ -34,12 +34,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: golangci-lint-services
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: services
-          version: v1.50.1
+          version: v1.57.2
           args: --timeout 3m
 
   golangci-tools:
@@ -49,12 +49,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: golangci-lint-tools
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: tools
-          version: v1.50.1
+          version: v1.57.2
           args: --timeout 3m
 
   golangci-cmd:
@@ -64,12 +64,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: golangci-lint-cmd
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: cmd
-          version: v1.50.1
+          version: v1.57.2
           args: --timeout 3m
 
   golangci-main:
@@ -79,10 +79,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - name: golangci-lint-main
         uses: golangci/golangci-lint-action@v3
         with:
           working-directory: main
-          version: v1.50.1
+          version: v1.57.2
           args: --timeout 3m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,5 @@
 run:
-  go: "1.19"
+  go: "1.22"
   timeout: 3m
 
 linters-settings:
@@ -18,19 +18,27 @@ linters-settings:
     # Default: false
     check-type-assertions: true
 
-    gocritic:
-      # Settings passed to gocritic.
-      # The settings key is the name of a supported gocritic checker.
-      # The list of supported checkers can be find in https://go-critic.github.io/overview.
-      settings:
-        captLocal:
-          # Whether to restrict checker to params only.
-          # Default: true
-          paramsOnly: false
-        underef:
-          # Whether to skip (*x).method() calls where x is a pointer receiver.
-          # Default: true
-          skipRecvDeref: false
+  gocritic:
+    # Settings passed to gocritic.
+    # The settings key is the name of a supported gocritic checker.
+    # The list of supported checkers can be find in https://go-critic.github.io/overview.
+    settings:
+      captLocal:
+        # Whether to restrict checker to params only.
+        # Default: true
+        paramsOnly: false
+      underef:
+        # Whether to skip (*x).method() calls where x is a pointer receiver.
+        # Default: true
+        skipRecvDeref: false
+
+  revive:
+    rules:
+      - name: if-return
+        disabled: true
+
+      - name: unused-parameter
+        disabled: true
 
   varcheck:
     # Check usage of exported fields and variables.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.22-alpine as builder
 
 # Put certs in builder image.
 RUN apk update
@@ -20,8 +20,7 @@ RUN cd main && go mod download && CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-w -s -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X main.commit=${COMMIT}" \
     -o bat-go main.go
 
-# golang:1.19-alpine is based on alpine:3.18.
-FROM alpine:3.18 as base
+FROM alpine:3.19 as base
 
 # Put certs in artifact from builder.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docker-compose.dev-refresh.yml
+++ b/docker-compose.dev-refresh.yml
@@ -8,7 +8,7 @@ services:
   # every time a file changes.
   dev-refresh:
     container_name: grant-dev-refresh
-    image: golang:1.19
+    image: golang:1.22
     ports:
       - "3335:3333"
       - "6061:6061"

--- a/services/rewards/docker-compose.yml
+++ b/services/rewards/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   rewards-dev-refresh:
     container_name: rewards-dev-refresh
-    image: golang:1.19
+    image: golang:1.22
     ports:
       - "3343:3343"
       - "6061:6061"

--- a/services/skus/docker-compose.payment-refresh.yml
+++ b/services/skus/docker-compose.payment-refresh.yml
@@ -8,7 +8,7 @@ services:
   # every time a file changes.
   payment-refresh:
     container_name: grant-payment-refresh
-    image: golang:1.19
+    image: golang:1.22
     ports:
       - "3335:3333"
       - "6061:6061"

--- a/services/skus/docker-compose.yml
+++ b/services/skus/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   # every time a file changes.
   skus-dev-refresh:
     container_name: skus-dev-refresh
-    image: golang:1.19
+    image: golang:1.22
     ports:
       - "3353:3353"
       - "6061:6061"

--- a/services/wallet/docker-compose.yml
+++ b/services/wallet/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   # every time a file changes.
   wallet-dev-refresh:
     container_name: wallet-dev-refresh
-    image: golang:1.19
+    image: golang:1.22
     ports:
       - "3353:3353"
       - "6061:6061"

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as builder
+FROM golang:1.22-alpine as builder
 
 # put certs in builder image
 RUN apk update
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -ldflags "-w -s -X main.version=${VERSION} -X main.buildTime=${BUILD_TIME} -X main.commit=${COMMIT}" \
     -o bat-go main.go
 
-FROM alpine:3.18 as base
+FROM alpine:3.19 as base
 # put certs in artifact from builder
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /src/bat-go /bin/


### PR DESCRIPTION
### Summary

There would not have been a need for this, but there are 6 security issues that require updating `hashicorp/vault` to `v1.17` and `1.18`, which in turn requires Go runtime of `1.22` or above.

This PR updates the requirements for the runtime to `1.22`. Unfortunately, Go `1.22` also brings changes to the `go` directive in `go.mod`, as well as adds `toolchain`.

After this PR, anyone working with the code base should have at least Go `1.22.5`. If it's desired to remain in control of the version of Go used locally, then it's also advised to have `GOTOOLCHAIN=local` instead of `auto`.

The [dependency update PR](https://github.com/brave-intl/bat-go/pull/2662) requires this to be merged first.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
