### PR TITLE
refactor: remove address checker enabled feat flag

### DIFF
--- a/services/wallet/controllers_v3_int_test.go
+++ b/services/wallet/controllers_v3_int_test.go
@@ -512,8 +512,6 @@ func (suite *WalletControllersTestSuite) TestChallenges_Options() {
 func (suite *WalletControllersTestSuite) TestLinkSolanaAddress_Success() {
 	viper.Set("enable-link-drain-flag", "true")
 
-	IsCheckerEnabled = true
-
 	pg, _, err := NewPostgres()
 	suite.Require().NoError(err)
 

--- a/services/wallet/service_test.go
+++ b/services/wallet/service_test.go
@@ -102,8 +102,6 @@ func TestService_LinkSolanaAddress(t *testing.T) {
 		},
 	}
 
-	IsCheckerEnabled = true
-
 	for i := range tests {
 		tc := tests[i]
 


### PR DESCRIPTION
### Summary
This PR removes the `ADDRESS_CHECKER_ENABLED` feat flag as it is no longer needed.

closes https://github.com/brave-intl/bat-go/issues/2924