### PR TITLE
feat(skus): add relink-subscription support tool

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -88,6 +88,12 @@ func Router(
 		metricsMwr("SetOrderTrialDays", NewCORSMwr(copts, http.MethodPatch)(authMwr(handleSetOrderTrialDays(svc)))),
 	)
 
+	r.Method(
+		http.MethodPatch,
+		"/{orderID}/subscription",
+		metricsMwr("RelinkOrderSubscription", supportMwr(handlers.AppHandler(handleRelinkOrderSubscription(svc)))),
+	)
+
 	r.Method(http.MethodGet, "/{orderID}/transactions", metricsMwr("GetTransactions", GetTransactions(svc)))
 
 	r.Method(
@@ -335,6 +341,39 @@ func handleSetOrderTrialDays(svc *Service) handlers.AppHandler {
 
 		if err := svc.setOrderTrialDays(ctx, orderID, req, now); err != nil {
 			return handlers.WrapError(err, "Error setting the trial days on the order", http.StatusInternalServerError)
+		}
+
+		return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+	})
+}
+
+func handleRelinkOrderSubscription(svc *Service) handlers.AppHandler {
+	return handlers.AppHandler(func(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+		ctx := r.Context()
+
+		orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+		if err != nil {
+			return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+		}
+
+		req := &model.RelinkSubscriptionRequest{}
+		if err := requestutils.ReadJSON(ctx, r.Body, req); err != nil {
+			return handlers.WrapError(err, "failed to read request body", http.StatusBadRequest)
+		}
+
+		if _, err := govalidator.ValidateStruct(req); err != nil {
+			return handlers.WrapValidationError(err)
+		}
+
+		if err := svc.relinkOrderSubscription(ctx, orderID, req.SubscriptionID); err != nil {
+			switch {
+			case errors.Is(err, model.ErrOrderNotFound):
+				return handlers.WrapError(err, "order not found", http.StatusNotFound)
+			case errors.Is(err, model.ErrStripeSubscriptionNotActive):
+				return handlers.WrapError(err, "stripe subscription is not active", http.StatusUnprocessableEntity)
+			default:
+				return handlers.WrapError(err, "failed to relink order subscription", http.StatusInternalServerError)
+			}
 		}
 
 		return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -61,6 +61,8 @@ const (
 
 	ErrOrderNotOneOffPayment = Error("model: order is not perpetual license")
 
+	ErrStripeSubscriptionNotActive Error = "model: stripe subscription is not active"
+
 	errInvalidNumConversion Error = "model: invalid numeric conversion"
 )
 
@@ -862,6 +864,10 @@ type VerifyCredentialOpaque struct {
 type SetTrialDaysRequest struct {
 	Email     string `json:"email"` // TODO: Make it required.
 	TrialDays int64  `json:"trialDays"`
+}
+
+type RelinkSubscriptionRequest struct {
+	SubscriptionID string `json:"subscriptionId" valid:"required"`
 }
 
 func addURLParam(src, name, val string) (string, error) {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -911,6 +911,40 @@ func (s *Service) setOrderTrialDaysTx(ctx context.Context, dbi sqlx.ExtContext, 
 	return err
 }
 
+// relinkOrderSubscription points an order at a new active Stripe subscription and
+// renews it. This fixes users whose order still references an old canceled subscription
+// after they cancel and resubscribe, leaving them unable to load new credentials.
+func (s *Service) relinkOrderSubscription(ctx context.Context, orderID uuid.UUID, subID string) error {
+	sub, err := s.stripeCl.Subscription(ctx, subID, nil)
+	if err != nil {
+		return fmt.Errorf("failed to fetch stripe subscription: %w", err)
+	}
+
+	if sub.Status != stripe.SubscriptionStatusActive && sub.Status != stripe.SubscriptionStatusTrialing {
+		return model.ErrStripeSubscriptionNotActive
+	}
+
+	expt := time.Unix(sub.CurrentPeriodEnd, 0).UTC()
+	paidt := time.Unix(sub.CurrentPeriodStart, 0).UTC()
+
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	ord, err := s.orderRepo.Get(ctx, tx, orderID)
+	if err != nil {
+		return err
+	}
+
+	if err := s.renewOrderStripe(ctx, tx, ord, subID, expt, paidt); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 // UpdateOrderStatus checks to see if an order has been paid and updates it if so
 func (s *Service) UpdateOrderStatus(orderID uuid.UUID) error {
 	// get the order

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -40,9 +40,32 @@ before making any changes.`,
 	RunE: runResetLinkingLimit,
 }
 
+var relinkSubscriptionCmd = &cobra.Command{
+	Use:   "relink-subscription",
+	Short: "Relink a Premium order to a new active Stripe subscription",
+	Long: `Points a Premium order at a new Stripe subscription and renews it.
+
+Use this when a user has canceled and resubscribed but their account still
+references the old canceled subscription, preventing new credentials from loading.`,
+	RunE: runRelinkSubscription,
+}
+
 func init() {
 	SkusCmd.AddCommand(resetLinkingLimitCmd)
+	SkusCmd.AddCommand(relinkSubscriptionCmd)
 	rootcmd.RootCmd.AddCommand(SkusCmd)
+
+	{
+		rl := relinkSubscriptionCmd.Flags()
+		rl.String("skus-base-url", "", "base URL of the SKUs service (e.g. https://payment.rewards.brave.com)")
+		rl.String("order-id", "", "the order UUID to relink")
+		rl.String("subscription-id", "", "the new active Stripe subscription ID (e.g. sub_...)")
+		rl.String("private-key", "", "path to the ed25519 private key file in SSH format used to sign requests")
+		rootcmd.Must(relinkSubscriptionCmd.MarkFlagRequired("skus-base-url"))
+		rootcmd.Must(relinkSubscriptionCmd.MarkFlagRequired("order-id"))
+		rootcmd.Must(relinkSubscriptionCmd.MarkFlagRequired("subscription-id"))
+		rootcmd.Must(relinkSubscriptionCmd.MarkFlagRequired("private-key"))
+	}
 
 	fb := rootcmd.NewFlagBuilder(resetLinkingLimitCmd)
 
@@ -228,6 +251,64 @@ func loadED25519PrivateKey(path string) (ed25519.PrivateKey, error) {
 	}
 
 	return *key, nil
+}
+
+func runRelinkSubscription(cmd *cobra.Command, args []string) error {
+	baseURL, _ := cmd.Flags().GetString("skus-base-url")
+	baseURL = strings.TrimRight(baseURL, "/")
+	orderID, _ := cmd.Flags().GetString("order-id")
+	subID, _ := cmd.Flags().GetString("subscription-id")
+	privKeyPath, _ := cmd.Flags().GetString("private-key")
+
+	privKey, err := loadED25519PrivateKey(privKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %w", err)
+	}
+
+	if !confirm(fmt.Sprintf("Relink order %s to subscription %s?", orderID, subID)) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	ctx := cmd.Context()
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	endpoint := fmt.Sprintf("%s/v1/orders/%s/subscription", baseURL, orderID)
+
+	payload := struct {
+		SubscriptionID string `json:"subscriptionId"`
+	}{SubscriptionID: subID}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := skus.SignSupportRequest(privKey, req); err != nil {
+		return fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, respBody)
+	}
+
+	fmt.Printf("Done. Order %s relinked to subscription %s.\n", orderID, subID)
+
+	return nil
 }
 
 func confirm(prompt string) bool {


### PR DESCRIPTION
Adds `bat-go skus relink-subscription` CLI command and a new support-authenticated endpoint PATCH /v1/orders/{orderID}/subscription.

When a user cancels and resubscribes via Stripe but the order still points to the old canceled subscription (blocking credential loads), this tool points the order at the new active subscription and renews it — atomically updating the sub ID, paid status, expiresAt, and lastPaidAt in one transaction.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
