### PR TITLE
refactor: reset payment failed on radom renew and cancel events

### DIFF
--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2512,7 +2512,11 @@ func (s *Service) processRadomNotificationTx(ctx context.Context, dbi sqlx.ExtCo
 			return err
 		}
 
-		return s.renewOrderWithExpPaidTimeTx(ctx, dbi, ord.ID, expAt, paidAt)
+		if err := s.renewOrderWithExpPaidTimeTx(ctx, dbi, ord.ID, expAt, paidAt); err != nil {
+			return err
+		}
+
+		return s.resetNumPaymentFailed(ctx, dbi, ord.ID)
 
 	case ntf.ShouldCancel():
 		subID, err := ntf.SubID()
@@ -2525,7 +2529,11 @@ func (s *Service) processRadomNotificationTx(ctx context.Context, dbi sqlx.ExtCo
 			return err
 		}
 
-		return s.cancelOrderTx(ctx, dbi, ord.ID)
+		if err := s.cancelOrderTx(ctx, dbi, ord.ID); err != nil {
+			return err
+		}
+
+		return s.resetNumPaymentFailed(ctx, dbi, ord.ID)
 
 	case ntf.ShouldRecordPayFailure():
 		subID, err := ntf.SubID()

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -5564,6 +5564,46 @@ func TestService_processRadomNotificationTx(t *testing.T) {
 		},
 
 		{
+			name: "subscription_payment_reset_payment_failed_error",
+			given: tcGiven{
+				event: &radom.Notification{
+					EventData: &radom.EventData{
+						Payment: &radom.SubscriptionPayment{
+							RadomData: &radom.Data{
+								Subscription: &radom.Subscription{
+									SubscriptionID: uuid.NewV4(),
+								},
+							},
+						},
+					},
+				},
+				orderRepo: &repository.MockOrder{
+					FnAppendMetadataInt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error {
+						return model.Error("reset_payment_failed_error")
+					},
+				},
+				orderPayHistory: &repository.MockOrderPayHistory{},
+				radomCl: &mockRadomClient{
+					fnGetSubscription: func(ctx context.Context, subID string) (*radom.SubscriptionResponse, error) {
+						return &radom.SubscriptionResponse{
+							NextBillingDateAt: "2023-06-12T09:38:13.604410Z",
+							Payments: []radom.Payment{
+								{
+									Date: "2023-06-12T09:38:13.604410Z",
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			exp: tcExpected{
+				shouldErr: func(t should.TestingT, err error, i ...interface{}) bool {
+					return should.ErrorIs(t, err, model.Error("reset_payment_failed_error"))
+				},
+			},
+		},
+
+		{
 			name: "subscription_cancelled",
 			given: tcGiven{
 				event: &radom.Notification{
@@ -5578,6 +5618,29 @@ func TestService_processRadomNotificationTx(t *testing.T) {
 			exp: tcExpected{
 				shouldErr: func(t should.TestingT, err error, i ...interface{}) bool {
 					return should.NoError(t, err)
+				},
+			},
+		},
+
+		{
+			name: "subscription_cancelled_reset_payment_failed_error",
+			given: tcGiven{
+				event: &radom.Notification{
+					EventData: &radom.EventData{
+						Cancelled: &radom.SubscriptionCancelled{
+							SubscriptionID: uuid.NewV4(),
+						},
+					},
+				},
+				orderRepo: &repository.MockOrder{
+					FnAppendMetadataInt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, key string, val int) error {
+						return model.Error("reset_payment_failed_error")
+					},
+				},
+			},
+			exp: tcExpected{
+				shouldErr: func(t should.TestingT, err error, i ...interface{}) bool {
+					return should.ErrorIs(t, err, model.Error("reset_payment_failed_error"))
 				},
 			},
 		},


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR reset payment failed metadata on radom renew and cancel events.

closes  https://github.com/brave-intl/bat-go/issues/2854

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
