### PR TITLE
feat: use customer id when present whilst creating a premium order

### DIFF
--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -413,6 +413,7 @@ type OrderItemRequest struct {
 // CreateOrderRequestNew includes information needed to create an order.
 type CreateOrderRequestNew struct {
 	Email          string                `json:"email" validate:"required,email"`
+	CustomerID     string                `json:"customer_id"` // Optional.
 	Currency       string                `json:"currency" validate:"required,iso4217"`
 	StripeMetadata *OrderStripeMetadata  `json:"stripe_metadata"`
 	RadomMetadata  *OrderRadomMetadata   `json:"radom_metadata"`

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2573,14 +2573,11 @@ func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerCont
 	req := createStripeSessionRequest{
 		orderID:    ord.ID.String(),
 		email:      email,
+		customerID: xstripe.CustomerIDFromSession(oldSess),
 		successURL: oldSess.SuccessURL,
 		cancelURL:  oldSess.CancelURL,
 		trialDays:  ord.GetTrialDays(),
 		items:      buildStripeLineItems(ord.Items),
-	}
-
-	if oldSess.Customer != nil {
-		req.customerID = oldSess.Customer.ID
 	}
 
 	if req.email == "" {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2573,11 +2573,14 @@ func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerCont
 	req := createStripeSessionRequest{
 		orderID:    ord.ID.String(),
 		email:      email,
-		customerID: oldSess.Customer.ID,
 		successURL: oldSess.SuccessURL,
 		cancelURL:  oldSess.CancelURL,
 		trialDays:  ord.GetTrialDays(),
 		items:      buildStripeLineItems(ord.Items),
+	}
+
+	if oldSess.Customer != nil {
+		req.customerID = oldSess.Customer.ID
 	}
 
 	if req.email == "" {

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -4388,7 +4388,7 @@ func TestService_recreateStripeSession(t *testing.T) {
 		},
 
 		{
-			name: "success_email_from_session",
+			name: "success_email_cust_from_session",
 			given: tcGiven{
 				ordRepo: &repository.MockOrder{
 					FnAppendMetadata: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key, val string) error {
@@ -4405,7 +4405,7 @@ func TestService_recreateStripeSession(t *testing.T) {
 							ID:         "cs_test_id_old",
 							SuccessURL: "https://example.com/success",
 							CancelURL:  "https://example.com/cancel",
-							Customer:   &stripe.Customer{Email: "you@example.com"},
+							Customer:   &stripe.Customer{ID: "cus_id", Email: "you@example.com"},
 						}
 
 						return result, nil
@@ -4473,7 +4473,6 @@ func TestService_recreateStripeSession(t *testing.T) {
 							ID:         "cs_test_id_old",
 							SuccessURL: "https://example.com/success",
 							CancelURL:  "https://example.com/cancel",
-							Customer:   &stripe.Customer{Email: "session@example.com"},
 						}
 
 						return result, nil

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -4564,7 +4564,84 @@ func TestCreateStripeSession(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "success_found_customer",
+			name: "success_cust_id",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if params.Customer == nil || *params.Customer != "cus_id" {
+							return nil, model.Error("unexpected")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+
+					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
+						panic("unexpected_find_customer")
+					},
+				},
+
+				req: createStripeSessionRequest{
+					orderID:    "facade00-0000-4000-a000-000000000000",
+					customerID: "cus_id",
+					successURL: "https://example.com/success",
+					cancelURL:  "https://example.com/cancel",
+					trialDays:  7,
+					items: []*stripe.CheckoutSessionLineItemParams{
+						{
+							Quantity: ptrTo[int64](1),
+							Price:    ptrTo("stripe_item_id"),
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
+
+		{
+			name: "success_cust_id_email",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if params.Customer == nil || *params.Customer != "cus_id" {
+							return nil, model.Error("unexpected")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+
+					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
+						panic("unexpected_find_customer")
+					},
+				},
+
+				req: createStripeSessionRequest{
+					orderID:    "facade00-0000-4000-a000-000000000000",
+					customerID: "cus_id",
+					email:      "you@example.com",
+					successURL: "https://example.com/success",
+					cancelURL:  "https://example.com/cancel",
+					trialDays:  7,
+					items: []*stripe.CheckoutSessionLineItemParams{
+						{
+							Quantity: ptrTo[int64](1),
+							Price:    ptrTo("stripe_item_id"),
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
+
+		{
+			name: "success_email_found_customer",
 			given: tcGiven{
 				cl: &xstripe.MockClient{
 					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
@@ -4598,7 +4675,7 @@ func TestCreateStripeSession(t *testing.T) {
 		},
 
 		{
-			name: "success_customer_not_found",
+			name: "success_email_customer_not_found",
 			given: tcGiven{
 				cl: &xstripe.MockClient{
 					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
@@ -4636,7 +4713,7 @@ func TestCreateStripeSession(t *testing.T) {
 		},
 
 		{
-			name: "success_no_customer_email",
+			name: "success_email_no_customer_email",
 			given: tcGiven{
 				cl: &xstripe.MockClient{
 					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
@@ -4663,7 +4740,7 @@ func TestCreateStripeSession(t *testing.T) {
 		},
 
 		{
-			name: "success_no_trial_days",
+			name: "success_email_no_trial_days",
 			given: tcGiven{
 				cl: &xstripe.MockClient{},
 

--- a/services/skus/xstripe/mock.go
+++ b/services/skus/xstripe/mock.go
@@ -15,7 +15,10 @@ type MockClient struct {
 
 func (c *MockClient) Session(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
 	if c.FnSession == nil {
-		result := &stripe.CheckoutSession{ID: id}
+		result := &stripe.CheckoutSession{
+			ID:       id,
+			Customer: &stripe.Customer{ID: "cus_id", Email: "customer@example.com"},
+		}
 
 		return result, nil
 	}

--- a/services/skus/xstripe/xstripe.go
+++ b/services/skus/xstripe/xstripe.go
@@ -56,3 +56,13 @@ func CustomerEmailFromSession(sess *stripe.CheckoutSession) string {
 	// Default to empty, Stripe will ask the customer.
 	return ""
 }
+
+func CustomerIDFromSession(sess *stripe.CheckoutSession) string {
+	// Return the customer id only if the customer is present AND it has email set.
+	// Without the email, the customer record is not fully formed, and does not suit the use case.
+	if sess.Customer != nil && sess.Customer.Email != "" {
+		return sess.Customer.ID
+	}
+
+	return ""
+}

--- a/services/skus/xstripe/xstripe_test.go
+++ b/services/skus/xstripe/xstripe_test.go
@@ -65,3 +65,52 @@ func TestCustomerEmailFromSession(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomerIDFromSession(t *testing.T) {
+	tests := []struct {
+		name  string
+		exp   string
+		given *stripe.CheckoutSession
+	}{
+		{
+			name:  "nil_customer_no_email",
+			given: &stripe.CheckoutSession{},
+		},
+
+		{
+			name: "customer_empty_email",
+			given: &stripe.CheckoutSession{
+				Customer: &stripe.Customer{},
+			},
+		},
+
+		{
+			name: "customer_email_no_id",
+			given: &stripe.CheckoutSession{
+				Customer: &stripe.Customer{
+					Email: "me@example.com",
+				},
+			},
+		},
+
+		{
+			name: "customer_email_id",
+			given: &stripe.CheckoutSession{
+				Customer: &stripe.Customer{
+					ID:    "cus_id",
+					Email: "me@example.com",
+				},
+			},
+			exp: "cus_id",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := CustomerIDFromSession(tc.given)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

This PR makes it possible for the known customer to be passed when creating a premium order. Additionally, this makes use of the customer information obtained from the old session when recreating one (mainly as part of the set trial days call).


### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
