### PR TITLE
feat: add locale to stripe checkout session

### DIFF
--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -458,6 +458,7 @@ type CreateOrderRequestNew struct {
 	Discounts      []string              `json:"discounts"`
 	Items          []OrderItemRequestNew `json:"items" validate:"required,gt=0,dive"`
 	Metadata       map[string]string     `json:"metadata"`
+	Locale         string                `json:"locale" validate:"omitempty,bcp47_language_tag"`
 }
 
 // OrderItemRequestNew represents an item in an order request.

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -2169,6 +2169,7 @@ func (s *Service) createStripeSession(ctx context.Context, req *model.CreateOrde
 		items:      buildStripeLineItems(order.Items),
 		discounts:  buildStripeDiscounts(req.Discounts),
 		metadata:   req.Metadata,
+		Locale:     req.Locale,
 	}
 
 	return createStripeSession(ctx, s.stripeCl, sreq)
@@ -2992,6 +2993,7 @@ type createStripeSessionRequest struct {
 	items      []*stripe.CheckoutSessionLineItemParams
 	discounts  []*stripe.CheckoutSessionDiscountParams
 	metadata   map[string]string
+	Locale     string
 }
 
 func createStripeSession(ctx context.Context, cl stripeClient, req createStripeSessionRequest) (string, error) {
@@ -3004,6 +3006,10 @@ func createStripeSession(ctx context.Context, cl stripeClient, req createStripeS
 		SubscriptionData:   &stripe.CheckoutSessionSubscriptionDataParams{},
 		LineItems:          req.items,
 		Discounts:          req.discounts,
+	}
+
+	if req.Locale != "" {
+		params.Locale = ptrTo(req.Locale)
 	}
 
 	// Different processes can supply different info about customer:

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -4954,6 +4954,34 @@ func TestCreateStripeSession(t *testing.T) {
 				err: model.Error("something_went_wrong"),
 			},
 		},
+
+		{
+			name: "success_locale",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if *params.Locale != "en-GB" {
+							return nil, model.Error("unexpected_locale")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+
+					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
+						panic("unexpected_find_customer")
+					},
+				},
+
+				req: createStripeSessionRequest{
+					Locale: "en-GB",
+				},
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR adds a locale to the new order request so it can be used in the stripe checkout session.

The locale must be a valid `bcp47_language_tag`.

closes https://github.com/brave-intl/bat-go/issues/2908