### PR TITLE
feat: add solana sanctioned address slack notifier

### DIFF
--- a/services/wallet/controllers_v3_int_test.go
+++ b/services/wallet/controllers_v3_int_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/brave-intl/bat-go/services/wallet/metric"
 	"github.com/brave-intl/bat-go/services/wallet/model"
 	"github.com/brave-intl/bat-go/services/wallet/storage"
+	"github.com/brave-intl/bat-go/services/wallet/xslack"
 )
 
 type WalletControllersTestSuite struct {
@@ -577,6 +578,7 @@ func (suite *WalletControllersTestSuite) TestLinkSolanaAddress_Success() {
 		solConf:         solConf,
 		dappConf:        dac,
 		crMu:            new(sync.RWMutex),
+		compBotCl:       &xslack.MockClient{},
 	}
 
 	cr := custodian.Regions{Solana: custodian.GeoAllowBlockMap{

--- a/services/wallet/controllers_v3_int_test.go
+++ b/services/wallet/controllers_v3_int_test.go
@@ -976,15 +976,3 @@ func setupRouter(service *Service) *chi.Mux {
 func ptrTo[T any](v T) *T {
 	return &v
 }
-
-type mockSolAddrsChecker struct {
-	fnIsAllowed func(ctx context.Context, addrs string) error
-}
-
-func (c *mockSolAddrsChecker) IsAllowed(ctx context.Context, addrs string) error {
-	if c.fnIsAllowed == nil {
-		return nil
-	}
-
-	return c.fnIsAllowed(ctx, addrs)
-}

--- a/services/wallet/mock.go
+++ b/services/wallet/mock.go
@@ -1,0 +1,15 @@
+package wallet
+
+import "context"
+
+type mockSolAddrsChecker struct {
+	fnIsAllowed func(ctx context.Context, addrs string) error
+}
+
+func (c *mockSolAddrsChecker) IsAllowed(ctx context.Context, addrs string) error {
+	if c.fnIsAllowed == nil {
+		return nil
+	}
+
+	return c.fnIsAllowed(ctx, addrs)
+}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -874,9 +874,11 @@ const errDisabledRegion model.Error = "disabled region"
 func (service *Service) LinkSolanaAddress(ctx context.Context, paymentID uuid.UUID, req linkSolanaAddrRequest) error {
 	if IsCheckerEnabled {
 		if err := service.solAddrsChecker.IsAllowed(ctx, req.SolanaPublicKey); err != nil {
-			msg := newSolSanctionedAddrsCompMsg(req.SolanaPublicKey)
-			if err := service.compBotCl.SendMessage(ctx, msg); err != nil {
-				return err
+			if errors.Is(err, model.ErrSolAddrsNotAllowed) {
+				msg := newSolSanctionedAddrsCompMsg(req.SolanaPublicKey)
+				if err := service.compBotCl.SendMessage(ctx, msg); err != nil {
+					return err
+				}
 			}
 
 			return err

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -372,7 +372,7 @@ func SetupService(ctx context.Context) (context.Context, *Service) {
 
 	solCl := xsolana.New(solEndpoint)
 
-	swURL := os.Getenv("SLACK_WEBHOOK_URL")
+	swURL := os.Getenv("SLACK_COMPLIANCE_WEBHOOK_SECRET")
 	if swURL == "" {
 		l.Panic().Err(model.Error("wallet: invalid slack webhook url"))
 	}

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -1292,7 +1292,7 @@ func doesSolAddrsHaveATAForMint(ctx context.Context, solCl solanaClient, solAddr
 }
 
 func newSolSanctionedAddrsCompMsg(addrs string) *xslack.Message {
-	msg := &xslack.Message{
+	return &xslack.Message{
 		Channel:  "#compliance-bot",
 		Username: "compliance-bot",
 		Blocks: []xslack.Block{
@@ -1313,6 +1313,4 @@ func newSolSanctionedAddrsCompMsg(addrs string) *xslack.Message {
 			},
 		},
 	}
-
-	return msg
 }

--- a/services/wallet/service.go
+++ b/services/wallet/service.go
@@ -49,6 +49,7 @@ import (
 	"github.com/brave-intl/bat-go/services/wallet/metric"
 	"github.com/brave-intl/bat-go/services/wallet/model"
 	"github.com/brave-intl/bat-go/services/wallet/storage"
+	"github.com/brave-intl/bat-go/services/wallet/xslack"
 	"github.com/brave-intl/bat-go/services/wallet/xsolana"
 )
 
@@ -172,6 +173,10 @@ type solanaClient interface {
 	GetTokenAccountsByOwner(ctx context.Context, owner solana.PublicKey, mint solana.PublicKey) (*rpc.GetTokenAccountsResult, error)
 }
 
+type compBotClient interface {
+	SendMessage(ctx context.Context, msg *xslack.Message) error
+}
+
 // Service contains datastore connections
 type Service struct {
 	Datastore   Datastore
@@ -197,6 +202,8 @@ type Service struct {
 	dappConf         DAppConfig
 
 	s3g s3Getter
+
+	compBotCl compBotClient
 }
 
 type DAppConfig struct {
@@ -223,7 +230,8 @@ func InitService(
 	retry backoff.RetryFunc,
 	metric metricSvc,
 	gemini geminiSvc,
-	dappConf DAppConfig) (*Service, error) {
+	dappConf DAppConfig,
+	compBotCl compBotClient) (*Service, error) {
 
 	service := &Service{
 		Datastore:       datastore,
@@ -242,6 +250,7 @@ func InitService(
 		gemini:          gemini,
 		dappConf:        dappConf,
 		crMu:            new(sync.RWMutex),
+		compBotCl:       compBotCl,
 	}
 
 	return service, nil
@@ -363,6 +372,14 @@ func SetupService(ctx context.Context) (context.Context, *Service) {
 
 	solCl := xsolana.New(solEndpoint)
 
+	swURL := os.Getenv("SLACK_WEBHOOK_URL")
+	if swURL == "" {
+		l.Panic().Err(model.Error("wallet: invalid slack webhook url"))
+	}
+
+	hc := &http.Client{}
+	compBotCl := xslack.NewClient(hc, swURL)
+
 	dappAO := strings.Split(os.Getenv("DAPP_ALLOWED_CORS_ORIGINS"), ",")
 	if len(dappAO) == 0 {
 		l.Panic().Err(errors.New("dapp allowed origins missing")).Msg("failed to initialize wallet service")
@@ -372,7 +389,7 @@ func SetupService(ctx context.Context) (context.Context, *Service) {
 		AllowedOrigins: dappAO,
 	}
 
-	s, err := InitService(db, roDB, chlRepo, alRepo, solWaitlistRepo, sac, solCl, solConf, repClient, geminiClient, geoCountryValidator, backoff.Retry, mtc, gemx, dappConf)
+	s, err := InitService(db, roDB, chlRepo, alRepo, solWaitlistRepo, sac, solCl, solConf, repClient, geminiClient, geoCountryValidator, backoff.Retry, mtc, gemx, dappConf, compBotCl)
 	if err != nil {
 		l.Panic().Err(err).Msg("failed to initialize wallet service")
 	}
@@ -857,6 +874,11 @@ const errDisabledRegion model.Error = "disabled region"
 func (service *Service) LinkSolanaAddress(ctx context.Context, paymentID uuid.UUID, req linkSolanaAddrRequest) error {
 	if IsCheckerEnabled {
 		if err := service.solAddrsChecker.IsAllowed(ctx, req.SolanaPublicKey); err != nil {
+			msg := newSolSanctionedAddrsCompMsg(req.SolanaPublicKey)
+			if err := service.compBotCl.SendMessage(ctx, msg); err != nil {
+				return err
+			}
+
 			return err
 		}
 	}
@@ -1267,4 +1289,30 @@ func doesSolAddrsHaveATAForMint(ctx context.Context, solCl solanaClient, solAddr
 	}
 
 	return nil
+}
+
+func newSolSanctionedAddrsCompMsg(addrs string) *xslack.Message {
+	msg := &xslack.Message{
+		Channel:  "#compliance-bot",
+		Username: "compliance-bot",
+		Blocks: []xslack.Block{
+			{
+				Type: "header",
+				Text: xslack.Text{
+					Type:  "plain_text",
+					Text:  ":octagonal_sign: Rewards Wallet Solana Sanctioned Address Linking Attempt",
+					Emoji: true,
+				},
+			},
+			{
+				Type: "section",
+				Text: xslack.Text{
+					Type: "mrkdwn",
+					Text: "Solana address " + addrs + " was blocked from linking",
+				},
+			},
+		},
+	}
+
+	return msg
 }

--- a/services/wallet/service_test.go
+++ b/services/wallet/service_test.go
@@ -26,7 +26,7 @@ func TestService_LinkSolanaAddress(t *testing.T) {
 	type tcGiven struct {
 		pid             uuid.UUID
 		req             linkSolanaAddrRequest
-		solAddrsChecker *mockAddrsChecker
+		solAddrsChecker solanaAddrsChecker
 		compBotCl       compBotClient
 	}
 
@@ -44,7 +44,7 @@ func TestService_LinkSolanaAddress(t *testing.T) {
 		{
 			name: "error_address_not_allowed",
 			given: tcGiven{
-				solAddrsChecker: &mockAddrsChecker{
+				solAddrsChecker: &mockSolAddrsChecker{
 					fnIsAllowed: func(ctx context.Context, addrs string) error {
 						return model.Error("error_address_not_allowed")
 					},
@@ -58,7 +58,7 @@ func TestService_LinkSolanaAddress(t *testing.T) {
 		{
 			name: "send_sol_sanctioned_message_error",
 			given: tcGiven{
-				solAddrsChecker: &mockAddrsChecker{
+				solAddrsChecker: &mockSolAddrsChecker{
 					fnIsAllowed: func(ctx context.Context, addrs string) error {
 						return model.ErrSolAddrsNotAllowed
 					},
@@ -81,7 +81,7 @@ func TestService_LinkSolanaAddress(t *testing.T) {
 		{
 			name: "send_sol_sanctioned_message_success",
 			given: tcGiven{
-				solAddrsChecker: &mockAddrsChecker{
+				solAddrsChecker: &mockSolAddrsChecker{
 					fnIsAllowed: func(ctx context.Context, addrs string) error {
 						return model.ErrSolAddrsNotAllowed
 					},
@@ -683,16 +683,4 @@ func (c *mockSolClient) GetTokenAccountsByOwner(ctx context.Context, owner solan
 	}
 
 	return c.fnGetTokenAccountsByOwner(ctx, owner, mint)
-}
-
-type mockAddrsChecker struct {
-	fnIsAllowed func(ctx context.Context, addrs string) error
-}
-
-func (c *mockAddrsChecker) IsAllowed(ctx context.Context, addrs string) error {
-	if c.fnIsAllowed == nil {
-		return nil
-	}
-
-	return c.fnIsAllowed(ctx, addrs)
 }

--- a/services/wallet/service_test.go
+++ b/services/wallet/service_test.go
@@ -19,7 +19,105 @@ import (
 	errorutils "github.com/brave-intl/bat-go/libs/errors"
 	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/services/wallet/model"
+	"github.com/brave-intl/bat-go/services/wallet/xslack"
 )
+
+func TestService_LinkSolanaAddress(t *testing.T) {
+	type tcGiven struct {
+		pid             uuid.UUID
+		req             linkSolanaAddrRequest
+		solAddrsChecker solanaAddrsChecker
+		compBotCl       compBotClient
+	}
+
+	type tcExpected struct {
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "error_address_not_allowed",
+			given: tcGiven{
+				solAddrsChecker: &mockSolAddrsChecker{
+					fnIsAllowed: func(ctx context.Context, addrs string) error {
+						return model.Error("error_address_not_allowed")
+					},
+				},
+			},
+			exp: tcExpected{
+				err: model.Error("error_address_not_allowed"),
+			},
+		},
+
+		{
+			name: "send_sol_sanctioned_message_error",
+			given: tcGiven{
+				solAddrsChecker: &mockSolAddrsChecker{
+					fnIsAllowed: func(ctx context.Context, addrs string) error {
+						return model.ErrSolAddrsNotAllowed
+					},
+				},
+				compBotCl: &xslack.MockClient{
+					FnSendMessage: func(ctx context.Context, msg *xslack.Message) error {
+						if msg == nil {
+							return model.Error("message_should_not_be_nil")
+						}
+
+						return model.Error("send_message_error")
+					},
+				},
+			},
+			exp: tcExpected{
+				err: model.Error("send_message_error"),
+			},
+		},
+
+		{
+			name: "send_sol_sanctioned_message_success",
+			given: tcGiven{
+				solAddrsChecker: &mockSolAddrsChecker{
+					fnIsAllowed: func(ctx context.Context, addrs string) error {
+						return model.ErrSolAddrsNotAllowed
+					},
+				},
+				compBotCl: &xslack.MockClient{
+					FnSendMessage: func(ctx context.Context, msg *xslack.Message) error {
+						if msg == nil {
+							return model.Error("message_should_not_be_nil")
+						}
+
+						return nil
+					},
+				},
+			},
+			exp: tcExpected{
+				err: model.ErrSolAddrsNotAllowed,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{
+				solAddrsChecker: tc.given.solAddrsChecker,
+				compBotCl:       tc.given.compBotCl,
+			}
+
+			ctx := context.Background()
+
+			actual := s.LinkSolanaAddress(ctx, tc.given.pid, tc.given.req)
+			should.Equal(t, tc.exp.err, actual)
+		})
+	}
+}
 
 func TestClaimsZP(t *testing.T) {
 	type tcGiven struct {

--- a/services/wallet/xslack/mock.go
+++ b/services/wallet/xslack/mock.go
@@ -1,0 +1,15 @@
+package xslack
+
+import "context"
+
+type MockClient struct {
+	FnSendMessage func(ctx context.Context, msg *Message) error
+}
+
+func (c *MockClient) SendMessage(ctx context.Context, msg *Message) error {
+	if c.FnSendMessage == nil {
+		return nil
+	}
+
+	return c.FnSendMessage(ctx, msg)
+}

--- a/services/wallet/xslack/xslack.go
+++ b/services/wallet/xslack/xslack.go
@@ -1,0 +1,71 @@
+package xslack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	doer  httpDoer
+	swURL string
+}
+
+func NewClient(httpDoer httpDoer, swURL string) *Client {
+	return &Client{
+		doer:  httpDoer,
+		swURL: swURL,
+	}
+}
+
+type Message struct {
+	Channel  string  `json:"channel"`
+	Username string  `json:"username"`
+	Blocks   []Block `json:"blocks"`
+}
+
+type Block struct {
+	Type string `json:"type"`
+	Text Text   `json:"text"`
+}
+
+type Text struct {
+	Type  string `json:"type"`
+	Text  string `json:"text"`
+	Emoji bool   `json:"emoji,omitempty"`
+}
+
+func (c *Client) SendMessage(ctx context.Context, msg *Message) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.swURL, bytes.NewBuffer(data))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.doer.Do(req)
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("xslack: failed to send message: status code %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/services/wallet/xslack/xslack_test.go
+++ b/services/wallet/xslack/xslack_test.go
@@ -1,0 +1,98 @@
+package xslack
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	should "github.com/stretchr/testify/assert"
+)
+
+func TestClient_SendMessage(t *testing.T) {
+	type tcGiven struct {
+		msg  *Message
+		doer httpDoer
+	}
+
+	type tcExpected struct {
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "http_do_error",
+			given: tcGiven{
+				msg: &Message{},
+				doer: &mockDoer{
+					fnDo: func(req *http.Request) (*http.Response, error) {
+						return nil, errors.New("http_error")
+					},
+				},
+			},
+			exp: tcExpected{
+				err: errors.New("http_error"),
+			},
+		},
+
+		{
+			name: "not_http_status_okay",
+			given: tcGiven{
+				msg: &Message{},
+				doer: &mockDoer{
+					fnDo: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{StatusCode: http.StatusInternalServerError}, nil
+					},
+				},
+			},
+			exp: tcExpected{
+				err: errors.New("xslack: failed to send message: status code 500"),
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				msg: &Message{},
+				doer: &mockDoer{
+					fnDo: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{StatusCode: http.StatusOK}, nil
+					},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			cl := &Client{
+				doer: tc.given.doer,
+			}
+
+			ctx := context.Background()
+
+			actual := cl.SendMessage(ctx, tc.given.msg)
+			should.Equal(t, tc.exp.err, actual)
+		})
+	}
+}
+
+type mockDoer struct {
+	fnDo func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockDoer) Do(req *http.Request) (*http.Response, error) {
+	if m.fnDo == nil {
+		return &http.Response{}, nil
+	}
+
+	return m.fnDo(req)
+}


### PR DESCRIPTION
### Summary

This PR adds functionality to send a slack notification when a user tries to link a Solana sanctioned address to their rewards wallet.

closes https://github.com/brave-intl/bat-go/issues/2921