### PR TITLE
feat: add support CLI command to update Premium order email

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -88,6 +88,12 @@ func Router(
 		metricsMwr("SetOrderTrialDays", NewCORSMwr(copts, http.MethodPatch)(authMwr(handleSetOrderTrialDays(svc)))),
 	)
 
+	r.Method(
+		http.MethodPatch,
+		"/{orderID}/email",
+		metricsMwr("UpdateOrderEmail", supportMwr(handlers.AppHandler(handleUpdateOrderEmail(svc)))),
+	)
+
 	r.Method(http.MethodGet, "/{orderID}/transactions", metricsMwr("GetTransactions", GetTransactions(svc)))
 
 	r.Method(
@@ -335,6 +341,39 @@ func handleSetOrderTrialDays(svc *Service) handlers.AppHandler {
 
 		if err := svc.setOrderTrialDays(ctx, orderID, req, now); err != nil {
 			return handlers.WrapError(err, "Error setting the trial days on the order", http.StatusInternalServerError)
+		}
+
+		return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+	})
+}
+
+func handleUpdateOrderEmail(svc *Service) handlers.AppHandler {
+	return handlers.AppHandler(func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		ctx := r.Context()
+
+		orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+		if err != nil {
+			return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+		}
+
+		req := &model.UpdateEmailRequest{}
+		if err := requestutils.ReadJSON(ctx, r.Body, req); err != nil {
+			return handlers.WrapError(err, "failed to read request body", http.StatusBadRequest)
+		}
+
+		if _, err := govalidator.ValidateStruct(req); err != nil {
+			return handlers.WrapValidationError(err)
+		}
+
+		if err := svc.updateOrderEmail(ctx, orderID, req.Email); err != nil {
+			switch {
+			case errors.Is(err, model.ErrOrderNotFound):
+				return handlers.WrapError(err, "order not found", http.StatusNotFound)
+			case errors.Is(err, model.ErrNoStripeSubscriptionID):
+				return handlers.WrapError(err, "order does not have a stripe subscription", http.StatusUnprocessableEntity)
+			default:
+				return handlers.WrapError(err, "failed to update order email", http.StatusInternalServerError)
+			}
 		}
 
 		return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -61,6 +61,9 @@ const (
 
 	ErrOrderNotOneOffPayment = Error("model: order is not perpetual license")
 
+	ErrNoStripeSubscriptionID Error = "model: order: no stripe subscription id"
+	ErrNoStripeCustomer       Error = "model: order: no stripe customer on subscription"
+
 	errInvalidNumConversion Error = "model: invalid numeric conversion"
 )
 
@@ -862,6 +865,10 @@ type VerifyCredentialOpaque struct {
 type SetTrialDaysRequest struct {
 	Email     string `json:"email"` // TODO: Make it required.
 	TrialDays int64  `json:"trialDays"`
+}
+
+type UpdateEmailRequest struct {
+	Email string `json:"email" valid:"email,required"`
 }
 
 func addURLParam(src, name, val string) (string, error) {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -132,6 +132,7 @@ type stripeClient interface {
 	Subscription(ctx context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error)
 	CancelSub(_ context.Context, id string, params *stripe.SubscriptionCancelParams) error
 	FindCustomer(ctx context.Context, email string) (*stripe.Customer, bool)
+	UpdateCustomer(ctx context.Context, id string, params *stripe.CustomerParams) (*stripe.Customer, error)
 }
 
 // Service contains datastore
@@ -909,6 +910,33 @@ func (s *Service) setOrderTrialDaysTx(ctx context.Context, dbi sqlx.ExtContext, 
 	_, err = s.recreateStripeSession(ctx, dbi, ord, oldSessID, req.Email)
 
 	return err
+}
+
+func (s *Service) updateOrderEmail(ctx context.Context, orderID uuid.UUID, email string) error {
+	ord, err := s.orderRepo.Get(ctx, s.Datastore.RawDB(), orderID)
+	if err != nil {
+		return err
+	}
+
+	subID, ok := ord.StripeSubID()
+	if !ok {
+		return model.ErrNoStripeSubscriptionID
+	}
+
+	sub, err := s.stripeCl.Subscription(ctx, subID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to fetch stripe subscription: %w", err)
+	}
+
+	if sub.Customer == nil {
+		return model.ErrNoStripeCustomer
+	}
+
+	if _, err := s.stripeCl.UpdateCustomer(ctx, sub.Customer.ID, &stripe.CustomerParams{Email: stripe.String(email)}); err != nil {
+		return fmt.Errorf("failed to update stripe customer email: %w", err)
+	}
+
+	return nil
 }
 
 // UpdateOrderStatus checks to see if an order has been paid and updates it if so

--- a/services/skus/xstripe/mock.go
+++ b/services/skus/xstripe/mock.go
@@ -7,11 +7,12 @@ import (
 )
 
 type MockClient struct {
-	FnSession       func(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
-	FnCreateSession func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
-	FnSubscription  func(ctx context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error)
-	FnFindCustomer  func(ctx context.Context, email string) (*stripe.Customer, bool)
-	FnCancelSub     func(ctx context.Context, id string, params *stripe.SubscriptionCancelParams) error
+	FnSession        func(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
+	FnCreateSession  func(ctx context.Context, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error)
+	FnSubscription   func(ctx context.Context, id string, params *stripe.SubscriptionParams) (*stripe.Subscription, error)
+	FnFindCustomer   func(ctx context.Context, email string) (*stripe.Customer, bool)
+	FnCancelSub      func(ctx context.Context, id string, params *stripe.SubscriptionCancelParams) error
+	FnUpdateCustomer func(ctx context.Context, id string, params *stripe.CustomerParams) (*stripe.Customer, error)
 }
 
 func (c *MockClient) Session(ctx context.Context, id string, params *stripe.CheckoutSessionParams) (*stripe.CheckoutSession, error) {
@@ -82,4 +83,17 @@ func (c *MockClient) CancelSub(ctx context.Context, id string, params *stripe.Su
 	}
 
 	return c.FnCancelSub(ctx, id, params)
+}
+
+func (c *MockClient) UpdateCustomer(ctx context.Context, id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
+	if c.FnUpdateCustomer == nil {
+		result := &stripe.Customer{ID: id}
+		if params.Email != nil {
+			result.Email = *params.Email
+		}
+
+		return result, nil
+	}
+
+	return c.FnUpdateCustomer(ctx, id, params)
 }

--- a/services/skus/xstripe/xstripe.go
+++ b/services/skus/xstripe/xstripe.go
@@ -48,6 +48,10 @@ func (c *Client) CancelSub(_ context.Context, id string, params *stripe.Subscrip
 	return err
 }
 
+func (c *Client) UpdateCustomer(_ context.Context, id string, params *stripe.CustomerParams) (*stripe.Customer, error) {
+	return c.cl.Customers.Update(id, params)
+}
+
 func CustomerEmailFromSession(sess *stripe.CheckoutSession) string {
 	// Use the customer email if the customer has completed the payment flow.
 	if sess.Customer != nil && sess.Customer.Email != "" {

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -40,9 +40,35 @@ before making any changes.`,
 	RunE: runResetLinkingLimit,
 }
 
+var updateEmailCmd = &cobra.Command{
+	Use:   "update-email",
+	Short: "Update the email address on a Premium order",
+	Long: `Updates the Stripe customer email associated with a Premium order.
+
+Use this when a user cannot change their email through the account page.`,
+	RunE: runUpdateEmail,
+}
+
 func init() {
 	SkusCmd.AddCommand(resetLinkingLimitCmd)
+	SkusCmd.AddCommand(updateEmailCmd)
 	rootcmd.RootCmd.AddCommand(SkusCmd)
+
+	{
+		// Flags for update-email are read directly from cmd.Flags() in runUpdateEmail
+		// to avoid collisions with reset-linking-limit's viper bindings.
+		ue := updateEmailCmd.Flags()
+
+		ue.String("skus-base-url", "", "base URL of the SKUs service (e.g. https://payment.rewards.brave.com)")
+		ue.String("order-id", "", "the order UUID whose email should be updated")
+		ue.String("email", "", "the new email address to set")
+		ue.String("private-key", "", "path to the ed25519 private key file in SSH format used to sign requests")
+
+		rootcmd.Must(updateEmailCmd.MarkFlagRequired("skus-base-url"))
+		rootcmd.Must(updateEmailCmd.MarkFlagRequired("order-id"))
+		rootcmd.Must(updateEmailCmd.MarkFlagRequired("email"))
+		rootcmd.Must(updateEmailCmd.MarkFlagRequired("private-key"))
+	}
 
 	fb := rootcmd.NewFlagBuilder(resetLinkingLimitCmd)
 
@@ -228,6 +254,64 @@ func loadED25519PrivateKey(path string) (ed25519.PrivateKey, error) {
 	}
 
 	return *key, nil
+}
+
+func runUpdateEmail(cmd *cobra.Command, args []string) error {
+	baseURL, _ := cmd.Flags().GetString("skus-base-url")
+	baseURL = strings.TrimRight(baseURL, "/")
+	orderID, _ := cmd.Flags().GetString("order-id")
+	email, _ := cmd.Flags().GetString("email")
+	privKeyPath, _ := cmd.Flags().GetString("private-key")
+
+	privKey, err := loadED25519PrivateKey(privKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %w", err)
+	}
+
+	if !confirm(fmt.Sprintf("Update email for order %s to %q?", orderID, email)) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	ctx := cmd.Context()
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	endpoint := fmt.Sprintf("%s/v1/orders/%s/email", baseURL, orderID)
+
+	payload := struct {
+		Email string `json:"email"`
+	}{Email: email}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := skus.SignSupportRequest(privKey, req); err != nil {
+		return fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, respBody)
+	}
+
+	fmt.Printf("Done. Email updated for order %s.\n", orderID)
+
+	return nil
 }
 
 func confirm(prompt string) bool {


### PR DESCRIPTION
Users on Stripe-backed Premium accounts can't reliably change their email through the account page, so support agents have no tooling to do it on their behalf.

Adds a PATCH /v1/orders/{orderID}/email endpoint behind the existing supportMwr key authentication, and a corresponding `bat-go skus update-email` CLI command. The handler resolves the Stripe customer via the order's stripeSubscriptionId metadata, calls Customers.Update with the new address, and shows a confirmation prompt before making any change.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
