### PR TITLE
fix: check for nil ValidTo so it'll go to the dead letter queue

### DIFF
--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -1233,6 +1233,10 @@ func (pg *Postgres) InsertSignedOrderCredentialsTx(ctx context.Context, tx *sqlx
 			}
 
 		case timeLimitedV2:
+			if soResult.Data[i].ValidTo == nil {
+				return fmt.Errorf("error validTo for order creds orderID %s itemID %s is nil", metadata.OrderID, metadata.ItemID)
+			}
+
 			validToRaw := soResult.Data[i].ValidTo.Value()
 			if validToRaw == nil {
 				return fmt.Errorf("error validTo for order creds orderID %s itemID %s is null", metadata.OrderID, metadata.ItemID)


### PR DESCRIPTION
### Summary

adds a missing check to ensure ValidTo is not nil ( not just `ValidTo.Value()`. )

I think the case that led to this happening was a quirk of long past testing on the development environment, but might as well add the check.

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
