### PR TITLE
refactor: use radom subscription id in metadata instead of external id

### DIFF
--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1362,7 +1362,7 @@ func haveCreds(creds *TimeLimitedV2Creds) bool {
 }
 
 // GetActiveCredentialSigningKey get the current active signing key for this merchant
-func (s *Service) GetActiveCredentialSigningKey(ctx context.Context, merchantID string) ([]byte, error) {
+func (s *Service) GetActiveCredentialSigningKey(_ context.Context, merchantID string) ([]byte, error) {
 	// sorted by name, created_at, first result is most recent
 	keys, err := s.Datastore.GetKeysByMerchant(merchantID, false)
 	if err != nil {
@@ -1384,7 +1384,7 @@ func (s *Service) GetActiveCredentialSigningKey(ctx context.Context, merchantID 
 }
 
 // GetCredentialSigningKeys get the current list of credential signing keys for this merchant
-func (s *Service) GetCredentialSigningKeys(ctx context.Context, merchantID string) ([][]byte, error) {
+func (s *Service) GetCredentialSigningKeys(_ context.Context, merchantID string) ([][]byte, error) {
 	var resp = [][]byte{}
 	keys, err := s.Datastore.GetKeysByMerchant(merchantID, false)
 	if err != nil {
@@ -1442,7 +1442,7 @@ func credChunkFn(interval timeutils.ISODuration) func(time.Time) (time.Time, tim
 
 // timeChunking - given a duration and interval size of credential, return number of credentials
 // to generate, and a function that takes a start time and increments it by an appropriate amount
-func timeChunking(ctx context.Context, issuerID string, timeLimitedSecret cryptography.TimeLimitedSecret, orderID, itemID uuid.UUID, issued time.Time, duration, interval timeutils.ISODuration) ([]TimeLimitedCreds, error) {
+func timeChunking(_ context.Context, issuerID string, timeLimitedSecret cryptography.TimeLimitedSecret, orderID, itemID uuid.UUID, issued time.Time, duration, interval timeutils.ISODuration) ([]TimeLimitedCreds, error) {
 	expiresAt, err := duration.From(issued)
 	if err != nil {
 		return nil, fmt.Errorf("unable to compute expiry")
@@ -1479,7 +1479,7 @@ func timeChunking(ctx context.Context, issuerID string, timeLimitedSecret crypto
 }
 
 // GetTimeLimitedCreds returns get an order's time limited creds.
-func (s *Service) GetTimeLimitedCreds(ctx context.Context, order *Order, itemID, reqID uuid.UUID) ([]TimeLimitedCreds, int, error) {
+func (s *Service) GetTimeLimitedCreds(ctx context.Context, order *Order, itemID, _ uuid.UUID) ([]TimeLimitedCreds, int, error) {
 	if !order.IsPaid() || order.LastPaidAt == nil {
 		return nil, http.StatusBadRequest, model.Error("order is not paid, or invalid last paid at")
 	}

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -94,6 +94,7 @@ type orderStoreSvc interface {
 	Create(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error)
 	Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error)
 	GetByExternalID(ctx context.Context, dbi sqlx.QueryerContext, extID string) (*model.Order, error)
+	GetByRadomSubscriptionID(ctx context.Context, dbi sqlx.QueryerContext, rsid string) (*model.Order, error)
 	SetStatus(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
 	SetExpiresAt(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
 	SetLastPaidAt(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
@@ -2465,7 +2466,7 @@ func (s *Service) processRadomNotificationTx(ctx context.Context, dbi sqlx.ExtCo
 			return err
 		}
 
-		ord, err := s.orderRepo.GetByExternalID(ctx, dbi, subID.String())
+		ord, err := s.orderRepo.GetByRadomSubscriptionID(ctx, dbi, subID.String())
 		if err != nil {
 			return err
 		}
@@ -2495,7 +2496,7 @@ func (s *Service) processRadomNotificationTx(ctx context.Context, dbi sqlx.ExtCo
 			return err
 		}
 
-		ord, err := s.orderRepo.GetByExternalID(ctx, dbi, subID.String())
+		ord, err := s.orderRepo.GetByRadomSubscriptionID(ctx, dbi, subID.String())
 		if err != nil {
 			return err
 		}

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -5429,7 +5429,7 @@ func TestNewRadomGateway(t *testing.T) {
 	}
 }
 
-func TestService_processRadomEvent(t *testing.T) {
+func TestService_processRadomNotification(t *testing.T) {
 	type tcGiven struct {
 		event *radom.Notification
 	}
@@ -5466,7 +5466,7 @@ func TestService_processRadomEvent(t *testing.T) {
 	}
 }
 
-func TestService_processRadomEventTx(t *testing.T) {
+func TestService_processRadomNotificationTx(t *testing.T) {
 	type tcGiven struct {
 		event           *radom.Notification
 		orderRepo       orderStoreSvc

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -15,6 +15,7 @@ import (
 type MockOrder struct {
 	FnGet                               func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error)
 	FnGetByExternalID                   func(ctx context.Context, dbi sqlx.QueryerContext, extID string) (*model.Order, error)
+	FnGetByRadomSubscriptionID          func(ctx context.Context, dbi sqlx.QueryerContext, extID string) (*model.Order, error)
 	FnCreate                            func(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error)
 	FnSetStatus                         func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error
 	FnSetExpiresAt                      func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error
@@ -49,6 +50,14 @@ func (r *MockOrder) GetByExternalID(ctx context.Context, dbi sqlx.QueryerContext
 	}
 
 	return r.FnGetByExternalID(ctx, dbi, extID)
+}
+
+func (r *MockOrder) GetByRadomSubscriptionID(ctx context.Context, dbi sqlx.QueryerContext, rsid string) (*model.Order, error) {
+	if r.FnGetByRadomSubscriptionID == nil {
+		return &model.Order{}, nil
+	}
+
+	return r.FnGetByRadomSubscriptionID(ctx, dbi, rsid)
 }
 
 func (r *MockOrder) Create(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error) {

--- a/services/skus/storage/repository/repository.go
+++ b/services/skus/storage/repository/repository.go
@@ -59,6 +59,25 @@ func (r *Order) GetByExternalID(ctx context.Context, dbi sqlx.QueryerContext, ex
 	return result, nil
 }
 
+func (r *Order) GetByRadomSubscriptionID(ctx context.Context, dbi sqlx.QueryerContext, rsid string) (*model.Order, error) {
+	const q = `SELECT
+		id, created_at, currency, updated_at, total_price,
+		merchant_id, location, status, allowed_payment_methods,
+		metadata, valid_for, last_paid_at, expires_at, trial_days
+	FROM orders WHERE metadata->>'radomSubscriptionId' = $1`
+
+	result := &model.Order{}
+	if err := sqlx.GetContext(ctx, dbi, result, q, rsid); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, model.ErrOrderNotFound
+		}
+
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // Create creates an order with the data in req.
 func (r *Order) Create(ctx context.Context, dbi sqlx.QueryerContext, oreq *model.OrderNew) (*model.Order, error) {
 	const q = `INSERT INTO orders


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR uses a Radom subscription id instead of the external id in orders metadata.

### Issues

closes https://github.com/brave-intl/bat-go/issues/2824
related issue https://github.com/brave-intl/bat-go/pull/2718

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [x] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
