### PR TITLE
feat: add initial support for passing stripe discounts

### DIFF
--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -418,7 +418,9 @@ type CreateOrderRequestNew struct {
 	StripeMetadata *OrderStripeMetadata  `json:"stripe_metadata"`
 	RadomMetadata  *OrderRadomMetadata   `json:"radom_metadata"`
 	PaymentMethods []string              `json:"payment_methods"`
+	Discounts      []string              `json:"discounts"`
 	Items          []OrderItemRequestNew `json:"items" validate:"required,gt=0,dive"`
+	Metadata       map[string]string     `json:"metadata"`
 }
 
 // OrderItemRequestNew represents an item in an order request.

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2855,7 +2855,11 @@ func createStripeSession(ctx context.Context, cl stripeClient, req createStripeS
 		params.SubscriptionData.TrialPeriodDays = &req.trialDays
 	}
 
-	params.AddExtra("allow_promotion_codes", "true")
+	// Only allow user facing promotion codes if params.Discounts are empty:
+	// - allow_promotion_codes and params.Discounts are mutually exclusive in Stripe.
+	if len(params.Discounts) == 0 {
+		params.AddExtra("allow_promotion_codes", "true")
+	}
 
 	params.SubscriptionData.AddMetadata("orderID", req.orderID)
 

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2855,7 +2855,7 @@ func createStripeSession(ctx context.Context, cl stripeClient, req createStripeS
 		params.SubscriptionData.TrialPeriodDays = &req.trialDays
 	}
 
-	// Only allow user facing promotion codes if params.Discounts are empty:
+	// Only allow user-facing promotion codes if params.Discounts is empty:
 	// - allow_promotion_codes and params.Discounts are mutually exclusive in Stripe.
 	if len(params.Discounts) == 0 {
 		params.AddExtra("allow_promotion_codes", "true")

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -4654,6 +4654,10 @@ func TestCreateStripeSession(t *testing.T) {
 							return nil, model.Error("unexpected_metadata_val")
 						}
 
+						if params.Extra != nil && params.Extra.Get("allow_promotion_codes") == "true" {
+							return nil, model.Error("unexpected_extra_allow_promotion_codes")
+						}
+
 						result := &stripe.CheckoutSession{ID: "cs_test_id"}
 
 						return result, nil
@@ -4871,6 +4875,39 @@ func TestCreateStripeSession(t *testing.T) {
 			name: "success_email_no_trial_days",
 			given: tcGiven{
 				cl: &xstripe.MockClient{},
+
+				req: createStripeSessionRequest{
+					orderID:    "facade00-0000-4000-a000-000000000000",
+					email:      "you@example.com",
+					successURL: "https://example.com/success",
+					cancelURL:  "https://example.com/cancel",
+					items: []*stripe.CheckoutSessionLineItemParams{
+						{
+							Quantity: ptrTo[int64](1),
+							Price:    ptrTo("stripe_item_id"),
+						},
+					},
+				},
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
+
+		{
+			name: "success_allow_promotion_codes",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if params.Extra.Get("allow_promotion_codes") != "true" {
+							return nil, model.Error("unexpected_extra_allow_promotion_codes")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+				},
 
 				req: createStripeSessionRequest{
 					orderID:    "facade00-0000-4000-a000-000000000000",

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -4636,6 +4637,61 @@ func TestCreateStripeSession(t *testing.T) {
 
 	tests := []testCase{
 		{
+			name: "success_discounts_metadata",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if len(params.Discounts) != 1 {
+							return nil, model.Error("unexpected_discounts")
+						}
+
+						if coup := params.Discounts[0].Coupon; coup == nil || *coup != "coup_id_01" {
+							return nil, model.Error("unexpected_discount_val")
+						}
+
+						if val, ok := params.SubscriptionData.Params.Metadata["key_01"]; !ok || val != "val_01" {
+							fmt.Println(params.SubscriptionData.Metadata)
+							return nil, model.Error("unexpected_metadata_val")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+
+					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
+						panic("unexpected_find_customer")
+					},
+				},
+
+				req: createStripeSessionRequest{
+					orderID:    "facade00-0000-4000-a000-000000000000",
+					customerID: "cus_id",
+					successURL: "https://example.com/success",
+					cancelURL:  "https://example.com/cancel",
+					trialDays:  7,
+					items: []*stripe.CheckoutSessionLineItemParams{
+						{
+							Quantity: ptrTo[int64](1),
+							Price:    ptrTo("stripe_item_id"),
+						},
+					},
+					discounts: []*stripe.CheckoutSessionDiscountParams{
+						{
+							Coupon: ptrTo("coup_id_01"),
+						},
+					},
+					metadata: map[string]string{
+						"key_01": "val_01",
+					},
+				},
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
+
+		{
 			name: "success_cust_id",
 			given: tcGiven{
 				cl: &xstripe.MockClient{
@@ -4949,6 +5005,49 @@ func TestBuildStripeLineItems(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			actual := buildStripeLineItems(tc.given)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestBuildStripeDiscounts(t *testing.T) {
+	tests := []struct {
+		name  string
+		given []string
+		exp   []*stripe.CheckoutSessionDiscountParams
+	}{
+		{
+			name: "nil",
+		},
+
+		{
+			name:  "empty_nil",
+			given: []string{},
+		},
+
+		{
+			name:  "one",
+			given: []string{"coup_id_01"},
+			exp: []*stripe.CheckoutSessionDiscountParams{
+				{Coupon: ptrTo("coup_id_01")},
+			},
+		},
+
+		{
+			name:  "two",
+			given: []string{"coup_id_01", "coup_id_02"},
+			exp: []*stripe.CheckoutSessionDiscountParams{
+				{Coupon: ptrTo("coup_id_01")},
+				{Coupon: ptrTo("coup_id_02")},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := buildStripeDiscounts(tc.given)
 			should.Equal(t, tc.exp, actual)
 		})
 	}


### PR DESCRIPTION
### Summary

This PR adds initial support for passing Stripe coupons to use as discounts at checkout. Additionally, it allows passing extra metadata. This is only allowed in the authenticated endpoint for creating orders used by us.


### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
