### PR TITLE
fix: don't panic when issuer wasn't found for vote

### DIFF
--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -520,6 +520,10 @@ var generateCredentialRedemptions = func(ctx context.Context, cb []CredentialBin
 			}
 		}
 
+		if issuer == nil {
+			return nil, model.ErrIssuerNotFound
+		}
+
 		requestCredentials[i].Issuer = issuer.Name()
 		requestCredentials[i].TokenPreimage = cb[i].TokenPreimage
 		requestCredentials[i].Signature = cb[i].Signature

--- a/services/skus/vote.go
+++ b/services/skus/vote.go
@@ -236,9 +236,7 @@ func (s *Service) RunNextVoteDrainJob(ctx context.Context) (bool, error) {
 }
 
 // Vote based on the browser's attention
-func (s *Service) Vote(
-	ctx context.Context, credentials []CredentialBinding, voteText string) error {
-
+func (s *Service) Vote(ctx context.Context, credentials []CredentialBinding, voteText string) error {
 	logger := logging.Logger(ctx, "skus.Vote")
 
 	var vote Vote
@@ -248,8 +246,7 @@ func (s *Service) Vote(
 	}
 
 	// generate all the cb credential redemptions
-	requestCredentials, err := generateCredentialRedemptions(
-		context.WithValue(ctx, appctx.DatastoreCTXKey, s.Datastore), credentials)
+	requestCredentials, err := generateCredentialRedemptions(context.WithValue(ctx, appctx.DatastoreCTXKey, s.Datastore), credentials)
 	if err != nil {
 		return fmt.Errorf("error generating credential redemptions: %w", err)
 	}


### PR DESCRIPTION
### Summary

This PR fixes a panic when the issuer wasn't found whilst voting.

There has been a spike in panics due to not found issuer because the datastore method returns `nil, nil` when not found, and the caller does not check the result for nil-ness.


### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
