### PR TITLE
refactor: delete no longer needed code

### DIFF
--- a/services/skus/datastore_test.go
+++ b/services/skus/datastore_test.go
@@ -133,28 +133,6 @@ func TestGetPagedMerchantTransactions(t *testing.T) {
 	}
 }
 
-func (suite *PostgresTestSuite) TestGetOrderByExternalID() {
-	ctx := context.Background()
-	defer ctx.Done()
-
-	// create an issuer and a paid order with one order item and a time limited v2 credential type.
-	ctx = context.WithValue(context.Background(), appctx.WhitelistSKUsCTXKey, []string{devFreeTimeLimitedV2})
-	o1, _ := createOrderAndIssuer(suite.T(), ctx, suite.storage, devFreeTimeLimitedV2)
-
-	// add the external id to metadata
-	err := suite.storage.AppendOrderMetadata(ctx, &o1.ID, "externalID", "my external id")
-	suite.Require().NoError(err)
-
-	// test out get by external id
-	o2, err := suite.storage.GetOrderByExternalID("my external id")
-	suite.Require().NoError(err)
-	suite.Assert().NotNil(o2)
-
-	if o2 != nil {
-		suite.Assert().Equal(o2.ID.String(), o1.ID.String())
-	}
-}
-
 func (suite *PostgresTestSuite) TestGetTimeLimitedV2OrderCredsByOrder_Success() {
 	env := os.Getenv("ENV")
 	ctx := context.WithValue(context.Background(), appctx.EnvironmentCTXKey, env)

--- a/services/skus/instrumented_datastore.go
+++ b/services/skus/instrumented_datastore.go
@@ -44,20 +44,6 @@ func NewDatastoreWithPrometheus(base Datastore, instanceName string) DatastoreWi
 	}
 }
 
-// AppendOrderMetadata implements Datastore
-func (_d DatastoreWithPrometheus) AppendOrderMetadata(ctx context.Context, up1 *uuid.UUID, s1 string, s2 string) (err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "AppendOrderMetadata", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.AppendOrderMetadata(ctx, up1, s1, s2)
-}
-
 // BeginTx implements Datastore
 func (_d DatastoreWithPrometheus) BeginTx() (tp1 *sqlx.Tx, err error) {
 	_since := time.Now()
@@ -70,20 +56,6 @@ func (_d DatastoreWithPrometheus) BeginTx() (tp1 *sqlx.Tx, err error) {
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "BeginTx", result).Observe(time.Since(_since).Seconds())
 	}()
 	return _d.base.BeginTx()
-}
-
-// CheckExpiredCheckoutSession implements Datastore
-func (_d DatastoreWithPrometheus) CheckExpiredCheckoutSession(u1 uuid.UUID) (b1 bool, s1 string, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "CheckExpiredCheckoutSession", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.CheckExpiredCheckoutSession(u1)
 }
 
 // CommitVote implements Datastore
@@ -254,20 +226,6 @@ func (_d DatastoreWithPrometheus) GetOrder(orderID uuid.UUID) (op1 *Order, err e
 	return _d.base.GetOrder(orderID)
 }
 
-// GetOrderByExternalID implements Datastore
-func (_d DatastoreWithPrometheus) GetOrderByExternalID(externalID string) (op1 *Order, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetOrderByExternalID", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.GetOrderByExternalID(externalID)
-}
-
 // GetOrderCreds implements Datastore
 func (_d DatastoreWithPrometheus) GetOrderCreds(orderID uuid.UUID, isSigned bool) (oa1 []OrderCreds, err error) {
 	_since := time.Now()
@@ -294,20 +252,6 @@ func (_d DatastoreWithPrometheus) GetOrderCredsByItemID(orderID uuid.UUID, itemI
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetOrderCredsByItemID", result).Observe(time.Since(_since).Seconds())
 	}()
 	return _d.base.GetOrderCredsByItemID(orderID, itemID, isSigned)
-}
-
-// GetOrderItem implements Datastore
-func (_d DatastoreWithPrometheus) GetOrderItem(ctx context.Context, itemID uuid.UUID) (op1 *OrderItem, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "GetOrderItem", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.GetOrderItem(ctx, itemID)
 }
 
 // GetOutboxMovAvgDurationSeconds implements Datastore
@@ -548,20 +492,6 @@ func (_d DatastoreWithPrometheus) InsertVote(ctx context.Context, vr VoteRecord)
 	return _d.base.InsertVote(ctx, vr)
 }
 
-// IsStripeSub implements Datastore
-func (_d DatastoreWithPrometheus) IsStripeSub(u1 uuid.UUID) (b1 bool, s1 string, err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "IsStripeSub", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.IsStripeSub(u1)
-}
-
 // MarkVoteErrored implements Datastore
 func (_d DatastoreWithPrometheus) MarkVoteErrored(ctx context.Context, vr VoteRecord, tx *sqlx.Tx) (err error) {
 	_since := time.Now()
@@ -665,20 +595,6 @@ func (_d DatastoreWithPrometheus) UpdateOrder(orderID uuid.UUID, status string) 
 		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "UpdateOrder", result).Observe(time.Since(_since).Seconds())
 	}()
 	return _d.base.UpdateOrder(orderID, status)
-}
-
-// UpdateOrderMetadata implements Datastore
-func (_d DatastoreWithPrometheus) UpdateOrderMetadata(orderID uuid.UUID, key string, value string) (err error) {
-	_since := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-
-		datastoreDurationSummaryVec.WithLabelValues(_d.instanceName, "UpdateOrderMetadata", result).Observe(time.Since(_since).Seconds())
-	}()
-	return _d.base.UpdateOrderMetadata(orderID, key, value)
 }
 
 // UpdateSigningOrderRequestOutboxTx implements Datastore

--- a/services/skus/mockdatastore.go
+++ b/services/skus/mockdatastore.go
@@ -42,20 +42,6 @@ func (m *MockDatastore) EXPECT() *MockDatastoreMockRecorder {
 	return m.recorder
 }
 
-// AppendOrderMetadata mocks base method.
-func (m *MockDatastore) AppendOrderMetadata(arg0 context.Context, arg1 *go_uuid.UUID, arg2, arg3 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendOrderMetadata", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AppendOrderMetadata indicates an expected call of AppendOrderMetadata.
-func (mr *MockDatastoreMockRecorder) AppendOrderMetadata(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendOrderMetadata", reflect.TypeOf((*MockDatastore)(nil).AppendOrderMetadata), arg0, arg1, arg2, arg3)
-}
-
 // BeginTx mocks base method.
 func (m *MockDatastore) BeginTx() (*sqlx.Tx, error) {
 	m.ctrl.T.Helper()
@@ -69,22 +55,6 @@ func (m *MockDatastore) BeginTx() (*sqlx.Tx, error) {
 func (mr *MockDatastoreMockRecorder) BeginTx() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTx", reflect.TypeOf((*MockDatastore)(nil).BeginTx))
-}
-
-// CheckExpiredCheckoutSession mocks base method.
-func (m *MockDatastore) CheckExpiredCheckoutSession(arg0 go_uuid.UUID) (bool, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckExpiredCheckoutSession", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CheckExpiredCheckoutSession indicates an expected call of CheckExpiredCheckoutSession.
-func (mr *MockDatastoreMockRecorder) CheckExpiredCheckoutSession(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckExpiredCheckoutSession", reflect.TypeOf((*MockDatastore)(nil).CheckExpiredCheckoutSession), arg0)
 }
 
 // CommitVote mocks base method.
@@ -263,21 +233,6 @@ func (mr *MockDatastoreMockRecorder) GetOrder(orderID interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrder", reflect.TypeOf((*MockDatastore)(nil).GetOrder), orderID)
 }
 
-// GetOrderByExternalID mocks base method.
-func (m *MockDatastore) GetOrderByExternalID(externalID string) (*Order, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrderByExternalID", externalID)
-	ret0, _ := ret[0].(*Order)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOrderByExternalID indicates an expected call of GetOrderByExternalID.
-func (mr *MockDatastoreMockRecorder) GetOrderByExternalID(externalID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrderByExternalID", reflect.TypeOf((*MockDatastore)(nil).GetOrderByExternalID), externalID)
-}
-
 // GetOrderCreds mocks base method.
 func (m *MockDatastore) GetOrderCreds(orderID go_uuid.UUID, isSigned bool) ([]OrderCreds, error) {
 	m.ctrl.T.Helper()
@@ -306,21 +261,6 @@ func (m *MockDatastore) GetOrderCredsByItemID(orderID, itemID go_uuid.UUID, isSi
 func (mr *MockDatastoreMockRecorder) GetOrderCredsByItemID(orderID, itemID, isSigned interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrderCredsByItemID", reflect.TypeOf((*MockDatastore)(nil).GetOrderCredsByItemID), orderID, itemID, isSigned)
-}
-
-// GetOrderItem mocks base method.
-func (m *MockDatastore) GetOrderItem(ctx context.Context, itemID go_uuid.UUID) (*OrderItem, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrderItem", ctx, itemID)
-	ret0, _ := ret[0].(*OrderItem)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOrderItem indicates an expected call of GetOrderItem.
-func (mr *MockDatastoreMockRecorder) GetOrderItem(ctx, itemID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrderItem", reflect.TypeOf((*MockDatastore)(nil).GetOrderItem), ctx, itemID)
 }
 
 // GetOutboxMovAvgDurationSeconds mocks base method.
@@ -575,22 +515,6 @@ func (mr *MockDatastoreMockRecorder) InsertVote(ctx, vr interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertVote", reflect.TypeOf((*MockDatastore)(nil).InsertVote), ctx, vr)
 }
 
-// IsStripeSub mocks base method.
-func (m *MockDatastore) IsStripeSub(arg0 go_uuid.UUID) (bool, string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsStripeSub", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(string)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// IsStripeSub indicates an expected call of IsStripeSub.
-func (mr *MockDatastoreMockRecorder) IsStripeSub(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStripeSub", reflect.TypeOf((*MockDatastore)(nil).IsStripeSub), arg0)
-}
-
 // MarkVoteErrored mocks base method.
 func (m *MockDatastore) MarkVoteErrored(ctx context.Context, vr VoteRecord, tx *sqlx.Tx) error {
 	m.ctrl.T.Helper()
@@ -704,20 +628,6 @@ func (m *MockDatastore) UpdateOrder(orderID go_uuid.UUID, status string) error {
 func (mr *MockDatastoreMockRecorder) UpdateOrder(orderID, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOrder", reflect.TypeOf((*MockDatastore)(nil).UpdateOrder), orderID, status)
-}
-
-// UpdateOrderMetadata mocks base method.
-func (m *MockDatastore) UpdateOrderMetadata(orderID go_uuid.UUID, key, value string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateOrderMetadata", orderID, key, value)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateOrderMetadata indicates an expected call of UpdateOrderMetadata.
-func (mr *MockDatastoreMockRecorder) UpdateOrderMetadata(orderID, key, value interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOrderMetadata", reflect.TypeOf((*MockDatastore)(nil).UpdateOrderMetadata), orderID, key, value)
 }
 
 // UpdateSigningOrderRequestOutboxTx mocks base method.


### PR DESCRIPTION
### Summary

The main purpose of this PR is to delete the logic for handling the `DELETE /v1/orders/{orderID}` endpoint. This was an authenticated endpoint for internal use, and it has long ago been migrated away from to `DELETE /v1/orders-new/{orderID}`. The SKUs service is no longer responsible for cancelling a Stripe subscription in Stripe.

Additionally, the PR adds a missing test for `repository.Order.GetByExternalID` method.

It also deletes other code that has not been used for a while.


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
