### PR TITLE
fix: check stripe supports locale when creating checkout session

### DIFF
--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -4622,6 +4622,7 @@ func TestCreateStripeSession(t *testing.T) {
 	type tcGiven struct {
 		cl  *xstripe.MockClient
 		req createStripeSessionRequest
+		slv xstripe.LocaleValidator
 	}
 
 	type tcExpected struct {
@@ -4689,6 +4690,8 @@ func TestCreateStripeSession(t *testing.T) {
 						"key_01": "val_01",
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4727,6 +4730,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4766,6 +4771,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4800,6 +4807,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4838,6 +4847,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4865,6 +4876,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4888,6 +4901,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4921,6 +4936,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4949,6 +4966,8 @@ func TestCreateStripeSession(t *testing.T) {
 						},
 					},
 				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				err: model.Error("something_went_wrong"),
@@ -4977,6 +4996,38 @@ func TestCreateStripeSession(t *testing.T) {
 				req: createStripeSessionRequest{
 					Locale: "en-GB",
 				},
+
+				slv: xstripe.NewLocaleValidator(),
+			},
+			exp: tcExpected{
+				val: "cs_test_id",
+			},
+		},
+
+		{
+			name: "invalid_locale",
+			given: tcGiven{
+				cl: &xstripe.MockClient{
+					FnCreateSession: func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
+						if params.Locale != nil {
+							return nil, model.Error("unexpected_locale")
+						}
+
+						result := &stripe.CheckoutSession{ID: "cs_test_id"}
+
+						return result, nil
+					},
+
+					FnFindCustomer: func(ctx context.Context, email string) (*stripe.Customer, bool) {
+						panic("unexpected_find_customer")
+					},
+				},
+
+				req: createStripeSessionRequest{
+					Locale: "uk",
+				},
+
+				slv: xstripe.NewLocaleValidator(),
 			},
 			exp: tcExpected{
 				val: "cs_test_id",
@@ -4990,7 +5041,7 @@ func TestCreateStripeSession(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			actual, err := createStripeSession(ctx, tc.given.cl, tc.given.req)
+			actual, err := createStripeSession(ctx, tc.given.cl, tc.given.req, tc.given.slv)
 			must.Equal(t, tc.exp.err, err)
 
 			should.Equal(t, tc.exp.val, actual)

--- a/services/skus/xstripe/xstripe.go
+++ b/services/skus/xstripe/xstripe.go
@@ -72,3 +72,57 @@ func CustomerIDFromSession(sess *stripe.CheckoutSession) string {
 
 	return ""
 }
+
+type LocaleValidator map[string]struct{}
+
+func NewLocaleValidator() LocaleValidator {
+	return map[string]struct{}{
+		"auto":   {},
+		"bg":     {},
+		"cs":     {},
+		"da":     {},
+		"de":     {},
+		"el":     {},
+		"en":     {},
+		"en-GB":  {},
+		"es":     {},
+		"es-419": {},
+		"et":     {},
+		"fi":     {},
+		"fil":    {},
+		"fr":     {},
+		"fr-CA":  {},
+		"hr":     {},
+		"hu":     {},
+		"id":     {},
+		"it":     {},
+		"ja":     {},
+		"ko":     {},
+		"lt":     {},
+		"lv":     {},
+		"ms":     {},
+		"mt":     {},
+		"nb":     {},
+		"nl":     {},
+		"pl":     {},
+		"pt-BR":  {},
+		"pt":     {},
+		"ro":     {},
+		"ru":     {},
+		"sk":     {},
+		"sl":     {},
+		"sv":     {},
+		"th":     {},
+		"tr":     {},
+		"vi":     {},
+		"zh":     {},
+		"zh-HK":  {},
+		"zh-TW":  {},
+	}
+}
+
+func (v LocaleValidator) IsLocaleSupported(locale string) bool {
+	_, ok := v[locale]
+
+	return ok
+}

--- a/services/skus/xstripe/xstripe_test.go
+++ b/services/skus/xstripe/xstripe_test.go
@@ -114,3 +114,284 @@ func TestCustomerIDFromSession(t *testing.T) {
 		})
 	}
 }
+
+func TestLocaleValidator_IsLocaleSupported(t *testing.T) {
+	type testCase struct {
+		name  string
+		given string
+		exp   bool
+	}
+
+	tests := []testCase{
+		{
+			name: "invalid_empty",
+		},
+
+		{
+			name:  "auto",
+			given: "auto",
+			exp:   true,
+		},
+
+		{
+			name:  "bulgarian",
+			given: "bg",
+			exp:   true,
+		},
+
+		{
+			name:  "czech",
+			given: "cs",
+			exp:   true,
+		},
+
+		{
+			name:  "danish",
+			given: "da",
+			exp:   true,
+		},
+
+		{
+			name:  "german",
+			given: "de",
+			exp:   true,
+		},
+
+		{
+			name:  "greek",
+			given: "el",
+			exp:   true,
+		},
+
+		{
+			name:  "english",
+			given: "en",
+			exp:   true,
+		},
+
+		{
+			name:  "english_united_kingdom",
+			given: "en-GB",
+			exp:   true,
+		},
+
+		{
+			name:  "spanish",
+			given: "es",
+			exp:   true,
+		},
+
+		{
+			name:  "spanish_latin_america",
+			given: "es-419",
+			exp:   true,
+		},
+
+		{
+			name:  "estonian",
+			given: "et",
+			exp:   true,
+		},
+
+		{
+			name:  "finnish",
+			given: "fi",
+			exp:   true,
+		},
+
+		{
+			name:  "filipino",
+			given: "fil",
+			exp:   true,
+		},
+
+		{
+			name:  "french",
+			given: "fr",
+			exp:   true,
+		},
+
+		{
+			name:  "french_canada",
+			given: "fr-CA",
+			exp:   true,
+		},
+
+		{
+			name:  "croatian",
+			given: "hr",
+			exp:   true,
+		},
+
+		{
+			name:  "hungarian",
+			given: "hu",
+			exp:   true,
+		},
+
+		{
+			name:  "hungarian",
+			given: "id",
+			exp:   true,
+		},
+
+		{
+			name:  "italian",
+			given: "it",
+			exp:   true,
+		},
+
+		{
+			name:  "japanese",
+			given: "ja",
+			exp:   true,
+		},
+
+		{
+			name:  "korean",
+			given: "ko",
+			exp:   true,
+		},
+
+		{
+			name:  "lithuanian",
+			given: "lt",
+			exp:   true,
+		},
+
+		{
+			name:  "latvian",
+			given: "lv",
+			exp:   true,
+		},
+
+		{
+			name:  "malay",
+			given: "ms",
+			exp:   true,
+		},
+
+		{
+			name:  "maltese",
+			given: "mt",
+			exp:   true,
+		},
+
+		{
+			name:  "norwegian",
+			given: "nb",
+			exp:   true,
+		},
+
+		{
+			name:  "dutch",
+			given: "nl",
+			exp:   true,
+		},
+
+		{
+			name:  "polish",
+			given: "pl",
+			exp:   true,
+		},
+
+		{
+			name:  "portuguese_brazil",
+			given: "pt-BR",
+			exp:   true,
+		},
+
+		{
+			name:  "portuguese",
+			given: "pt",
+			exp:   true,
+		},
+
+		{
+			name:  "romanian",
+			given: "ro",
+			exp:   true,
+		},
+
+		{
+			name:  "russian",
+			given: "ru",
+			exp:   true,
+		},
+
+		{
+			name:  "slovak",
+			given: "sk",
+			exp:   true,
+		},
+
+		{
+			name:  "slovenian",
+			given: "sl",
+			exp:   true,
+		},
+
+		{
+			name:  "swedish",
+			given: "sv",
+			exp:   true,
+		},
+
+		{
+			name:  "thai",
+			given: "th",
+			exp:   true,
+		},
+
+		{
+			name:  "turkish",
+			given: "tr",
+			exp:   true,
+		},
+
+		{
+			name:  "vietnamese",
+			given: "vi",
+			exp:   true,
+		},
+
+		{
+			name:  "chinese_simplified",
+			given: "zh",
+			exp:   true,
+		},
+
+		{
+			name:  "chinese_traditional_hong_kong",
+			given: "zh-HK",
+			exp:   true,
+		},
+
+		{
+			name:  "chinese_traditional_taiwan",
+			given: "zh-TW",
+			exp:   true,
+		},
+
+		{
+			name:  "invalid_numbers",
+			given: "12345",
+		},
+
+		{
+			name:  "invalid_letters",
+			given: "uk",
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			slv := NewLocaleValidator()
+
+			actual := slv.IsLocaleSupported(tc.given)
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR adds a check to see if the locale the users has set on the account site is supported by the Stripe checkout page, if not then it does not set the locale which means Stripe will fallback to the default.

closes https://github.com/brave-intl/bat-go/issues/2960

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
