### PR TITLE
feat: add extend-linking-limit support CLI command

### DIFF
--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -71,9 +71,9 @@ one. Alternatively pass --subscription-id to target a subscription directly.
 If the subscriber is not eligible (not at limit, rate-limited, or cap reached)
 the command reports the reason and makes no change.
 
-Note: email lookup only works for desktop/browser subscriptions created through
-the subscriptions service. iOS and Android subscriptions use anonymous receipts
-and cannot be looked up by email.`,
+Note: email lookup requires the subscription to be linked to a Premium account.
+Mobile (iOS/Android) purchases are found by email once linked; an order that has
+only been created anonymously and not yet linked has no associated email.`,
 	RunE: runExtendLinkingLimit,
 }
 
@@ -123,28 +123,24 @@ func init() {
 
 	SkusCmd.AddCommand(extendLinkingLimitCmd)
 
+	// These flags are intentionally not bound to viper. reset-linking-limit
+	// already binds the global viper keys "email", "subscriptions-base-url" and
+	// "subscriptions-token" to its own flags, and viper.BindPFlag is global, so
+	// binding them again here would clobber that command. runExtendLinkingLimit
+	// reads these directly from the command, falling back to the environment.
 	efb := rootcmd.NewFlagBuilder(extendLinkingLimitCmd)
 
 	efb.Flag().String("subscriptions-base-url", "",
-		"base URL of the subscriptions service (e.g. https://subscriptions.brave.com)").
-		Env("SUBSCRIPTIONS_BASE_URL").
-		Bind("subscriptions-base-url").
-		Require()
+		"base URL of the subscriptions service, e.g. https://subscriptions.brave.com [env: SUBSCRIPTIONS_BASE_URL]")
 
 	efb.Flag().String("subscriptions-token", "",
-		"bearer token for the subscriptions support API").
-		Env("SUBSCRIPTIONS_SUPPORT_TOKEN").
-		Bind("subscriptions-token").
-		Require()
+		"bearer token for the subscriptions support API [env: SUBSCRIPTIONS_SUPPORT_TOKEN]")
 
 	efb.Flag().String("email", "",
-		"subscriber email to look up the subscription (mutually exclusive with --subscription-id)").
-		Env("SUBSCRIBER_EMAIL").
-		Bind("email")
+		"subscriber email to look up the subscription, mutually exclusive with --subscription-id [env: SUBSCRIBER_EMAIL]")
 
 	efb.Flag().String("subscription-id", "",
-		"the subscription UUID to extend (mutually exclusive with --email)").
-		Bind("subscription-id")
+		"the subscription UUID to extend (mutually exclusive with --email)")
 }
 
 func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
@@ -247,11 +243,24 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// flagOrEnv returns the command-line flag value, falling back to the environment
+// variable when the flag is unset. extend-linking-limit reads its flags this way
+// rather than through the shared viper bindings used by reset-linking-limit.
+func flagOrEnv(cmd *cobra.Command, flag, env string) string {
+	if v, _ := cmd.Flags().GetString(flag); v != "" {
+		return v
+	}
+
+	return os.Getenv(env)
+}
+
 func runExtendLinkingLimit(cmd *cobra.Command, args []string) error {
-	subsBaseURL := strings.TrimRight(viper.GetString("subscriptions-base-url"), "/")
-	subsToken := viper.GetString("subscriptions-token")
-	email := strings.TrimSpace(viper.GetString("email"))
-	subID := strings.TrimSpace(viper.GetString("subscription-id"))
+	subsBaseURL := strings.TrimRight(flagOrEnv(cmd, "subscriptions-base-url", "SUBSCRIPTIONS_BASE_URL"), "/")
+	subsToken := flagOrEnv(cmd, "subscriptions-token", "SUBSCRIPTIONS_SUPPORT_TOKEN")
+	email := strings.TrimSpace(flagOrEnv(cmd, "email", "SUBSCRIBER_EMAIL"))
+
+	subID, _ := cmd.Flags().GetString("subscription-id")
+	subID = strings.TrimSpace(subID)
 
 	if subsBaseURL == "" {
 		return fmt.Errorf("--subscriptions-base-url (or SUBSCRIPTIONS_BASE_URL) is required")

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/viper"
 
 	rootcmd "github.com/brave-intl/bat-go/cmd"
+	"github.com/brave-intl/bat-go/libs/handlers"
 	"github.com/brave-intl/bat-go/services/skus"
 	"github.com/brave-intl/bat-go/services/skus/model"
 )
@@ -47,6 +48,33 @@ Note: email lookup only works for desktop/browser orders created through
 the subscriptions service. iOS and Android orders use anonymous receipts
 and cannot be looked up by email.`,
 	RunE: runResetLinkingLimit,
+}
+
+var extendLinkingLimitCmd = &cobra.Command{
+	Use:   "extend-linking-limit",
+	Short: "Grant a device-linking-limit extension for a premium subscriber",
+	Long: `Grants a self-service-style linking-limit extension for a TLV2 subscriber,
+adding device slots without first unlinking a device.
+
+Unlike reset-linking-limit, this goes through the subscriptions service support
+API rather than talking to SKUs directly. Subscriptions owns and enforces the
+same policy as the in-browser self-service flow, so the same gates apply:
+
+  - the subscriber must currently be at their device limit,
+  - extensions are capped per subscription over its lifetime,
+  - and are rate-limited (one per window).
+
+The subscriber is identified by --email (looked up via the subscriptions
+support API). If multiple subscriptions match you will be prompted to choose
+one. Alternatively pass --subscription-id to target a subscription directly.
+
+If the subscriber is not eligible (not at limit, rate-limited, or cap reached)
+the command reports the reason and makes no change.
+
+Note: email lookup only works for desktop/browser subscriptions created through
+the subscriptions service. iOS and Android subscriptions use anonymous receipts
+and cannot be looked up by email.`,
+	RunE: runExtendLinkingLimit,
 }
 
 func init() {
@@ -92,6 +120,31 @@ func init() {
 		"path to the ed25519 private key file in SSH format used to sign requests").
 		Env("SKUS_SUPPORT_PRIVATE_KEY").
 		Bind("private-key")
+
+	SkusCmd.AddCommand(extendLinkingLimitCmd)
+
+	efb := rootcmd.NewFlagBuilder(extendLinkingLimitCmd)
+
+	efb.Flag().String("subscriptions-base-url", "",
+		"base URL of the subscriptions service (e.g. https://subscriptions.brave.com)").
+		Env("SUBSCRIPTIONS_BASE_URL").
+		Bind("subscriptions-base-url").
+		Require()
+
+	efb.Flag().String("subscriptions-token", "",
+		"bearer token for the subscriptions support API").
+		Env("SUBSCRIPTIONS_SUPPORT_TOKEN").
+		Bind("subscriptions-token").
+		Require()
+
+	efb.Flag().String("email", "",
+		"subscriber email to look up the subscription (mutually exclusive with --subscription-id)").
+		Env("SUBSCRIBER_EMAIL").
+		Bind("email")
+
+	efb.Flag().String("subscription-id", "",
+		"the subscription UUID to extend (mutually exclusive with --email)").
+		Bind("subscription-id")
 }
 
 func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
@@ -194,86 +247,216 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type activeSubsResp struct {
-	Email       string `json:"email"`
-	OrderID     string `json:"order_id"`
-	ProductName string `json:"product_name"`
+func runExtendLinkingLimit(cmd *cobra.Command, args []string) error {
+	subsBaseURL := strings.TrimRight(viper.GetString("subscriptions-base-url"), "/")
+	subsToken := viper.GetString("subscriptions-token")
+	email := strings.TrimSpace(viper.GetString("email"))
+	subID := strings.TrimSpace(viper.GetString("subscription-id"))
+
+	if subsBaseURL == "" {
+		return fmt.Errorf("--subscriptions-base-url (or SUBSCRIPTIONS_BASE_URL) is required")
+	}
+
+	if subsToken == "" {
+		return fmt.Errorf("--subscriptions-token (or SUBSCRIPTIONS_SUPPORT_TOKEN) is required")
+	}
+
+	switch {
+	case email == "" && subID == "":
+		return fmt.Errorf("one of --email or --subscription-id is required")
+	case email != "" && subID != "":
+		return fmt.Errorf("--email and --subscription-id are mutually exclusive")
+	}
+
+	ctx := cmd.Context()
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	productName := ""
+	if email != "" {
+		sub, err := resolveSubByEmail(ctx, client, subsBaseURL, email, subsToken)
+		if err != nil {
+			return err
+		}
+
+		if sub.SubscriptionID == "" {
+			return fmt.Errorf("subscription for %q has no subscription_id; cannot extend", email)
+		}
+
+		subID = sub.SubscriptionID
+		productName = sub.ProductName
+	}
+
+	prompt := fmt.Sprintf("Extend the device linking limit for subscription %s?", subID)
+	if productName != "" {
+		prompt = fmt.Sprintf("Extend the device linking limit for subscription %s (%s)?", subID, productName)
+	}
+
+	fmt.Println("Subscriptions enforces the self-service policy: the subscriber must be at")
+	fmt.Println("their device limit, under the lifetime extension cap, and outside the rate")
+	fmt.Println("limit window. If they are not eligible, no change is made.")
+	fmt.Println()
+
+	if !confirm(prompt) {
+		fmt.Println("Aborted.")
+		return nil
+	}
+
+	if err := extendLinkingLimit(ctx, client, subsBaseURL, subID, subsToken); err != nil {
+		return err
+	}
+
+	fmt.Printf("Done. Linking limit extended for subscription %s.\n", subID)
+
+	return nil
 }
 
-type activeSubsListResp struct {
-	Results []activeSubsResp `json:"results"`
-}
+// extendLinkingLimit calls the subscriptions support API to grant an extension.
+// The endpoint returns 200 on success and a handlers.AppError envelope on
+// failure, with errorCode set for the policy-gate cases.
+func extendLinkingLimit(ctx context.Context, client *http.Client, baseURL, subID, token string) error {
+	endpoint := fmt.Sprintf("%s/v1/support/subscriptions/%s/credentials/batches/extend", baseURL, url.PathEscape(subID))
 
-func resolveOrderIDByEmail(ctx context.Context, client *http.Client, baseURL, email, token string) (string, error) {
-	u := baseURL + "/v1/support/subscribers/" + url.PathEscape(email)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, nil)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := client.Do(req)
 	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("extension failed: unexpected status %d: failed to read response body: %w", resp.StatusCode, err)
+	}
+
+	var ae handlers.AppError
+	if err := json.Unmarshal(body, &ae); err != nil || ae.Message == "" {
+		return fmt.Errorf("extension failed: unexpected status %d: %s", resp.StatusCode, body)
+	}
+
+	if ae.ErrorCode != "" {
+		return fmt.Errorf("extension failed (status %d, %s): %s", resp.StatusCode, ae.ErrorCode, ae.Message)
+	}
+
+	return fmt.Errorf("extension failed (status %d): %s", resp.StatusCode, ae.Message)
+}
+
+type activeSubsResp struct {
+	Email          string `json:"email"`
+	SubscriptionID string `json:"subscription_id"`
+	OrderID        string `json:"order_id"`
+	ProductName    string `json:"product_name"`
+}
+
+type activeSubsListResp struct {
+	Results []activeSubsResp `json:"results"`
+}
+
+// resolveOrderIDByEmail looks up the subscriber's order ID via the subscriptions
+// support API, prompting for a choice when the email maps to several subscriptions.
+func resolveOrderIDByEmail(ctx context.Context, client *http.Client, baseURL, email, token string) (string, error) {
+	sub, err := resolveSubByEmail(ctx, client, baseURL, email, token)
+	if err != nil {
 		return "", err
+	}
+
+	return sub.OrderID, nil
+}
+
+// resolveSubByEmail fetches the active subscriptions for an email and returns the
+// chosen one, prompting the operator when more than one matches.
+func resolveSubByEmail(ctx context.Context, client *http.Client, baseURL, email, token string) (activeSubsResp, error) {
+	subs, err := fetchActiveSubs(ctx, client, baseURL, email, token)
+	if err != nil {
+		return activeSubsResp{}, err
+	}
+
+	return selectActiveSub(subs, email)
+}
+
+func fetchActiveSubs(ctx context.Context, client *http.Client, baseURL, email, token string) ([]activeSubsResp, error) {
+	u := baseURL + "/v1/support/subscribers/" + url.PathEscape(email)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return "", fmt.Errorf("no subscriber found for email %q", email)
+		return nil, fmt.Errorf("no subscriber found for email %q", email)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		if err != nil {
-			return "", fmt.Errorf("unexpected status %d: failed to read response body: %w", resp.StatusCode, err)
+			return nil, fmt.Errorf("unexpected status %d: failed to read response body: %w", resp.StatusCode, err)
 		}
-		return "", fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)
 	}
 
 	var result activeSubsListResp
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", fmt.Errorf("failed to decode response: %w", err)
+		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
 	if len(result.Results) == 0 {
-		return "", fmt.Errorf("no active subscriptions found for email %q", email)
+		return nil, fmt.Errorf("no active subscriptions found for email %q", email)
 	}
 
-	if len(result.Results) == 1 {
-		r := result.Results[0]
+	return result.Results, nil
+}
+
+func selectActiveSub(results []activeSubsResp, email string) (activeSubsResp, error) {
+	if len(results) == 1 {
+		r := results[0]
 		fmt.Printf("Found 1 active subscription for %s (%s)\n\n", r.Email, r.ProductName)
-		return r.OrderID, nil
+		return r, nil
 	}
 
-	fmt.Printf("Found %d active subscriptions matching %q:\n\n", len(result.Results), email)
-	fmt.Printf("  %-3s  %-36s  %-20s  %s\n", "#", "order_id", "product", "email")
-	fmt.Printf("  %-3s  %-36s  %-20s  %s\n",
-		"---", strings.Repeat("-", 36), strings.Repeat("-", 20), strings.Repeat("-", 30))
+	fmt.Printf("Found %d active subscriptions matching %q:\n\n", len(results), email)
+	fmt.Printf("  %-3s  %-36s  %-36s  %-20s  %s\n", "#", "subscription_id", "order_id", "product", "email")
+	fmt.Printf("  %-3s  %-36s  %-36s  %-20s  %s\n",
+		"---", strings.Repeat("-", 36), strings.Repeat("-", 36), strings.Repeat("-", 20), strings.Repeat("-", 30))
 
-	for i, r := range result.Results {
-		fmt.Printf("  %-3d  %-36s  %-20s  %s\n", i+1, r.OrderID, r.ProductName, r.Email)
+	for i, r := range results {
+		fmt.Printf("  %-3d  %-36s  %-36s  %-20s  %s\n", i+1, r.SubscriptionID, r.OrderID, r.ProductName, r.Email)
 	}
 	fmt.Println()
 
 	scanner := bufio.NewScanner(os.Stdin)
 	for {
-		fmt.Printf("Select subscription [1-%d]: ", len(result.Results))
+		fmt.Printf("Select subscription [1-%d]: ", len(results))
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
-				return "", fmt.Errorf("reading stdin: %w", err)
+				return activeSubsResp{}, fmt.Errorf("reading stdin: %w", err)
 			}
-			return "", fmt.Errorf("no selection made")
+			return activeSubsResp{}, fmt.Errorf("no selection made")
 		}
 
 		n, err := strconv.Atoi(strings.TrimSpace(scanner.Text()))
-		if err != nil || n < 1 || n > len(result.Results) {
-			fmt.Printf("Please enter a number between 1 and %d.\n", len(result.Results))
+		if err != nil || n < 1 || n > len(results) {
+			fmt.Printf("Please enter a number between 1 and %d.\n", len(results))
 			continue
 		}
 
-		return result.Results[n-1].OrderID, nil
+		return results[n-1], nil
 	}
 }
 

--- a/tools/skus/cmd/skus_test.go
+++ b/tools/skus/cmd/skus_test.go
@@ -294,3 +294,180 @@ func TestListBatchesBodyLimit(t *testing.T) {
 	// We expect an error (JSON parse failure), not a panic or timeout.
 	must.Error(t, err)
 }
+
+func TestExtendLinkingLimit(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	const subID = "1f14a340-edfb-4d14-bbdb-06a6c441568b"
+
+	t.Run("success_on_200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			should.Equal(t, http.MethodPost, r.Method)
+			should.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			should.Equal(t, "/v1/support/subscriptions/"+subID+"/credentials/batches/extend", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "{}")
+		}))
+		defer srv.Close()
+
+		err := extendLinkingLimit(context.Background(), client, srv.URL, subID, "tok")
+		must.NoError(t, err)
+	})
+
+	t.Run("policy_error_surfaces_errorCode_and_message", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			fmt.Fprint(w, `{"message":"extension rate limited","code":429,"errorCode":"rate_limited"}`)
+		}))
+		defer srv.Close()
+
+		err := extendLinkingLimit(context.Background(), client, srv.URL, subID, "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "rate_limited")
+		should.Contains(t, err.Error(), "extension rate limited")
+		should.Contains(t, err.Error(), "429")
+	})
+
+	t.Run("error_without_errorCode_uses_message", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprint(w, `{"message":"subscription not found","code":404}`)
+		}))
+		defer srv.Close()
+
+		err := extendLinkingLimit(context.Background(), client, srv.URL, subID, "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "subscription not found")
+		should.NotContains(t, err.Error(), "errorCode")
+	})
+
+	t.Run("non_json_error_falls_back_to_raw_body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "gateway timeout", http.StatusGatewayTimeout)
+		}))
+		defer srv.Close()
+
+		err := extendLinkingLimit(context.Background(), client, srv.URL, subID, "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "504")
+		should.Contains(t, err.Error(), "gateway timeout")
+	})
+
+	t.Run("context_cancelled_returns_error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer srv.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := extendLinkingLimit(ctx, client, srv.URL, subID, "tok")
+		must.Error(t, err)
+	})
+}
+
+func TestFetchActiveSubs(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	t.Run("returns_results_with_subscription_id", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			should.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			should.Equal(t, "/v1/support/subscribers/user@example.com", r.URL.Path)
+			json.NewEncoder(w).Encode(activeSubsListResp{Results: []activeSubsResp{
+				{Email: "user@example.com", SubscriptionID: "sub-1", OrderID: "ord-1", ProductName: "VPN"},
+			}})
+		}))
+		defer srv.Close()
+
+		got, err := fetchActiveSubs(context.Background(), client, srv.URL, "user@example.com", "tok")
+		must.NoError(t, err)
+		must.Len(t, got, 1)
+		should.Equal(t, "sub-1", got[0].SubscriptionID)
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		_, err := fetchActiveSubs(context.Background(), client, srv.URL, "nope@example.com", "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "no subscriber found")
+	})
+
+	t.Run("empty_results", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(activeSubsListResp{Results: []activeSubsResp{}})
+		}))
+		defer srv.Close()
+
+		_, err := fetchActiveSubs(context.Background(), client, srv.URL, "user@example.com", "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "no active subscriptions")
+	})
+}
+
+func TestSelectActiveSub_single(t *testing.T) {
+	// A single result is returned without prompting.
+	subs := []activeSubsResp{
+		{Email: "user@example.com", SubscriptionID: "sub-1", OrderID: "ord-1", ProductName: "VPN"},
+	}
+
+	got, err := selectActiveSub(subs, "user@example.com")
+	must.NoError(t, err)
+	should.Equal(t, "sub-1", got.SubscriptionID)
+}
+
+func TestSelectActiveSub_multiple(t *testing.T) {
+	subs := []activeSubsResp{
+		{Email: "user@example.com", SubscriptionID: "sub-1", OrderID: "ord-1", ProductName: "VPN"},
+		{Email: "user@example.com", SubscriptionID: "sub-2", OrderID: "ord-2", ProductName: "Leo"},
+	}
+
+	// selectActiveSub prompts on os.Stdin when there is more than one match;
+	// redirect it to a pipe for each case.
+	withStdin := func(t *testing.T, input string) (activeSubsResp, error) {
+		t.Helper()
+
+		r, w, err := os.Pipe()
+		must.NoError(t, err)
+
+		orig := os.Stdin
+		os.Stdin = r
+		t.Cleanup(func() { os.Stdin = orig })
+
+		_, err = fmt.Fprint(w, input)
+		must.NoError(t, err)
+		w.Close()
+
+		return selectActiveSub(subs, "user@example.com")
+	}
+
+	t.Run("selects_by_number", func(t *testing.T) {
+		got, err := withStdin(t, "2\n")
+		must.NoError(t, err)
+		should.Equal(t, "sub-2", got.SubscriptionID)
+	})
+
+	t.Run("reprompts_on_out_of_range_then_valid", func(t *testing.T) {
+		got, err := withStdin(t, "9\n1\n")
+		must.NoError(t, err)
+		should.Equal(t, "sub-1", got.SubscriptionID)
+	})
+
+	t.Run("reprompts_on_non_numeric_then_valid", func(t *testing.T) {
+		got, err := withStdin(t, "abc\n2\n")
+		must.NoError(t, err)
+		should.Equal(t, "sub-2", got.SubscriptionID)
+	})
+
+	t.Run("no_selection_on_eof", func(t *testing.T) {
+		_, err := withStdin(t, "")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "no selection made")
+	})
+}


### PR DESCRIPTION
### Summary

Adds `bat-go skus extend-linking-limit`, a support CLI command that grants a self-service-style device-linking-limit extension for a premium subscriber.

Unlike `reset-linking-limit` (which calls SKUs directly), this goes **through the subscriptions support API**, which owns and enforces the extension policy — so an operator-triggered extension respects the same at-limit / lifetime-cap / rate-limit gates as the in-browser self-service flow, and surfaces the same typed errors. The subscriber is identified by `--email` (reusing the `/v1/support/subscribers/{email}` lookup, which now returns `subscription_id`) or `--subscription-id`.

Depends on the subscriptions support endpoint `POST /v1/support/subscriptions/{id}/credentials/batches/extend` (brave-intl/subscription).

### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

<!-- Unit-tested only so far; depends on the subscriptions endpoint being deployed before an end-to-end run. -->

### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [x] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [x] Have validated query efficiency for new database queries? (n/a — no DB queries; thin HTTP client)
- [x] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [x] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan

Against an environment where the subscriptions support endpoint is deployed:

```
bat-go skus extend-linking-limit \
  --subscriptions-base-url https://<subscriptions-host> \
  --subscriptions-token <SUPPORT_TOKEN> \
  --email subscriber@example.com
```

- Resolves the subscription by email (prompts when several match), confirms, then POSTs the extension.
- Ineligible subscribers (not at limit / rate-limited / cap reached) report the reason and make no change.
- `--subscription-id <uuid>` targets a subscription directly without the email lookup.
