### PR TITLE
refactor: add support for apple one off purchase receipt validation

### DIFF
--- a/services/skus/appstore.go
+++ b/services/skus/appstore.go
@@ -353,7 +353,18 @@ func (x *appStoreTransaction) isRevoked(now time.Time) bool {
 	return x.RevocationDate > 0 && now.After(time.UnixMilli(x.RevocationDate))
 }
 
-func newReceiptDataApple(req model.ReceiptRequest, item *wrapAppStoreInApp) model.ReceiptData {
+func newReceiptDataAppleOneOff(req model.ReceiptRequest, iap *appstore.InApp, expt time.Time) model.ReceiptData {
+	result := model.ReceiptData{
+		Type:      req.Type,
+		ProductID: iap.ProductID,
+		ExtID:     iap.OriginalTransactionID,
+		ExpiresAt: expt,
+	}
+
+	return result
+}
+
+func newReceiptDataAppleSub(req model.ReceiptRequest, item *wrapAppStoreInApp) model.ReceiptData {
 	result := model.ReceiptData{
 		Type:      req.Type,
 		ProductID: item.ProductID,

--- a/services/skus/appstore_test.go
+++ b/services/skus/appstore_test.go
@@ -392,7 +392,56 @@ func TestShouldCancelOrderIOS(t *testing.T) {
 	}
 }
 
-func TestNewReceiptDataApple(t *testing.T) {
+func TestNewReceiptDataAppleOneOff(t *testing.T) {
+	type tcGiven struct {
+		req  model.ReceiptRequest
+		iap  *appstore.InApp
+		expt time.Time
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   model.ReceiptData
+	}
+
+	tests := []testCase{
+		{
+			name: "valid",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Type:           model.VendorApple,
+					Blob:           "blob",
+					Package:        "package",
+					SubscriptionID: "one-off",
+				},
+				iap: &appstore.InApp{
+					ProductID:             "one-off",
+					OriginalTransactionID: "720000000000001",
+				},
+				expt: time.Date(2024, time.July, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: model.ReceiptData{
+				Type:      model.VendorApple,
+				ProductID: "one-off",
+				ExtID:     "720000000000001",
+				ExpiresAt: time.Date(2024, time.July, 1, 0, 0, 1, 0, time.UTC),
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := newReceiptDataAppleOneOff(tc.given.req, tc.given.iap, tc.given.expt)
+
+			should.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestNewReceiptDataAppleSub(t *testing.T) {
 	type tcGiven struct {
 		req  model.ReceiptRequest
 		item *wrapAppStoreInApp
@@ -435,7 +484,7 @@ func TestNewReceiptDataApple(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual := newReceiptDataApple(tc.given.req, tc.given.item)
+			actual := newReceiptDataAppleSub(tc.given.req, tc.given.item)
 
 			should.Equal(t, tc.exp, actual)
 		})

--- a/services/skus/receipt.go
+++ b/services/skus/receipt.go
@@ -16,6 +16,7 @@ import (
 const (
 	errNoInAppTx           model.Error = "no in app info in response"
 	errIOSPurchaseNotFound model.Error = "ios: purchase not found"
+	errInvalidPurchaseDate model.Error = "ios: invalid purchase date"
 )
 
 type appStoreVerifier interface {
@@ -68,33 +69,55 @@ func (v *receiptVerifier) validateAppleTime(ctx context.Context, req model.Recei
 		return model.ReceiptData{}, fmt.Errorf("failed to verify receipt: %w", err)
 	}
 
-	// ProductID on an InApp object must match the SubscriptionID.
-	//
-	// By doing so we:
-	// - find the purchase that is being verified (i.e. to disambiguate VPN from Leo);
-	// - utilise Apple verification to make sure the client supplied data (SubscriptionID) is valid and to be trusted.
-	item, ok := findInAppBySubIDIAP(resp, req.SubscriptionID, now)
-	if ok {
-		return newReceiptDataApple(req, item), nil
+	svnt, err := skuVntByMobileName(req.SubscriptionID)
+	if err != nil {
+		return model.ReceiptData{}, err
 	}
 
-	// Special case for VPN.
-	// The client may send bravevpn.monthly as subscription_id for bravevpn.yearly product.
-	if req.SubscriptionID == "bravevpn.monthly" {
-		item, ok := findInAppBySubIDIAP(resp, "bravevpn.yearly", now)
-		if ok {
-			return newReceiptDataApple(req, item), nil
+	switch svnt {
+	case "brave-origin-premium-perpetual-license":
+		iap, ok := findInAppBySubIDIAPOneOff(resp, req.SubscriptionID)
+		if !ok {
+			return model.ReceiptData{}, errIOSPurchaseNotFound
 		}
-	}
 
-	// Handle legacy iOS versions predating the release that started using proper values for subscription_id.
-	// This only applies to VPN.
-	item, ok = findInAppBySubIDLegacy(resp, req.SubscriptionID, now)
-	if !ok {
-		return model.ReceiptData{}, errIOSPurchaseNotFound
-	}
+		if iap.PurchaseDate.PurchaseDateMS == "" {
+			return model.ReceiptData{}, errInvalidPurchaseDate
+		}
 
-	return newReceiptDataApple(req, item), nil
+		expt := now.AddDate(100, 0, 0)
+
+		return newReceiptDataAppleOneOff(req, iap, expt), nil
+
+	default:
+		// ProductID on an InApp object must match the SubscriptionID.
+		//
+		// By doing so we:
+		// - find the purchase that is being verified (i.e. to disambiguate VPN from Leo);
+		// - utilise Apple verification to make sure the client supplied data (SubscriptionID) is valid and to be trusted.
+		item, ok := findInAppBySubIDIAPSub(resp, req.SubscriptionID, now)
+		if ok {
+			return newReceiptDataAppleSub(req, item), nil
+		}
+
+		// Special case for VPN.
+		// The client may send bravevpn.monthly as subscription_id for bravevpn.yearly product.
+		if req.SubscriptionID == "bravevpn.monthly" {
+			item, ok := findInAppBySubIDIAPSub(resp, "bravevpn.yearly", now)
+			if ok {
+				return newReceiptDataAppleSub(req, item), nil
+			}
+		}
+
+		// Handle legacy iOS versions predating the release that started using proper values for subscription_id.
+		// This only applies to VPN.
+		item, ok = findInAppBySubIDVPNLegacy(resp, req.SubscriptionID, now)
+		if !ok {
+			return model.ReceiptData{}, errIOSPurchaseNotFound
+		}
+
+		return newReceiptDataAppleSub(req, item), nil
+	}
 }
 
 // validateGoogle validates a Play Store receipt.
@@ -145,16 +168,35 @@ func (v *receiptVerifier) fetchSubPlayStore(ctx context.Context, pkgName, subID,
 	return (*playStoreSubPurchase)(sub), nil
 }
 
-func findInAppBySubIDIAP(iap *appstore.IAPResponse, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
-	result, ok := findInAppBySubID(iap.LatestReceiptInfo, subID, now)
+func findInAppBySubIDIAPOneOff(iap *appstore.IAPResponse, subID string) (*appstore.InApp, bool) {
+	result, ok := findInAppBySubIDOneOff(iap.LatestReceiptInfo, subID)
 	if ok {
 		return result, true
 	}
 
-	return findInAppBySubID(iap.Receipt.InApp, subID, now)
+	return findInAppBySubIDOneOff(iap.Receipt.InApp, subID)
 }
 
-func findInAppBySubID(iap []appstore.InApp, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
+func findInAppBySubIDOneOff(iap []appstore.InApp, subID string) (*appstore.InApp, bool) {
+	for i := range iap {
+		if iap[i].ProductID == subID {
+			return &iap[i], true
+		}
+	}
+
+	return nil, false
+}
+
+func findInAppBySubIDIAPSub(iap *appstore.IAPResponse, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
+	result, ok := findInAppBySubIDSub(iap.LatestReceiptInfo, subID, now)
+	if ok {
+		return result, true
+	}
+
+	return findInAppBySubIDSub(iap.Receipt.InApp, subID, now)
+}
+
+func findInAppBySubIDSub(iap []appstore.InApp, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
 	for i := range iap {
 		if iap[i].ProductID == subID {
 			item := newWrapAppStoreInApp(&iap[i])
@@ -168,7 +210,7 @@ func findInAppBySubID(iap []appstore.InApp, subID string, now time.Time) (*wrapA
 	return nil, false
 }
 
-func findInAppBySubIDLegacy(resp *appstore.IAPResponse, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
+func findInAppBySubIDVPNLegacy(resp *appstore.IAPResponse, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
 	item, ok := findInAppVPNLegacy(resp.LatestReceiptInfo, subID, now)
 	if ok {
 		return item, true
@@ -180,17 +222,17 @@ func findInAppBySubIDLegacy(resp *appstore.IAPResponse, subID string, now time.T
 func findInAppVPNLegacy(iap []appstore.InApp, subID string, now time.Time) (*wrapAppStoreInApp, bool) {
 	switch subID {
 	case "brave-firewall-vpn-premium":
-		item, ok := findInAppBySubID(iap, "bravevpn.monthly", now)
+		item, ok := findInAppBySubIDSub(iap, "bravevpn.monthly", now)
 		if ok {
 			return item, true
 		}
 
 		// Quick fix for linking coming from iOS v1.61.1 and below.
 		// The old clients might send brave-firewall-vpn-premium for bravevpn.yearly.
-		return findInAppBySubID(iap, "bravevpn.yearly", now)
+		return findInAppBySubIDSub(iap, "bravevpn.yearly", now)
 
 	case "brave-firewall-vpn-premium-year":
-		return findInAppBySubID(iap, "bravevpn.yearly", now)
+		return findInAppBySubIDSub(iap, "bravevpn.yearly", now)
 	default:
 		return nil, false
 	}

--- a/services/skus/receipt_test.go
+++ b/services/skus/receipt_test.go
@@ -800,6 +800,163 @@ func TestReceiptVerifier_validateAppleTime(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "ios_one_off_not_found",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Type:           model.VendorApple,
+					Package:        "com.brave.ios.browser",
+					Blob:           "blob",
+					SubscriptionID: "braveorigin.perpetual",
+				},
+
+				cl: &mockASClient{
+					fnVerify: func(ctx context.Context, req appstore.IAPRequest, result interface{}) error {
+						resp, ok := result.(*appstore.IAPResponse)
+						if !ok {
+							return model.Error("invalid response type")
+						}
+
+						resp.Receipt.BundleID = "com.brave.ios.browser"
+						resp.LatestReceiptInfo = []appstore.InApp{}
+
+						return nil
+					},
+				},
+
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{
+				err: errIOSPurchaseNotFound,
+			},
+		},
+
+		{
+			name: "ios_one_off_purchase_date_ms_empty",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Type:           model.VendorApple,
+					Package:        "com.brave.ios.browser",
+					Blob:           "blob",
+					SubscriptionID: "braveorigin.perpetual",
+				},
+
+				cl: &mockASClient{
+					fnVerify: func(ctx context.Context, req appstore.IAPRequest, result interface{}) error {
+						resp, ok := result.(*appstore.IAPResponse)
+						if !ok {
+							return model.Error("invalid response type")
+						}
+
+						resp.Receipt.BundleID = "com.brave.ios.browser"
+
+						resp.LatestReceiptInfo = []appstore.InApp{
+							{
+								ProductID:             "braveorigin.perpetual",
+								OriginalTransactionID: "720000000000002",
+							},
+						}
+
+						return nil
+					},
+				},
+
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{
+				err: errInvalidPurchaseDate,
+			},
+		},
+
+		{
+			name: "ios_one_off_latest_receipt_info",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Type:           model.VendorApple,
+					Package:        "com.brave.ios.browser",
+					Blob:           "blob",
+					SubscriptionID: "braveorigin.perpetual",
+				},
+
+				cl: &mockASClient{
+					fnVerify: func(ctx context.Context, req appstore.IAPRequest, result interface{}) error {
+						resp, ok := result.(*appstore.IAPResponse)
+						if !ok {
+							return model.Error("invalid response type")
+						}
+
+						resp.Receipt.BundleID = "com.brave.ios.browser"
+
+						resp.LatestReceiptInfo = []appstore.InApp{
+							{
+								ProductID:             "braveorigin.perpetual",
+								OriginalTransactionID: "720000000000002",
+								PurchaseDate: appstore.PurchaseDate{
+									PurchaseDateMS: "1111",
+								},
+							},
+						}
+
+						return nil
+					},
+				},
+
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{
+				val: model.ReceiptData{
+					Type:      model.VendorApple,
+					ProductID: "braveorigin.perpetual",
+					ExtID:     "720000000000002",
+					ExpiresAt: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC).AddDate(100, 0, 0),
+				},
+			},
+		},
+
+		{
+			name: "ios_one_off_receipt_inapp",
+			given: tcGiven{
+				req: model.ReceiptRequest{
+					Type:           model.VendorApple,
+					Package:        "com.brave.ios.browser",
+					Blob:           "blob",
+					SubscriptionID: "braveorigin.perpetual",
+				},
+
+				cl: &mockASClient{
+					fnVerify: func(ctx context.Context, req appstore.IAPRequest, result interface{}) error {
+						resp, ok := result.(*appstore.IAPResponse)
+						if !ok {
+							return model.Error("invalid response type")
+						}
+
+						resp.Receipt.BundleID = "com.brave.ios.browser"
+						resp.Receipt.InApp = []appstore.InApp{
+							{
+								ProductID:             "braveorigin.perpetual",
+								OriginalTransactionID: "720000000000001",
+								PurchaseDate: appstore.PurchaseDate{
+									PurchaseDateMS: "1111",
+								},
+							},
+						}
+
+						return nil
+					},
+				},
+
+				now: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC),
+			},
+			exp: tcExpected{
+				val: model.ReceiptData{
+					Type:      model.VendorApple,
+					ProductID: "braveorigin.perpetual",
+					ExtID:     "720000000000001",
+					ExpiresAt: time.Date(2024, time.January, 1, 0, 0, 1, 0, time.UTC).AddDate(100, 0, 0),
+				},
+			},
+		},
 	}
 
 	for i := range tests {
@@ -816,7 +973,213 @@ func TestReceiptVerifier_validateAppleTime(t *testing.T) {
 	}
 }
 
-func TestFindInAppBySubIDIAP(t *testing.T) {
+func TestFindInAppBySubIDIAPOneOff(t *testing.T) {
+	type tcGiven struct {
+		resp  *appstore.IAPResponse
+		subID string
+	}
+
+	type tcExpected struct {
+		iap *appstore.InApp
+		ok  bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "empty",
+			given: tcGiven{
+				subID: "one-off",
+				resp:  &appstore.IAPResponse{},
+			},
+		},
+
+		{
+			name: "found_latest_receipt_info",
+			given: tcGiven{
+				resp: &appstore.IAPResponse{
+					LatestReceiptInfo: []appstore.InApp{
+						{
+							ProductID: "one-off",
+						},
+					},
+				},
+				subID: "one-off",
+			},
+			exp: tcExpected{
+				iap: &appstore.InApp{
+					ProductID: "one-off",
+				},
+				ok: true,
+			},
+		},
+
+		{
+			name: "found_receipt",
+			given: tcGiven{
+				resp: &appstore.IAPResponse{
+					Receipt: appstore.Receipt{
+						InApp: []appstore.InApp{
+							{
+								ProductID: "one-off",
+							},
+						},
+					},
+				},
+				subID: "one-off",
+			},
+			exp: tcExpected{
+				iap: &appstore.InApp{
+					ProductID: "one-off",
+				},
+				ok: true,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := findInAppBySubIDIAPOneOff(tc.given.resp, tc.given.subID)
+			must.Equal(t, tc.exp.ok, ok)
+
+			if !tc.exp.ok {
+				return
+			}
+
+			should.Equal(t, tc.exp.iap, actual)
+		})
+	}
+}
+
+func TestFindInAppBySubIDOneOff(t *testing.T) {
+	type tcGiven struct {
+		iap   []appstore.InApp
+		subID string
+	}
+
+	type tcExpected struct {
+		iap *appstore.InApp
+		ok  bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "empty",
+			given: tcGiven{
+				iap:   []appstore.InApp{},
+				subID: "one-off",
+			},
+			exp: tcExpected{},
+		},
+
+		{
+			name: "one_item_not_found_product_id_sub_id_mismatch",
+			given: tcGiven{
+				iap: []appstore.InApp{
+					{
+						ProductID: "one-off",
+						ExpiresDate: appstore.ExpiresDate{
+							ExpiresDateMS: strconv.FormatInt(time.Now().Add(15*24*time.Hour).UnixMilli(), 10),
+						},
+					},
+				},
+
+				subID: "sub-id",
+			},
+			exp: tcExpected{},
+		},
+
+		{
+			name: "two_items_not_found",
+			given: tcGiven{
+				iap: []appstore.InApp{
+					{
+						ProductID: "one-off-1",
+					},
+
+					{
+						ProductID: "one-off-2",
+					},
+				},
+
+				subID: "sub-id",
+			},
+			exp: tcExpected{},
+		},
+
+		{
+			name: "one_item_found",
+			given: tcGiven{
+				iap: []appstore.InApp{
+					{
+						ProductID: "one-off",
+					},
+				},
+
+				subID: "one-off",
+			},
+			exp: tcExpected{
+				iap: &appstore.InApp{
+					ProductID: "one-off",
+				},
+				ok: true,
+			},
+		},
+
+		{
+			name: "two_items_found",
+			given: tcGiven{
+				iap: []appstore.InApp{
+					{
+						ProductID: "one-off-1",
+					},
+
+					{
+						ProductID: "one-off-2",
+					},
+				},
+
+				subID: "one-off-2",
+			},
+			exp: tcExpected{
+				iap: &appstore.InApp{
+					ProductID: "one-off-2",
+				},
+				ok: true,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual, ok := findInAppBySubIDOneOff(tc.given.iap, tc.given.subID)
+			must.Equal(t, tc.exp.ok, ok)
+
+			if !tc.exp.ok {
+				return
+			}
+
+			should.Equal(t, tc.exp.iap, actual)
+		})
+	}
+}
+
+func TestFindInAppBySubIDIAPSub(t *testing.T) {
 	type tcGiven struct {
 		resp  *appstore.IAPResponse
 		subID string
@@ -910,7 +1273,7 @@ func TestFindInAppBySubIDIAP(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual, ok := findInAppBySubIDIAP(tc.given.resp, tc.given.subID, tc.given.now)
+			actual, ok := findInAppBySubIDIAPSub(tc.given.resp, tc.given.subID, tc.given.now)
 			must.Equal(t, tc.exp.ok, ok)
 
 			if !tc.exp.ok {
@@ -922,7 +1285,7 @@ func TestFindInAppBySubIDIAP(t *testing.T) {
 	}
 }
 
-func TestFindInAppBySubID(t *testing.T) {
+func TestFindInAppBySubIDSub(t *testing.T) {
 	type tcGiven struct {
 		iap   []appstore.InApp
 		subID string
@@ -1082,7 +1445,7 @@ func TestFindInAppBySubID(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual, ok := findInAppBySubID(tc.given.iap, tc.given.subID, tc.given.now)
+			actual, ok := findInAppBySubIDSub(tc.given.iap, tc.given.subID, tc.given.now)
 			must.Equal(t, tc.exp.ok, ok)
 
 			if !tc.exp.ok {
@@ -1094,7 +1457,7 @@ func TestFindInAppBySubID(t *testing.T) {
 	}
 }
 
-func TestFindInAppBySubIDLegacy(t *testing.T) {
+func TestFindInAppBySubIDVPNLegacy(t *testing.T) {
 	type tcGiven struct {
 		resp  *appstore.IAPResponse
 		subID string
@@ -1202,7 +1565,7 @@ func TestFindInAppBySubIDLegacy(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			actual, ok := findInAppBySubIDLegacy(tc.given.resp, tc.given.subID, tc.given.now)
+			actual, ok := findInAppBySubIDVPNLegacy(tc.given.resp, tc.given.subID, tc.given.now)
 			must.Equal(t, tc.exp.ok, ok)
 
 			if !tc.exp.ok {


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
This PR adds support for apple one off purchase receipt validation

### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
