### PR TITLE
fix: set email when creating new session for trial days

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/go-chi/chi"
@@ -310,11 +311,6 @@ func VoteRouter(service *Service, instrumentHandler middleware.InstrumentHandler
 	return r
 }
 
-type setTrialDaysRequest struct {
-	TrialDays int64 `json:"trialDays"`
-}
-
-// TODO: refactor this to avoid multiple fetches of an order.
 func handleSetOrderTrialDays(svc *Service) handlers.AppHandler {
 	return handlers.AppHandler(func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 		ctx := r.Context()
@@ -324,21 +320,19 @@ func handleSetOrderTrialDays(svc *Service) handlers.AppHandler {
 			return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
 		}
 
-		if err := svc.validateOrderMerchantAndCaveats(ctx, orderID); err != nil {
-			return handlers.ValidationError("merchant and caveats", map[string]interface{}{"orderMerchantAndCaveats": err.Error()})
-		}
-
 		data, err := io.ReadAll(io.LimitReader(r.Body, reqBodyLimit10MB))
 		if err != nil {
 			return handlers.WrapError(err, "failed to read request body", http.StatusBadRequest)
 		}
 
-		req := &setTrialDaysRequest{}
+		req := &model.SetTrialDaysRequest{}
 		if err := json.Unmarshal(data, req); err != nil {
 			return handlers.WrapError(err, "failed to parse request", http.StatusBadRequest)
 		}
 
-		if err := svc.SetOrderTrialDays(ctx, &orderID, req.TrialDays); err != nil {
+		now := time.Now().UTC()
+
+		if err := svc.setOrderTrialDays(ctx, orderID, req, now); err != nil {
 			return handlers.WrapError(err, "Error setting the trial days on the order", http.StatusInternalServerError)
 		}
 

--- a/services/skus/instrumented_datastore.go
+++ b/services/skus/instrumented_datastore.go
@@ -653,20 +653,6 @@ func (_d DatastoreWithPrometheus) SendSigningRequest(ctx context.Context, signin
 	return _d.base.SendSigningRequest(ctx, signingRequestWriter)
 }
 
-// SetOrderTrialDays implements Datastore
-func (_d DatastoreWithPrometheus) SetOrderTrialDays(ctx context.Context, orderID *uuid.UUID, days int64) (op1 *Order, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "SetOrderTrialDays", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.SetOrderTrialDays(ctx, orderID, days)
-}
-
 // UpdateOrder implements Datastore
 func (_d DatastoreWithPrometheus) UpdateOrder(orderID uuid.UUID, status string) (err error) {
 	_since := time.Now()

--- a/services/skus/mockdatastore.go
+++ b/services/skus/mockdatastore.go
@@ -692,21 +692,6 @@ func (mr *MockDatastoreMockRecorder) SendSigningRequest(ctx, signingRequestWrite
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSigningRequest", reflect.TypeOf((*MockDatastore)(nil).SendSigningRequest), ctx, signingRequestWriter)
 }
 
-// SetOrderTrialDays mocks base method.
-func (m *MockDatastore) SetOrderTrialDays(ctx context.Context, orderID *go_uuid.UUID, days int64) (*Order, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetOrderTrialDays", ctx, orderID, days)
-	ret0, _ := ret[0].(*Order)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SetOrderTrialDays indicates an expected call of SetOrderTrialDays.
-func (mr *MockDatastoreMockRecorder) SetOrderTrialDays(ctx, orderID, days interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOrderTrialDays", reflect.TypeOf((*MockDatastore)(nil).SetOrderTrialDays), ctx, orderID, days)
-}
-
 // UpdateOrder mocks base method.
 func (m *MockDatastore) UpdateOrder(orderID go_uuid.UUID, status string) error {
 	m.ctrl.T.Helper()
@@ -974,21 +959,6 @@ func (m *MockorderStore) SetStatus(ctx context.Context, dbi sqlx.ExecerContext, 
 func (mr *MockorderStoreMockRecorder) SetStatus(ctx, dbi, id, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockorderStore)(nil).SetStatus), ctx, dbi, id, status)
-}
-
-// SetTrialDays mocks base method.
-func (m *MockorderStore) SetTrialDays(ctx context.Context, dbi sqlx.QueryerContext, id go_uuid.UUID, ndays int64) (*model.Order, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetTrialDays", ctx, dbi, id, ndays)
-	ret0, _ := ret[0].(*model.Order)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SetTrialDays indicates an expected call of SetTrialDays.
-func (mr *MockorderStoreMockRecorder) SetTrialDays(ctx, dbi, id, ndays interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTrialDays", reflect.TypeOf((*MockorderStore)(nil).SetTrialDays), ctx, dbi, id, ndays)
 }
 
 // UpdateMetadata mocks base method.

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -118,12 +118,21 @@ func (o *Order) IsRadomPayable() bool {
 	return Slice[string](o.AllowedPaymentMethods).Contains(RadomPaymentMethod)
 }
 
-func (o *Order) ShouldSetTrialDays() bool {
-	return !o.IsPaid() && o.IsStripePayable()
+func (o *Order) ShouldCreateTrialSessionStripe(now time.Time) bool {
+	return !o.IsPaidAt(now) && o.IsStripePayable()
 }
 
 // IsPaid returns true if the order is paid.
+//
+// TODO: Update all callers of the method to pass time explicitly.
 func (o *Order) IsPaid() bool {
+	return o.IsPaidAt(time.Now())
+}
+
+// IsPaidAt returns true if the order is paid.
+//
+// If canceled, it checks if expires_at is in the future.
+func (o *Order) IsPaidAt(now time.Time) bool {
 	switch o.Status {
 	case OrderStatusPaid:
 		// The order is paid if the status is paid.
@@ -134,7 +143,7 @@ func (o *Order) IsPaid() bool {
 			return false
 		}
 
-		return o.ExpiresAt.After(time.Now())
+		return o.ExpiresAt.After(now)
 	default:
 		return false
 	}
@@ -729,6 +738,11 @@ type VerifyCredentialOpaque struct {
 	Type         string  `json:"type" validate:"oneof=single-use time-limited time-limited-v2"`
 	Presentation string  `json:"presentation" validate:"base64"`
 	Version      float64 `json:"version" validate:"-"`
+}
+
+type SetTrialDaysRequest struct {
+	Email     string `json:"email"` // TODO: Make it required.
+	TrialDays int64  `json:"trialDays"`
 }
 
 func addURLParam(src, name, val string) (string, error) {

--- a/services/skus/model/model_test.go
+++ b/services/skus/model/model_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	uuid "github.com/satori/go.uuid"
@@ -1157,53 +1158,68 @@ func TestOrder_Vendor(t *testing.T) {
 	}
 }
 
-func TestOrder_ShouldSetTrialDays(t *testing.T) {
+func TestOrder_ShouldCreateTrialSessionStripe(t *testing.T) {
+	type tcGiven struct {
+		ord *model.Order
+		now time.Time
+	}
+
 	type testCase struct {
 		name  string
-		given model.Order
+		given tcGiven
 		exp   bool
 	}
 
 	tests := []testCase{
 		{
-			name:  "not_paid",
-			given: model.Order{Status: model.OrderStatusPending},
-		},
-
-		{
-			name: "not_paid_not_stripe",
-			given: model.Order{
-				Status:                model.OrderStatusPending,
-				AllowedPaymentMethods: pq.StringArray{"something"},
+			name: "false_paid_not_stripe",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:                model.OrderStatusPaid,
+					AllowedPaymentMethods: pq.StringArray{"radom"},
+				},
 			},
 		},
 
 		{
-			name:  "paid",
-			given: model.Order{Status: model.OrderStatusPaid},
-		},
-
-		{
-			name: "paid_not_stripe",
-			given: model.Order{
-				Status:                model.OrderStatusPaid,
-				AllowedPaymentMethods: pq.StringArray{"something"},
+			name: "false_not_paid_not_stripe",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:                model.OrderStatusPending,
+					AllowedPaymentMethods: pq.StringArray{"radom"},
+				},
 			},
 		},
 
 		{
-			name: "paid_stripe",
-			given: model.Order{
-				Status:                model.OrderStatusPaid,
-				AllowedPaymentMethods: pq.StringArray{"stripe"},
+			name: "false_paid_stripe",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:                model.OrderStatusPaid,
+					AllowedPaymentMethods: pq.StringArray{"stripe"},
+				},
 			},
 		},
 
 		{
-			name: "not_paid_stripe",
-			given: model.Order{
-				Status:                model.OrderStatusPending,
-				AllowedPaymentMethods: pq.StringArray{"stripe"},
+			name: "false_canceled_not_expired_stripe",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:                model.OrderStatusPaid,
+					AllowedPaymentMethods: pq.StringArray{"stripe"},
+					ExpiresAt:             ptrTo(time.Date(2024, time.November, 1, 0, 0, 0, 0, time.UTC)),
+				},
+				now: time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "true_pending_stripe",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:                model.OrderStatusPending,
+					AllowedPaymentMethods: pq.StringArray{"stripe"},
+				},
 			},
 			exp: true,
 		},
@@ -1213,7 +1229,82 @@ func TestOrder_ShouldSetTrialDays(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual := tc.given.ShouldSetTrialDays()
+			actual := tc.given.ord.ShouldCreateTrialSessionStripe(tc.given.now)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestOrder_IsPaidAt(t *testing.T) {
+	type tcGiven struct {
+		ord *model.Order
+		now time.Time
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "true_paid",
+			given: tcGiven{
+				ord: &model.Order{
+					Status: model.OrderStatusPaid,
+				},
+			},
+			exp: true,
+		},
+
+		{
+			name: "false_canceled_no_expiry",
+			given: tcGiven{
+				ord: &model.Order{
+					Status: model.OrderStatusCanceled,
+				},
+			},
+		},
+
+		{
+			name: "true_canceled_expires_later",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:    model.OrderStatusCanceled,
+					ExpiresAt: ptrTo(time.Date(2024, time.November, 1, 0, 0, 0, 0, time.UTC)),
+				},
+				now: time.Date(2024, time.October, 1, 0, 0, 0, 0, time.UTC),
+			},
+			exp: true,
+		},
+
+		{
+			name: "false_canceled_expired",
+			given: tcGiven{
+				ord: &model.Order{
+					Status:    model.OrderStatusCanceled,
+					ExpiresAt: ptrTo(time.Date(2024, time.November, 1, 0, 0, 0, 0, time.UTC)),
+				},
+				now: time.Date(2024, time.December, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+
+		{
+			name: "false_pending",
+			given: tcGiven{
+				ord: &model.Order{
+					Status: model.OrderStatusPending,
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.ord.IsPaidAt(tc.given.now)
 			should.Equal(t, tc.exp, actual)
 		})
 	}

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -97,6 +97,7 @@ type orderStoreSvc interface {
 	SetStatus(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
 	SetExpiresAt(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
 	SetLastPaidAt(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
+	SetTrialDays(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, ndays int64) error
 	AppendMetadata(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error
 	AppendMetadataInt(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error
 	AppendMetadataInt64(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int64) error
@@ -634,7 +635,7 @@ func (s *Service) updateOrderStripeSession(ctx context.Context, dbi sqlx.ExtCont
 	var newSessID string
 
 	if expSessID != "" {
-		nsessID, err := s.recreateStripeSession(ctx, dbi, ord, expSessID)
+		nsessID, err := s.recreateStripeSession(ctx, dbi, ord, expSessID, "")
 		if err != nil {
 			return fmt.Errorf("failed to create checkout session: %w", err)
 		}
@@ -755,13 +756,31 @@ func (s *Service) CancelOrderLegacy(orderID uuid.UUID) error {
 	return s.Datastore.UpdateOrder(orderID, OrderStatusCanceled)
 }
 
-func (s *Service) SetOrderTrialDays(ctx context.Context, orderID *uuid.UUID, days int64) error {
-	ord, err := s.Datastore.SetOrderTrialDays(ctx, orderID, days)
+func (s *Service) setOrderTrialDays(ctx context.Context, orderID uuid.UUID, req *model.SetTrialDaysRequest, now time.Time) error {
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("failed to set the order's trial days: %w", err)
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.setOrderTrialDaysTx(ctx, tx, orderID, req, now); err != nil {
+		return err
 	}
 
-	if !ord.ShouldSetTrialDays() {
+	return tx.Commit()
+}
+
+func (s *Service) setOrderTrialDaysTx(ctx context.Context, dbi sqlx.ExtContext, orderID uuid.UUID, req *model.SetTrialDaysRequest, now time.Time) error {
+	if err := s.orderRepo.SetTrialDays(ctx, dbi, orderID, req.TrialDays); err != nil {
+		return err
+	}
+
+	ord, err := s.getOrderFullTx(ctx, dbi, orderID)
+	if err != nil {
+		return err
+	}
+
+	if !ord.ShouldCreateTrialSessionStripe(now) {
 		return nil
 	}
 
@@ -770,7 +789,7 @@ func (s *Service) SetOrderTrialDays(ctx context.Context, orderID *uuid.UUID, day
 		return model.ErrNoStripeCheckoutSessID
 	}
 
-	_, err = s.recreateStripeSession(ctx, s.Datastore.RawDB(), ord, oldSessID)
+	_, err = s.recreateStripeSession(ctx, dbi, ord, oldSessID, req.Email)
 
 	return err
 }
@@ -2554,7 +2573,7 @@ func (s *Service) renewOrderStripe(ctx context.Context, dbi sqlx.ExecerContext, 
 	return s.orderRepo.AppendMetadata(ctx, dbi, ord.ID, "paymentProcessor", model.StripePaymentMethod)
 }
 
-func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerContext, ord *model.Order, oldSessID string) (string, error) {
+func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerContext, ord *model.Order, oldSessID, email string) (string, error) {
 	oldSess, err := s.stripeCl.Session(ctx, oldSessID, nil)
 	if err != nil {
 		return "", err
@@ -2562,11 +2581,15 @@ func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerCont
 
 	req := createStripeSessionRequest{
 		orderID:    ord.ID.String(),
-		email:      xstripe.CustomerEmailFromSession(oldSess),
+		email:      email,
 		successURL: oldSess.SuccessURL,
 		cancelURL:  oldSess.CancelURL,
 		trialDays:  ord.GetTrialDays(),
 		items:      buildStripeLineItems(ord.Items),
+	}
+
+	if req.email == "" {
+		req.email = xstripe.CustomerEmailFromSession(oldSess)
 	}
 
 	sessID, err := createStripeSession(ctx, s.stripeCl, req)

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -19,6 +19,7 @@ type MockOrder struct {
 	FnSetStatus                         func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
 	FnSetExpiresAt                      func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
 	FnSetLastPaidAt                     func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
+	FnSetTrialDays                      func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, ndays int64) error
 	FnAppendMetadata                    func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error
 	FnAppendMetadataInt                 func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error
 	FnAppendMetadataInt64               func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int64) error
@@ -91,6 +92,14 @@ func (r *MockOrder) SetLastPaidAt(ctx context.Context, dbi sqlx.ExecerContext, i
 	}
 
 	return r.FnSetLastPaidAt(ctx, dbi, id, when)
+}
+
+func (r *MockOrder) SetTrialDays(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, ndays int64) error {
+	if r.FnSetTrialDays == nil {
+		return nil
+	}
+
+	return r.FnSetTrialDays(ctx, dbi, id, ndays)
 }
 
 func (r *MockOrder) AppendMetadata(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error {

--- a/services/skus/storage/repository/repository.go
+++ b/services/skus/storage/repository/repository.go
@@ -92,22 +92,10 @@ func (r *Order) SetLastPaidAt(ctx context.Context, dbi sqlx.ExecerContext, id uu
 }
 
 // SetTrialDays sets trial_days to ndays.
-func (r *Order) SetTrialDays(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID, ndays int64) (*model.Order, error) {
-	const q = `UPDATE orders
-	SET trial_days = $2, updated_at = now()
-	WHERE id = $1
-	RETURNING id, created_at, currency, updated_at, total_price, merchant_id, location, status, allowed_payment_methods, metadata, valid_for, last_paid_at, expires_at, trial_days`
+func (r *Order) SetTrialDays(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, ndays int64) error {
+	const q = `UPDATE orders SET trial_days = $2, updated_at = now() WHERE id = $1`
 
-	result := &model.Order{}
-	if err := dbi.QueryRowxContext(ctx, q, id, ndays).StructScan(result); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, model.ErrOrderNotFound
-		}
-
-		return nil, err
-	}
-
-	return result, nil
+	return r.execUpdate(ctx, dbi, q, id, ndays)
 }
 
 // SetStatus sets status to status.


### PR DESCRIPTION
### Summary

This PR improves handling of the customer email on a Stripe checkout session when setting trial days on an order and session.

https://github.com/brave-intl/bat-go/pull/2698 improved handling, but that was not enough. When we're setting trial days on a session, the caller already has the correct email. SKUs attempts to work out the email based on the old session. Because the two calls (the creation of the initial session and setting trial days) happen very close to each other, the customer record might not be ready yet or miss information.

This PR makes use of the passed email address, and falls back to the old behaviour (i.e. takes the email from on old session) only if it was not passed.

This should address the majority of cases where the checkout page for products with trial might be shown without a pre-filled email address.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
