### PR TITLE
fix: use correct time when calling iso duration from method

### DIFF
--- a/services/skus/service_test.go
+++ b/services/skus/service_test.go
@@ -730,7 +730,7 @@ func TestTimeChunking(t *testing.T) {
 				now:      time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
 			},
 			exp: tcExpected{
-				numCreds: 35,
+				numCreds: 36,
 			},
 		},
 
@@ -750,7 +750,7 @@ func TestTimeChunking(t *testing.T) {
 				now:      time.Date(2025, time.December, 1, 0, 0, 0, 0, time.UTC), //36
 			},
 			exp: tcExpected{
-				numCreds: 35,
+				numCreds: 36,
 			},
 		},
 


### PR DESCRIPTION
### Summary
This pull request fixes a bug where the time passed to the ISODuration From method was not being used. 

The parameter [t](https://github.com/brave-intl/bat-go/compare/master...fix-ios-duration-from#diff-af9e3847fd48f1c7587f06b242b99099dff940b959660a27b45cb40dd5d2ce01R51) was being passed into the From function however it was not being used and the call to duration function [here](https://github.com/brave-intl/bat-go/compare/master...fix-ios-duration-from#diff-af9e3847fd48f1c7587f06b242b99099dff940b959660a27b45cb40dd5d2ce01L105) 
created a [new time based from now](https://github.com/brave-intl/bat-go/compare/master...fix-ios-duration-from#diff-af9e3847fd48f1c7587f06b242b99099dff940b959660a27b45cb40dd5d2ce01L130) hence we were getting the wrong number of tokens as the time was not being calculated from the passed in value.

closes https://github.com/brave-intl/bat-go/issues/2911

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other