### PR TITLE
feat: add set-linking-limit support endpoint and CLI command

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -125,6 +125,7 @@ func Router(
 		cr.Method(http.MethodGet, "/batches/count", metricsMwr("CountBatches", authMwr(handlers.AppHandler(credh.CountBatches))))
 		cr.Method(http.MethodGet, "/batches", metricsMwr("ListActiveBatches", supportMwr(handlers.AppHandler(credh.ListActiveBatches))))
 		cr.Method(http.MethodDelete, "/batches", metricsMwr("DeleteBatches", supportMwr(handlers.AppHandler(credh.DeleteBatches))))
+		cr.Method(http.MethodPatch, "/batches/limit", metricsMwr("SetLinkingLimit", supportMwr(handlers.AppHandler(credh.SetLinkingLimit))))
 
 		// Handle the old endpoint while the new is being rolled out:
 		// - true: the handler uses itemID as the request id, which is the old mode;

--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -125,7 +125,7 @@ func Router(
 		cr.Method(http.MethodGet, "/batches/count", metricsMwr("CountBatches", authMwr(handlers.AppHandler(credh.CountBatches))))
 		cr.Method(http.MethodGet, "/batches", metricsMwr("ListActiveBatches", supportMwr(handlers.AppHandler(credh.ListActiveBatches))))
 		cr.Method(http.MethodDelete, "/batches", metricsMwr("DeleteBatches", supportMwr(handlers.AppHandler(credh.DeleteBatches))))
-		cr.Method(http.MethodPatch, "/batches/limit", metricsMwr("SetLinkingLimit", supportMwr(handlers.AppHandler(credh.SetLinkingLimit))))
+		cr.Method(http.MethodPatch, "/items/{itemID}/batches/limit", metricsMwr("SetLinkingLimit", supportMwr(handlers.AppHandler(credh.SetLinkingLimit))))
 
 		// Handle the old endpoint while the new is being rolled out:
 		// - true: the handler uses itemID as the request id, which is the old mode;

--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -114,6 +114,7 @@ type orderItemStore interface {
 	Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error)
 	FindByOrderID(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
 	InsertMany(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
+	SetMaxActiveBatches(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, max int) error
 }
 
 type orderPayHistoryStore interface {

--- a/services/skus/handler/cred.go
+++ b/services/skus/handler/cred.go
@@ -19,6 +19,7 @@ type tlv2Svc interface {
 	UniqBatches(ctx context.Context, orderID, itemID uuid.UUID) (int, int, error)
 	ListActiveBatches(ctx context.Context, orderID, itemID uuid.UUID) ([]model.TLV2ActiveBatch, error)
 	DeleteBatches(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
+	SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, max int) error
 }
 
 type Cred struct {
@@ -181,6 +182,68 @@ func (h *Cred) DeleteBatches(w http.ResponseWriter, r *http.Request) *handlers.A
 
 		default:
 			lg.Error().Err(err).Msg("failed to delete batches")
+			return handlers.WrapError(model.ErrSomethingWentWrong, "something went wrong", http.StatusInternalServerError)
+		}
+	}
+
+	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+}
+
+// SetLinkingLimit updates the maximum number of active TLV2 credential batches (linked devices)
+// for an order. An optional item_id in the request body scopes the change to a specific item.
+//
+// PATCH /v1/orders/{orderID}/credentials/batches/limit
+func (h *Cred) SetLinkingLimit(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, reqBodyLimit10MB))
+	if err != nil {
+		return handlers.WrapError(err, "failed to read request body", http.StatusBadRequest)
+	}
+
+	var req model.SetLinkingLimitReq
+	if err := json.Unmarshal(body, &req); err != nil {
+		return handlers.WrapError(err, "failed to parse request body", http.StatusBadRequest)
+	}
+
+	if req.Max <= 0 {
+		return handlers.ValidationError("request", map[string]interface{}{"max": "must be a positive integer"})
+	}
+
+	itemID := uuid.Nil
+	if req.ItemID != "" {
+		itemID, err = uuid.FromString(req.ItemID)
+		if err != nil {
+			return handlers.ValidationError("request", map[string]interface{}{"item_id": err.Error()})
+		}
+	}
+
+	if err := h.tlv2.SetLinkingLimit(ctx, orderID, itemID, req.Max); err != nil {
+		lg := logging.Logger(ctx, "skus").With().Str("func", "SetLinkingLimit").Logger()
+
+		switch {
+		case errors.Is(err, context.Canceled):
+			return handlers.WrapError(err, "client ended request", model.StatusClientClosedConn)
+
+		case errors.Is(err, context.DeadlineExceeded):
+			return handlers.WrapError(err, "request timed out", http.StatusGatewayTimeout)
+
+		case errors.Is(err, model.ErrOrderNotFound), errors.Is(err, model.ErrInvalidOrderNoItems), errors.Is(err, model.ErrOrderItemNotFound):
+			return handlers.WrapError(err, "order not found", http.StatusNotFound)
+
+		case errors.Is(err, model.ErrOrderNotPaid):
+			return handlers.WrapError(err, "order not paid", http.StatusPaymentRequired)
+
+		case errors.Is(err, model.ErrUnsupportedCredType):
+			return handlers.WrapError(err, "credential type not supported", http.StatusBadRequest)
+
+		default:
+			lg.Error().Err(err).Msg("failed to set linking limit")
 			return handlers.WrapError(model.ErrSomethingWentWrong, "something went wrong", http.StatusInternalServerError)
 		}
 	}

--- a/services/skus/handler/cred.go
+++ b/services/skus/handler/cred.go
@@ -190,15 +190,20 @@ func (h *Cred) DeleteBatches(w http.ResponseWriter, r *http.Request) *handlers.A
 }
 
 // SetLinkingLimit updates the maximum number of active TLV2 credential batches (linked devices)
-// for an order. An optional item_id in the request body scopes the change to a specific item.
+// for a specific order item.
 //
-// PATCH /v1/orders/{orderID}/credentials/batches/limit
+// PATCH /v1/orders/{orderID}/credentials/items/{itemID}/batches/limit
 func (h *Cred) SetLinkingLimit(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	ctx := r.Context()
 
 	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
 	if err != nil {
 		return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+	}
+
+	itemID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "itemID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"itemID": err.Error()})
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, reqBodyLimit10MB))
@@ -211,19 +216,11 @@ func (h *Cred) SetLinkingLimit(w http.ResponseWriter, r *http.Request) *handlers
 		return handlers.WrapError(err, "failed to parse request body", http.StatusBadRequest)
 	}
 
-	if req.Max <= 0 {
-		return handlers.ValidationError("request", map[string]interface{}{"max": "must be a positive integer"})
+	if req.MaxActiveBatchesTLV2Creds <= 0 {
+		return handlers.ValidationError("request", map[string]interface{}{"max_active_batches_tlv2_creds": "must be a positive integer"})
 	}
 
-	itemID := uuid.Nil
-	if req.ItemID != "" {
-		itemID, err = uuid.FromString(req.ItemID)
-		if err != nil {
-			return handlers.ValidationError("request", map[string]interface{}{"item_id": err.Error()})
-		}
-	}
-
-	if err := h.tlv2.SetLinkingLimit(ctx, orderID, itemID, req.Max); err != nil {
+	if err := h.tlv2.SetLinkingLimit(ctx, orderID, itemID, req.MaxActiveBatchesTLV2Creds); err != nil {
 		lg := logging.Logger(ctx, "skus").With().Str("func", "SetLinkingLimit").Logger()
 
 		switch {

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -742,3 +742,254 @@ func TestCred_DeleteBatches(t *testing.T) {
 		})
 	}
 }
+
+func TestCred_SetLinkingLimit(t *testing.T) {
+	orderCtx := func(orderID string) context.Context {
+		return context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+			URLParams: chi.RouteParams{
+				Keys:   []string{"orderID"},
+				Values: []string{orderID},
+			},
+		})
+	}
+
+	type tcGiven struct {
+		ctx  context.Context
+		body string
+		svc  *mockTLV2Svc
+	}
+
+	type tcExpected struct {
+		err *handlers.AppError
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invalid_orderID",
+			given: tcGiven{
+				ctx:  orderCtx("not-a-uuid"),
+				body: `{"max":15}`,
+				svc:  &mockTLV2Svc{},
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError("request", map[string]interface{}{"orderID": "uuid: incorrect UUID length: not-a-uuid"}),
+			},
+		},
+
+		{
+			name: "invalid_json_body",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{not json}`,
+				svc:  &mockTLV2Svc{},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(
+					json.NewDecoder(strings.NewReader(`{not json}`)).Decode(&struct{}{}),
+					"failed to parse request body",
+					http.StatusBadRequest,
+				),
+			},
+		},
+
+		{
+			name: "max_zero",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":0}`,
+				svc:  &mockTLV2Svc{},
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError("request", map[string]interface{}{"max": "must be a positive integer"}),
+			},
+		},
+
+		{
+			name: "invalid_item_id",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15,"item_id":"not-a-uuid"}`,
+				svc:  &mockTLV2Svc{},
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError("request", map[string]interface{}{"item_id": "uuid: incorrect UUID length: not-a-uuid"}),
+			},
+		},
+
+		{
+			name: "context_cancelled",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return context.Canceled
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(context.Canceled, "client ended request", model.StatusClientClosedConn),
+			},
+		},
+
+		{
+			name: "deadline_exceeded",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return context.DeadlineExceeded
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(context.DeadlineExceeded, "request timed out", http.StatusGatewayTimeout),
+			},
+		},
+
+		{
+			name: "order_not_found",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.ErrOrderNotFound
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrOrderNotFound, "order not found", http.StatusNotFound),
+			},
+		},
+
+		{
+			name: "order_not_found_no_items",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.ErrInvalidOrderNoItems
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrInvalidOrderNoItems, "order not found", http.StatusNotFound),
+			},
+		},
+
+		{
+			name: "order_item_not_found",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15,"item_id":"ad0be000-0000-4000-a000-000000000000"}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.ErrOrderItemNotFound
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrOrderItemNotFound, "order not found", http.StatusNotFound),
+			},
+		},
+
+		{
+			name: "order_not_paid",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.ErrOrderNotPaid
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrOrderNotPaid, "order not paid", http.StatusPaymentRequired),
+			},
+		},
+
+		{
+			name: "cred_type_not_supported",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.ErrUnsupportedCredType
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrUnsupportedCredType, "credential type not supported", http.StatusBadRequest),
+			},
+		},
+
+		{
+			name: "internal_error",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						return model.Error("unexpected")
+					},
+				},
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrSomethingWentWrong, "something went wrong", http.StatusInternalServerError),
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				body: `{"max":15,"item_id":"ad0be000-0000-4000-a000-000000000000"}`,
+				svc: &mockTLV2Svc{
+					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+						should.Equal(t, 15, max)
+						should.Equal(t, "ad0be000-0000-4000-a000-000000000000", itemID.String())
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			h := handler.NewCred(tc.given.svc)
+
+			req := httptest.NewRequest(http.MethodPatch, "http://localhost", strings.NewReader(tc.given.body))
+			req = req.WithContext(tc.given.ctx)
+
+			rw := httptest.NewRecorder()
+			rw.Header().Set("content-type", "application/json")
+
+			appErr := h.SetLinkingLimit(rw, req)
+			must.Equal(t, tc.exp.err, appErr)
+
+			if tc.exp.err != nil {
+				appErr.ServeHTTP(rw, req)
+				exp, err := json.Marshal(tc.exp.err)
+				must.Equal(t, nil, err)
+				should.Equal(t, exp, bytes.TrimSpace(rw.Body.Bytes()))
+				return
+			}
+
+			should.Equal(t, http.StatusOK, rw.Code)
+		})
+	}
+}

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -24,6 +24,7 @@ type mockTLV2Svc struct {
 	FnUniqBatches       func(ctx context.Context, orderID, itemID uuid.UUID) (int, int, error)
 	FnListActiveBatches func(ctx context.Context, orderID, itemID uuid.UUID) ([]model.TLV2ActiveBatch, error)
 	FnDeleteBatches     func(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
+	FnSetLinkingLimit   func(ctx context.Context, orderID, itemID uuid.UUID, max int) error
 }
 
 func (s *mockTLV2Svc) UniqBatches(ctx context.Context, orderID, itemID uuid.UUID) (int, int, error) {
@@ -48,6 +49,14 @@ func (s *mockTLV2Svc) DeleteBatches(ctx context.Context, orderID, itemID uuid.UU
 	}
 
 	return s.FnDeleteBatches(ctx, orderID, itemID, seats)
+}
+
+func (s *mockTLV2Svc) SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+	if s.FnSetLinkingLimit == nil {
+		return nil
+	}
+
+	return s.FnSetLinkingLimit(ctx, orderID, itemID, max)
 }
 
 func TestCred_CountBatches(t *testing.T) {

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -744,14 +744,19 @@ func TestCred_DeleteBatches(t *testing.T) {
 }
 
 func TestCred_SetLinkingLimit(t *testing.T) {
-	orderCtx := func(orderID string) context.Context {
+	orderItemCtx := func(orderID, itemID string) context.Context {
 		return context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
 			URLParams: chi.RouteParams{
-				Keys:   []string{"orderID"},
-				Values: []string{orderID},
+				Keys:   []string{"orderID", "itemID"},
+				Values: []string{orderID, itemID},
 			},
 		})
 	}
+
+	const (
+		validOrderID = "c0c0a000-0000-4000-a000-000000000000"
+		validItemID  = "ad0be000-0000-4000-a000-000000000000"
+	)
 
 	type tcGiven struct {
 		ctx  context.Context
@@ -773,8 +778,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "invalid_orderID",
 			given: tcGiven{
-				ctx:  orderCtx("not-a-uuid"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx("not-a-uuid", validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc:  &mockTLV2Svc{},
 			},
 			exp: tcExpected{
@@ -783,9 +788,21 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		},
 
 		{
+			name: "invalid_itemID",
+			given: tcGiven{
+				ctx:  orderItemCtx(validOrderID, "not-a-uuid"),
+				body: `{"max_active_batches_tlv2_creds":15}`,
+				svc:  &mockTLV2Svc{},
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError("request", map[string]interface{}{"itemID": "uuid: incorrect UUID length: not-a-uuid"}),
+			},
+		},
+
+		{
 			name: "invalid_json_body",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
+				ctx:  orderItemCtx(validOrderID, validItemID),
 				body: `{not json}`,
 				svc:  &mockTLV2Svc{},
 			},
@@ -801,32 +818,20 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "max_zero",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":0}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":0}`,
 				svc:  &mockTLV2Svc{},
 			},
 			exp: tcExpected{
-				err: handlers.ValidationError("request", map[string]interface{}{"max": "must be a positive integer"}),
-			},
-		},
-
-		{
-			name: "invalid_item_id",
-			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15,"item_id":"not-a-uuid"}`,
-				svc:  &mockTLV2Svc{},
-			},
-			exp: tcExpected{
-				err: handlers.ValidationError("request", map[string]interface{}{"item_id": "uuid: incorrect UUID length: not-a-uuid"}),
+				err: handlers.ValidationError("request", map[string]interface{}{"max_active_batches_tlv2_creds": "must be a positive integer"}),
 			},
 		},
 
 		{
 			name: "context_cancelled",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return context.Canceled
@@ -841,8 +846,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "deadline_exceeded",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return context.DeadlineExceeded
@@ -857,8 +862,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "order_not_found",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.ErrOrderNotFound
@@ -873,8 +878,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "order_not_found_no_items",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.ErrInvalidOrderNoItems
@@ -889,8 +894,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "order_item_not_found",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15,"item_id":"ad0be000-0000-4000-a000-000000000000"}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.ErrOrderItemNotFound
@@ -905,8 +910,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "order_not_paid",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.ErrOrderNotPaid
@@ -921,8 +926,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "cred_type_not_supported",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.ErrUnsupportedCredType
@@ -937,8 +942,8 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "internal_error",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						return model.Error("unexpected")
@@ -953,12 +958,12 @@ func TestCred_SetLinkingLimit(t *testing.T) {
 		{
 			name: "success",
 			given: tcGiven{
-				ctx:  orderCtx("c0c0a000-0000-4000-a000-000000000000"),
-				body: `{"max":15,"item_id":"ad0be000-0000-4000-a000-000000000000"}`,
+				ctx:  orderItemCtx(validOrderID, validItemID),
+				body: `{"max_active_batches_tlv2_creds":15}`,
 				svc: &mockTLV2Svc{
 					FnSetLinkingLimit: func(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
 						should.Equal(t, 15, max)
-						should.Equal(t, "ad0be000-0000-4000-a000-000000000000", itemID.String())
+						should.Equal(t, validItemID, itemID.String())
 						return nil
 					},
 				},

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -782,7 +782,7 @@ type DeleteBatchesReq struct {
 // SetLinkingLimitReq is the request body for the set linking limit endpoint.
 type SetLinkingLimitReq struct {
 	Max    int    `json:"max"`
-	ItemID string `json:"item_id,omitempty"`
+	ItemID string `json:"item_id"`
 }
 
 // ReceiptRequest represents a receipt submitted by a mobile or web client.

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -781,8 +781,7 @@ type DeleteBatchesReq struct {
 
 // SetLinkingLimitReq is the request body for the set linking limit endpoint.
 type SetLinkingLimitReq struct {
-	Max    int    `json:"max"`
-	ItemID string `json:"item_id"`
+	MaxActiveBatchesTLV2Creds int `json:"max_active_batches_tlv2_creds"`
 }
 
 // ReceiptRequest represents a receipt submitted by a mobile or web client.

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -779,6 +779,12 @@ type DeleteBatchesReq struct {
 	ItemID string `json:"item_id"`
 }
 
+// SetLinkingLimitReq is the request body for the set linking limit endpoint.
+type SetLinkingLimitReq struct {
+	Max    int    `json:"max"`
+	ItemID string `json:"item_id,omitempty"`
+}
+
 // ReceiptRequest represents a receipt submitted by a mobile or web client.
 type ReceiptRequest struct {
 	Type           Vendor `json:"type" validate:"required,oneof=ios android"`

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1374,6 +1374,48 @@ func (s *Service) deleteBatchesTx(ctx context.Context, dbi sqlx.ExecerContext, o
 	return s.tlv2Repo.DeleteOutboxByRequestIDs(ctx, dbi, orderID, requestIDs)
 }
 
+// SetLinkingLimit sets the maximum number of active TLV2 credential batches (linked devices)
+// allowed for an order item. When itemID is uuid.Nil, the first item in the order is used.
+func (s *Service) SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, max int) error {
+	ord, err := s.getOrderFullTx(ctx, s.Datastore.RawDB(), orderID)
+	if err != nil {
+		return err
+	}
+
+	if !ord.IsPaid() {
+		return model.ErrOrderNotPaid
+	}
+
+	if len(ord.Items) == 0 {
+		return model.ErrInvalidOrderNoItems
+	}
+
+	item := &ord.Items[0]
+	if !uuid.Equal(itemID, uuid.Nil) {
+		var ok bool
+		item, ok = ord.HasItem(itemID)
+		if !ok {
+			return model.ErrOrderItemNotFound
+		}
+	}
+
+	if !item.IsCredTLV2() {
+		return model.ErrUnsupportedCredType
+	}
+
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer s.Datastore.RollbackTx(tx)
+
+	if err := s.orderItemRepo.SetMaxActiveBatches(ctx, tx, item.ID, max); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
 // isValidBatchReq validates that the order contains TLV2 credentials. When itemID is
 // non-nil it checks that the specific item exists and is TLV2; otherwise it requires
 // at least one TLV2 item in the order.

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1403,17 +1403,7 @@ func (s *Service) SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID
 		return model.ErrUnsupportedCredType
 	}
 
-	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer s.Datastore.RollbackTx(tx)
-
-	if err := s.orderItemRepo.SetMaxActiveBatches(ctx, tx, item.ID, max); err != nil {
-		return err
-	}
-
-	return tx.Commit()
+	return s.orderItemRepo.SetMaxActiveBatches(ctx, s.Datastore.RawDB(), item.ID, max)
 }
 
 // isValidBatchReq validates that the order contains TLV2 credentials. When itemID is

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -152,9 +152,10 @@ func (r *MockOrder) IncrementNumPayFailed(ctx context.Context, dbi sqlx.ExecerCo
 }
 
 type MockOrderItem struct {
-	FnGet           func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error)
-	FnFindByOrderID func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
-	FnInsertMany    func(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
+	FnGet                  func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error)
+	FnFindByOrderID        func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
+	FnInsertMany           func(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
+	FnSetMaxActiveBatches  func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, max int) error
 }
 
 func (r *MockOrderItem) Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error) {
@@ -179,6 +180,14 @@ func (r *MockOrderItem) InsertMany(ctx context.Context, dbi sqlx.ExtContext, ite
 	}
 
 	return r.FnInsertMany(ctx, dbi, items...)
+}
+
+func (r *MockOrderItem) SetMaxActiveBatches(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, max int) error {
+	if r.FnSetMaxActiveBatches == nil {
+		return nil
+	}
+
+	return r.FnSetMaxActiveBatches(ctx, dbi, id, max)
 }
 
 type MockIssuer struct {

--- a/services/skus/storage/repository/order_item.go
+++ b/services/skus/storage/repository/order_item.go
@@ -53,6 +53,17 @@ func (r *OrderItem) FindByOrderID(ctx context.Context, dbi sqlx.QueryerContext, 
 	return result, nil
 }
 
+// SetMaxActiveBatches updates the max_active_batches_tlv2_creds column for the given order item.
+func (r *OrderItem) SetMaxActiveBatches(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, max int) error {
+	const q = `UPDATE order_items SET max_active_batches_tlv2_creds = $2 WHERE id = $1`
+
+	if _, err := dbi.ExecContext(ctx, q, id, max); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // InsertMany inserts given items and returns the result.
 func (r *OrderItem) InsertMany(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error) {
 	if len(items) == 0 {

--- a/services/skus/storage/repository/order_item.go
+++ b/services/skus/storage/repository/order_item.go
@@ -57,8 +57,18 @@ func (r *OrderItem) FindByOrderID(ctx context.Context, dbi sqlx.QueryerContext, 
 func (r *OrderItem) SetMaxActiveBatches(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, max int) error {
 	const q = `UPDATE order_items SET max_active_batches_tlv2_creds = $2 WHERE id = $1`
 
-	if _, err := dbi.ExecContext(ctx, q, id, max); err != nil {
+	result, err := dbi.ExecContext(ctx, q, id, max)
+	if err != nil {
 		return err
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if n == 0 {
+		return model.ErrOrderItemNotFound
 	}
 
 	return nil

--- a/tools/skus/cmd/README.md
+++ b/tools/skus/cmd/README.md
@@ -113,3 +113,98 @@ The subscriptions service URL and support token are environment-specific — con
 **"No active device batches found for this order"** — the order has no linked devices to clear. The user's limit issue may have a different cause.
 
 **Unexpected status 401** — your private key is not in the authorized keystore for this environment, or your system clock is off by more than 10 minutes (requests are signed with a timestamp).
+
+---
+
+## set-linking-limit
+
+Raises the maximum number of devices that can be simultaneously linked to a premium order. The default limit is 10. Use this when a user has a legitimate need to exceed that limit.
+
+This command only works for **desktop/browser Leo Premium orders** (TLV2 credential type). It cannot be used for iOS or Android orders — those use anonymous receipt-based credentials and do not have a device linking limit.
+
+### Prerequisites
+
+Same as `reset-linking-limit`: `bat-go` binary, an ed25519 private key, and (when using `--email`) the subscriptions service support token.
+
+### Flags
+
+| Flag | Env var | Required | Description |
+|------|---------|----------|-------------|
+| `--skus-base-url` | `SKUS_BASE_URL` | Yes | Base URL of the SKUs/payments service |
+| `--private-key` | `SKUS_SUPPORT_PRIVATE_KEY` | Yes | Path to your ed25519 private key file |
+| `--max` | — | Yes | New maximum number of linked devices (must be a positive integer) |
+| `--order-id` | — | One of these | Order UUID (mutually exclusive with `--email`) |
+| `--email` | `SUBSCRIBER_EMAIL` | One of these | Subscriber email (mutually exclusive with `--order-id`) |
+| `--subscriptions-base-url` | `SUBSCRIPTIONS_BASE_URL` | Yes, with `--email` | Base URL of the subscriptions service |
+| `--subscriptions-token` | `SUBSCRIPTIONS_SUPPORT_TOKEN` | Yes, with `--email` | Bearer token for the support API |
+| `--item-id` | — | No | Scope the change to a specific order item UUID |
+
+Flags take precedence over env vars.
+
+### Usage
+
+#### When you have the order ID
+
+```bash
+bat-go skus set-linking-limit \
+  --skus-base-url https://payment.rewards.brave.com \
+  --order-id <ORDER_UUID> \
+  --max <N> \
+  --private-key /path/to/operator.key
+```
+
+#### When the user provides only their email
+
+```bash
+bat-go skus set-linking-limit \
+  --skus-base-url https://payment.rewards.brave.com \
+  --subscriptions-base-url https://subscriptions.rewards.brave.com \
+  --subscriptions-token <SUPPORT_API_TOKEN> \
+  --email <USER_EMAIL> \
+  --max <N> \
+  --private-key /path/to/operator.key
+```
+
+### Multiple subscriptions (VPN + Leo)
+
+If the email matches more than one active subscription, the command prints a numbered list and prompts for a selection:
+
+```
+Found 2 active subscriptions matching "user@example.com":
+
+  #    order_id                              product               email
+  ---  ------------------------------------  --------------------  ------------------------------
+  1    aaaa-...                              leo-premium           user@example.com
+  2    bbbb-...                              vpn-premium           user@example.com
+
+Select subscription [1-2]:
+```
+
+Select the Leo Premium entry. The linking limit only applies to Leo — selecting the VPN order will fail with "credential type not supported".
+
+### Interactive flow
+
+The command shows the current number of active linked devices and the new limit before making any change:
+
+```
+Order bf399efe-... has 3 active linked device(s).
+New linking limit: 15
+
+Set linking limit to 15 for order bf399efe-...? [y/N]:
+```
+
+Type `y` to confirm. Anything else aborts with no changes made.
+
+### Orders with multiple items
+
+If an order has more than one item and you omit `--item-id`, the command targets the first item. If that item is not a Leo credential (e.g. a bundle containing both Leo and VPN items), the command will fail with "credential type not supported". In that case, obtain the correct item UUID from the order and re-run with `--item-id`.
+
+### Troubleshooting
+
+**"credential type not supported"** — the order is not a desktop Leo Premium order. This command cannot be used for iOS/Android orders. If the user has both Leo and VPN subscriptions, make sure you selected Leo when prompted, and use `--item-id` if the order has multiple items.
+
+**"order not paid"** — the user's subscription has expired or been cancelled. Raising the limit won't help until they renew.
+
+**"no subscriber found for email"** / **"no active subscriptions found for email"** — see the same entries under `reset-linking-limit` above.
+
+**Unexpected status 401** — your private key is not authorized for this environment, or your system clock is skewed by more than 10 minutes.

--- a/tools/skus/cmd/README.md
+++ b/tools/skus/cmd/README.md
@@ -137,7 +137,7 @@ Same as `reset-linking-limit`: `bat-go` binary, an ed25519 private key, and (whe
 | `--email` | `SUBSCRIBER_EMAIL` | One of these | Subscriber email (mutually exclusive with `--order-id`) |
 | `--subscriptions-base-url` | `SUBSCRIPTIONS_BASE_URL` | Yes, with `--email` | Base URL of the subscriptions service |
 | `--subscriptions-token` | `SUBSCRIPTIONS_SUPPORT_TOKEN` | Yes, with `--email` | Bearer token for the support API |
-| `--item-id` | — | No | Scope the change to a specific order item UUID |
+| `--item-id` | — | No | Order item UUID to set the limit for; prompted if omitted |
 
 Flags take precedence over env vars.
 
@@ -149,6 +149,17 @@ Flags take precedence over env vars.
 bat-go skus set-linking-limit \
   --skus-base-url https://payment.rewards.brave.com \
   --order-id <ORDER_UUID> \
+  --max <N> \
+  --private-key /path/to/operator.key
+```
+
+If the order has more than one TLV2 item, you will be prompted to pick one. To skip the prompt, provide `--item-id` directly:
+
+```bash
+bat-go skus set-linking-limit \
+  --skus-base-url https://payment.rewards.brave.com \
+  --order-id <ORDER_UUID> \
+  --item-id <ITEM_UUID> \
   --max <N> \
   --private-key /path/to/operator.key
 ```
@@ -195,13 +206,33 @@ Set linking limit to 15 for order bf399efe-...? [y/N]:
 
 Type `y` to confirm. Anything else aborts with no changes made.
 
-### Orders with multiple items
+### Item selection
 
-If an order has more than one item and you omit `--item-id`, the command targets the first item. If that item is not a Leo credential (e.g. a bundle containing both Leo and VPN items), the command will fail with "credential type not supported". In that case, obtain the correct item UUID from the order and re-run with `--item-id`.
+If `--item-id` is omitted, the command fetches the order's TLV2 items automatically:
+
+- **One item** — selected silently, no prompt:
+  ```
+  Using item ad0be000-... (leo-premium-year) for order bf399efe-...
+  ```
+
+- **Multiple items** — a numbered list is shown and you are asked to choose:
+  ```
+  Found 2 TLV2 items for order bf399efe-...:
+
+    #    item_id                               sku                             current_limit
+    ---  ------------------------------------  ------------------------------  -------------
+    1    ad0be000-...                          leo-premium-year                10
+    2    be0ef000-...                          leo-premium-month               (default)
+
+  Select item [1-2]:
+  ```
+  The `current_limit` column shows the value already set via this command, or `(default)` if it has never been changed.
+
+If you already know the item UUID, pass `--item-id` to skip the selection entirely.
 
 ### Troubleshooting
 
-**"credential type not supported"** — the order is not a desktop Leo Premium order. This command cannot be used for iOS/Android orders. If the user has both Leo and VPN subscriptions, make sure you selected Leo when prompted, and use `--item-id` if the order has multiple items.
+**"credential type not supported"** — the order or item is not a desktop Leo Premium credential. This command cannot be used for iOS/Android orders. If the user has both Leo and VPN subscriptions, make sure you selected Leo when prompted, and verify that `--item-id` points to the Leo item.
 
 **"order not paid"** — the user's subscription has expired or been cancelled. Raising the limit won't help until they renew.
 

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -30,6 +30,25 @@ var SkusCmd = &cobra.Command{
 	Short: "provides skus service support tooling",
 }
 
+var setLinkingLimitCmd = &cobra.Command{
+	Use:   "set-linking-limit",
+	Short: "Set the maximum number of linked devices for a premium order",
+	Long: `Sets the max_active_batches_tlv2_creds limit for a TLV2 order item,
+controlling how many devices can be simultaneously linked to the order.
+
+The order can be identified by --order-id or by --email (which looks up
+the subscriber in the subscriptions service). If multiple orders match an
+email you will be prompted to choose one.
+
+The command shows the current limit and active device count before asking
+for confirmation.
+
+Note: email lookup only works for desktop/browser orders created through
+the subscriptions service. iOS and Android orders use anonymous receipts
+and cannot be looked up by email.`,
+	RunE: runSetLinkingLimit,
+}
+
 var resetLinkingLimitCmd = &cobra.Command{
 	Use:   "reset-linking-limit",
 	Short: "Free device linking slots for a premium order",
@@ -51,7 +70,20 @@ and cannot be looked up by email.`,
 
 func init() {
 	SkusCmd.AddCommand(resetLinkingLimitCmd)
+	SkusCmd.AddCommand(setLinkingLimitCmd)
 	rootcmd.RootCmd.AddCommand(SkusCmd)
+
+	// set-linking-limit flags — use cmd.Flags() directly to avoid viper key collisions
+	// with resetLinkingLimitCmd which shares several flag names.
+	f := setLinkingLimitCmd.Flags()
+	f.String("skus-base-url", "", "base URL of the SKUs service (e.g. https://payment.rewards.brave.com)")
+	f.String("order-id", "", "the order UUID to set the limit for (mutually exclusive with --email)")
+	f.String("email", "", "subscriber email to look up the order ID (mutually exclusive with --order-id)")
+	f.String("subscriptions-base-url", "", "base URL of the subscriptions service, required when using --email")
+	f.String("subscriptions-token", "", "bearer token for the subscriptions support API, required when using --email")
+	f.Int("max", 0, "new maximum number of linked devices (must be a positive integer)")
+	f.String("item-id", "", "optional: scope the change to a specific order item UUID")
+	f.String("private-key", "", "path to the ed25519 private key file in SSH format used to sign requests")
 
 	fb := rootcmd.NewFlagBuilder(resetLinkingLimitCmd)
 
@@ -194,6 +226,86 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
+	baseURL, _ := cmd.Flags().GetString("skus-base-url")
+	baseURL = strings.TrimRight(baseURL, "/")
+	orderID, _ := cmd.Flags().GetString("order-id")
+	emailRaw, _ := cmd.Flags().GetString("email")
+	email := strings.TrimSpace(emailRaw)
+	max, _ := cmd.Flags().GetInt("max")
+	itemID, _ := cmd.Flags().GetString("item-id")
+	privKeyPath, _ := cmd.Flags().GetString("private-key")
+
+	if baseURL == "" {
+		return fmt.Errorf("--skus-base-url is required")
+	}
+
+	if privKeyPath == "" {
+		return fmt.Errorf("--private-key is required")
+	}
+
+	if max <= 0 {
+		return fmt.Errorf("--max must be a positive integer")
+	}
+
+	switch {
+	case orderID == "" && email == "":
+		return fmt.Errorf("one of --order-id or --email is required")
+	case orderID != "" && email != "":
+		return fmt.Errorf("--order-id and --email are mutually exclusive")
+	}
+
+	privKey, err := loadED25519PrivateKey(privKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %w", err)
+	}
+
+	ctx := cmd.Context()
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	if email != "" {
+		subsBaseURL, _ := cmd.Flags().GetString("subscriptions-base-url")
+		subsBaseURL = strings.TrimRight(subsBaseURL, "/")
+		subsToken, _ := cmd.Flags().GetString("subscriptions-token")
+
+		if subsBaseURL == "" {
+			return fmt.Errorf("--subscriptions-base-url is required when using --email")
+		}
+
+		if subsToken == "" {
+			return fmt.Errorf("--subscriptions-token is required when using --email")
+		}
+
+		orderID, err = resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
+		if err != nil {
+			return err
+		}
+	}
+
+	countURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches/count", baseURL, orderID)
+	lim, nact, err := countBatches(ctx, client, countURL, privKey)
+	if err != nil {
+		return fmt.Errorf("failed to fetch current batch count: %w", err)
+	}
+
+	fmt.Printf("Order %s current linking limit: %d (active devices: %d)\n\n", orderID, lim, nact)
+	fmt.Printf("New limit: %d\n\n", max)
+
+	if !confirm(fmt.Sprintf("Set linking limit to %d for order %s?", max, orderID)) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	limitURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches/limit", baseURL, orderID)
+	if err := setLinkingLimitHTTP(ctx, client, limitURL, privKey, max, itemID); err != nil {
+		return fmt.Errorf("failed to set linking limit: %w", err)
+	}
+
+	fmt.Printf("Done. Linking limit set to %d for order %s.\n", max, orderID)
+
+	return nil
+}
+
 type activeSubsResp struct {
 	Email       string `json:"email"`
 	OrderID     string `json:"order_id"`
@@ -275,6 +387,79 @@ func resolveOrderIDByEmail(ctx context.Context, client *http.Client, baseURL, em
 
 		return result.Results[n-1].OrderID, nil
 	}
+}
+
+func countBatches(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey) (lim, active int, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if err := skus.SignSupportRequest(key, req); err != nil {
+		return 0, 0, fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, 0, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+	}
+
+	var result struct {
+		Limit  int `json:"limit"`
+		Active int `json:"active"`
+	}
+
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, 0, err
+	}
+
+	return result.Limit, result.Active, nil
+}
+
+func setLinkingLimitHTTP(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey, max int, itemID string) error {
+	payload := struct {
+		Max    int    `json:"max"`
+		ItemID string `json:"item_id,omitempty"`
+	}{Max: max, ItemID: itemID}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	if err := skus.SignSupportRequest(key, req); err != nil {
+		return fmt.Errorf("failed to sign request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, respBody)
+	}
+
+	return nil
 }
 
 func listBatches(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey) ([]model.TLV2ActiveBatch, error) {

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -302,17 +302,22 @@ func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
-	if itemID != "" {
-		listURL += "?" + url.Values{"item_id": {itemID}}.Encode()
+	if itemID == "" {
+		itemID, err = resolveItemID(ctx, client, baseURL, orderID)
+		if err != nil {
+			return err
+		}
 	}
+
+	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches?%s", baseURL, orderID,
+		url.Values{"item_id": {itemID}}.Encode())
 
 	batches, err := listBatches(ctx, client, listURL, privKey)
 	if err != nil {
 		return fmt.Errorf("failed to fetch active batches: %w", err)
 	}
 
-	fmt.Printf("Order %s has %d active linked device(s).\n", orderID, len(batches))
+	fmt.Printf("Item %s has %d active linked device(s).\n", itemID, len(batches))
 	fmt.Printf("New linking limit: %d\n\n", max)
 
 	if !confirm(fmt.Sprintf("Set linking limit to %d for order %s?", max, orderID)) {
@@ -320,8 +325,8 @@ func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	limitURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches/limit", baseURL, orderID)
-	if err := setLinkingLimitHTTP(ctx, client, limitURL, privKey, max, itemID); err != nil {
+	limitURL := fmt.Sprintf("%s/v1/orders/%s/credentials/items/%s/batches/limit", baseURL, orderID, itemID)
+	if err := setLinkingLimitHTTP(ctx, client, limitURL, privKey, max); err != nil {
 		return fmt.Errorf("failed to set linking limit: %w", err)
 	}
 
@@ -413,11 +418,111 @@ func resolveOrderIDByEmail(ctx context.Context, client *http.Client, baseURL, em
 	}
 }
 
-func setLinkingLimitHTTP(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey, max int, itemID string) error {
+type orderItemEntry struct {
+	ID                        string `json:"id"`
+	SKU                       string `json:"sku"`
+	CredentialType            string `json:"credentialType"`
+	MaxActiveBatchesTLV2Creds *int   `json:"max_active_batches_tlv2_creds"`
+}
+
+type orderEntry struct {
+	Items []orderItemEntry `json:"items"`
+}
+
+func getOrderItems(ctx context.Context, client *http.Client, baseURL, orderID string) ([]orderItemEntry, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v1/orders/"+orderID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("order %q not found", orderID)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+	}
+
+	var result orderEntry
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to decode order: %w", err)
+	}
+
+	return result.Items, nil
+}
+
+func resolveItemID(ctx context.Context, client *http.Client, baseURL, orderID string) (string, error) {
+	items, err := getOrderItems(ctx, client, baseURL, orderID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch order items: %w", err)
+	}
+
+	var tlv2 []orderItemEntry
+	for _, item := range items {
+		if item.CredentialType == "time-limited-v2" {
+			tlv2 = append(tlv2, item)
+		}
+	}
+
+	if len(tlv2) == 0 {
+		return "", fmt.Errorf("no TLV2 credential items found for order %q", orderID)
+	}
+
+	if len(tlv2) == 1 {
+		item := tlv2[0]
+		fmt.Printf("Using item %s (%s) for order %s\n\n", item.ID, item.SKU, orderID)
+		return item.ID, nil
+	}
+
+	fmt.Printf("Found %d TLV2 items for order %s:\n\n", len(tlv2), orderID)
+	fmt.Printf("  %-3s  %-36s  %-30s  %s\n", "#", "item_id", "sku", "current_limit")
+	fmt.Printf("  %-3s  %-36s  %-30s  %s\n",
+		"---", strings.Repeat("-", 36), strings.Repeat("-", 30), strings.Repeat("-", 13))
+
+	for i, item := range tlv2 {
+		limit := "(default)"
+		if item.MaxActiveBatchesTLV2Creds != nil {
+			limit = strconv.Itoa(*item.MaxActiveBatchesTLV2Creds)
+		}
+		fmt.Printf("  %-3d  %-36s  %-30s  %s\n", i+1, item.ID, item.SKU, limit)
+	}
+	fmt.Println()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		fmt.Printf("Select item [1-%d]: ", len(tlv2))
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				return "", fmt.Errorf("reading stdin: %w", err)
+			}
+			return "", fmt.Errorf("no selection made")
+		}
+
+		n, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
+		if err != nil || n < 1 || n > len(tlv2) {
+			fmt.Printf("Please enter a number between 1 and %d.\n", len(tlv2))
+			continue
+		}
+
+		return tlv2[n-1].ID, nil
+	}
+}
+
+func setLinkingLimitHTTP(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey, max int) error {
 	payload := struct {
-		Max    int    `json:"max"`
-		ItemID string `json:"item_id,omitempty"`
-	}{Max: max, ItemID: itemID}
+		Max int `json:"max_active_batches_tlv2_creds"`
+	}{Max: max}
 
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -228,20 +228,33 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 
 func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
 	baseURL, _ := cmd.Flags().GetString("skus-base-url")
+	if baseURL == "" {
+		baseURL = os.Getenv("SKUS_BASE_URL")
+	}
 	baseURL = strings.TrimRight(baseURL, "/")
+
 	orderID, _ := cmd.Flags().GetString("order-id")
+
 	emailRaw, _ := cmd.Flags().GetString("email")
+	if emailRaw == "" {
+		emailRaw = os.Getenv("SUBSCRIBER_EMAIL")
+	}
 	email := strings.TrimSpace(emailRaw)
+
 	max, _ := cmd.Flags().GetInt("max")
 	itemID, _ := cmd.Flags().GetString("item-id")
+
 	privKeyPath, _ := cmd.Flags().GetString("private-key")
+	if privKeyPath == "" {
+		privKeyPath = os.Getenv("SKUS_SUPPORT_PRIVATE_KEY")
+	}
 
 	if baseURL == "" {
-		return fmt.Errorf("--skus-base-url is required")
+		return fmt.Errorf("--skus-base-url (or SKUS_BASE_URL) is required")
 	}
 
 	if privKeyPath == "" {
-		return fmt.Errorf("--private-key is required")
+		return fmt.Errorf("--private-key (or SKUS_SUPPORT_PRIVATE_KEY) is required")
 	}
 
 	if max <= 0 {
@@ -265,15 +278,22 @@ func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
 
 	if email != "" {
 		subsBaseURL, _ := cmd.Flags().GetString("subscriptions-base-url")
+		if subsBaseURL == "" {
+			subsBaseURL = os.Getenv("SUBSCRIPTIONS_BASE_URL")
+		}
 		subsBaseURL = strings.TrimRight(subsBaseURL, "/")
+
 		subsToken, _ := cmd.Flags().GetString("subscriptions-token")
+		if subsToken == "" {
+			subsToken = os.Getenv("SUBSCRIPTIONS_SUPPORT_TOKEN")
+		}
 
 		if subsBaseURL == "" {
-			return fmt.Errorf("--subscriptions-base-url is required when using --email")
+			return fmt.Errorf("--subscriptions-base-url (or SUBSCRIPTIONS_BASE_URL) is required when using --email")
 		}
 
 		if subsToken == "" {
-			return fmt.Errorf("--subscriptions-token is required when using --email")
+			return fmt.Errorf("--subscriptions-token (or SUBSCRIPTIONS_SUPPORT_TOKEN) is required when using --email")
 		}
 
 		orderID, err = resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
@@ -282,14 +302,18 @@ func runSetLinkingLimit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	countURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches/count", baseURL, orderID)
-	lim, nact, err := countBatches(ctx, client, countURL, privKey)
-	if err != nil {
-		return fmt.Errorf("failed to fetch current batch count: %w", err)
+	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
+	if itemID != "" {
+		listURL += "?" + url.Values{"item_id": {itemID}}.Encode()
 	}
 
-	fmt.Printf("Order %s current linking limit: %d (active devices: %d)\n\n", orderID, lim, nact)
-	fmt.Printf("New limit: %d\n\n", max)
+	batches, err := listBatches(ctx, client, listURL, privKey)
+	if err != nil {
+		return fmt.Errorf("failed to fetch active batches: %w", err)
+	}
+
+	fmt.Printf("Order %s has %d active linked device(s).\n", orderID, len(batches))
+	fmt.Printf("New linking limit: %d\n\n", max)
 
 	if !confirm(fmt.Sprintf("Set linking limit to %d for order %s?", max, orderID)) {
 		fmt.Println("Aborted.")
@@ -387,43 +411,6 @@ func resolveOrderIDByEmail(ctx context.Context, client *http.Client, baseURL, em
 
 		return result.Results[n-1].OrderID, nil
 	}
-}
-
-func countBatches(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey) (lim, active int, err error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if err := skus.SignSupportRequest(key, req); err != nil {
-		return 0, 0, fmt.Errorf("failed to sign request: %w", err)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return 0, 0, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if err != nil {
-		return 0, 0, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, 0, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
-	}
-
-	var result struct {
-		Limit  int `json:"limit"`
-		Active int `json:"active"`
-	}
-
-	if err := json.Unmarshal(body, &result); err != nil {
-		return 0, 0, err
-	}
-
-	return result.Limit, result.Active, nil
 }
 
 func setLinkingLimitHTTP(ctx context.Context, client *http.Client, endpoint string, key ed25519.PrivateKey, max int, itemID string) error {


### PR DESCRIPTION
### Summary

Adds a support operator endpoint and CLI command to set the per-order TLV2 credential batch limit (max_active_batches_tlv2_creds), enabling operators to increase the linked device cap for individual orders.

Backend:
- PATCH /v1/orders/{orderID}/credentials/batches/limit (supportMwr)
- SetMaxActiveBatches repo method on order_items
- SetLinkingLimit service method (validates paid + TLV2, runs in tx)
- SetLinkingLimitReq model type

CLI:
- `bat-go skus set-linking-limit` with --order-id or --email lookup, --max, optional --item-id, --private-key, and subscriptions service flags when using email; shows current limit/active count before confirming


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
