### PR TITLE
feat: add show-linking-usage support CLI command

### DIFF
--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -49,6 +49,25 @@ and cannot be looked up by email.`,
 	RunE: runResetLinkingLimit,
 }
 
+var showLinkingUsageCmd = &cobra.Command{
+	Use:   "show-linking-usage",
+	Short: "Show device linking slot usage for a premium order",
+	Long: `Shows how many device linking slots are in use for a TLV2 order by listing
+its active credential batches. Each batch corresponds to one linked device.
+
+This is the read-only counterpart of reset-linking-limit: it lists the same
+batches the deletion flow shows, but never makes changes.
+
+The order can be identified by --order-id or by --email (which looks up
+the subscriber in the subscriptions service). If multiple orders match an
+email you will be prompted to choose one.
+
+Note: email lookup requires the order to be linked to a Premium account.
+Mobile (iOS/Android) purchases are found by email once linked; an order that
+has only been created anonymously and not yet linked has no associated email.`,
+	RunE: runShowLinkingUsage,
+}
+
 func init() {
 	SkusCmd.AddCommand(resetLinkingLimitCmd)
 	rootcmd.RootCmd.AddCommand(SkusCmd)
@@ -92,6 +111,36 @@ func init() {
 		"path to the ed25519 private key file in SSH format used to sign requests").
 		Env("SKUS_SUPPORT_PRIVATE_KEY").
 		Bind("private-key")
+
+	SkusCmd.AddCommand(showLinkingUsageCmd)
+
+	// These flags are intentionally not bound to viper. reset-linking-limit
+	// already binds the global viper keys for these names to its own flags,
+	// and viper.BindPFlag is global, so binding them again here would clobber
+	// that command. runShowLinkingUsage reads these directly from the command,
+	// falling back to the environment.
+	sfb := rootcmd.NewFlagBuilder(showLinkingUsageCmd)
+
+	sfb.Flag().String("skus-base-url", "",
+		"base URL of the SKUs service, e.g. https://payment.rewards.brave.com [env: SKUS_BASE_URL]")
+
+	sfb.Flag().String("order-id", "",
+		"the order UUID to show slot usage for (mutually exclusive with --email)")
+
+	sfb.Flag().String("email", "",
+		"subscriber email to look up the order ID (mutually exclusive with --order-id) [env: SUBSCRIBER_EMAIL]")
+
+	sfb.Flag().String("subscriptions-base-url", "",
+		"base URL of the subscriptions service, required when using --email [env: SUBSCRIPTIONS_BASE_URL]")
+
+	sfb.Flag().String("subscriptions-token", "",
+		"bearer token for the subscriptions support API, required when using --email [env: SUBSCRIPTIONS_SUPPORT_TOKEN]")
+
+	sfb.Flag().String("item-id", "",
+		"optional: scope the listing to a specific order item UUID")
+
+	sfb.Flag().String("private-key", "",
+		"path to the ed25519 private key file in SSH format used to sign requests [env: SKUS_SUPPORT_PRIVATE_KEY]")
 }
 
 func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
@@ -192,6 +241,111 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Done. %d device slot(s) freed for order %s.\n", seats, orderID)
 
 	return nil
+}
+
+// flagOrEnv returns the command-line flag value, falling back to the environment
+// variable when the flag is unset. show-linking-usage reads its flags this way
+// rather than through the shared viper bindings used by reset-linking-limit.
+func flagOrEnv(cmd *cobra.Command, flag, env string) string {
+	if v, _ := cmd.Flags().GetString(flag); v != "" {
+		return v
+	}
+
+	return os.Getenv(env)
+}
+
+func runShowLinkingUsage(cmd *cobra.Command, args []string) error {
+	baseURL := strings.TrimRight(flagOrEnv(cmd, "skus-base-url", "SKUS_BASE_URL"), "/")
+	email := strings.TrimSpace(flagOrEnv(cmd, "email", "SUBSCRIBER_EMAIL"))
+	privKeyPath := flagOrEnv(cmd, "private-key", "SKUS_SUPPORT_PRIVATE_KEY")
+
+	orderID, _ := cmd.Flags().GetString("order-id")
+	orderID = strings.TrimSpace(orderID)
+
+	itemID, _ := cmd.Flags().GetString("item-id")
+	itemID = strings.TrimSpace(itemID)
+
+	if baseURL == "" {
+		return fmt.Errorf("--skus-base-url (or SKUS_BASE_URL) is required")
+	}
+
+	if privKeyPath == "" {
+		return fmt.Errorf("--private-key (or SKUS_SUPPORT_PRIVATE_KEY) is required")
+	}
+
+	switch {
+	case orderID == "" && email == "":
+		return fmt.Errorf("one of --order-id or --email is required")
+	case orderID != "" && email != "":
+		return fmt.Errorf("--order-id and --email are mutually exclusive")
+	}
+
+	privKey, err := loadED25519PrivateKey(privKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to load private key: %w", err)
+	}
+
+	ctx := cmd.Context()
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	if email != "" {
+		subsBaseURL := strings.TrimRight(flagOrEnv(cmd, "subscriptions-base-url", "SUBSCRIPTIONS_BASE_URL"), "/")
+		subsToken := flagOrEnv(cmd, "subscriptions-token", "SUBSCRIPTIONS_SUPPORT_TOKEN")
+
+		if subsBaseURL == "" {
+			return fmt.Errorf("--subscriptions-base-url is required when using --email")
+		}
+
+		if subsToken == "" {
+			return fmt.Errorf("--subscriptions-token is required when using --email")
+		}
+
+		orderID, err = resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
+		if err != nil {
+			return err
+		}
+	}
+
+	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
+	if itemID != "" {
+		listURL += "?" + url.Values{"item_id": {itemID}}.Encode()
+	}
+
+	batches, err := listBatches(ctx, client, listURL, privKey)
+	if err != nil {
+		return fmt.Errorf("failed to list batches: %w", err)
+	}
+
+	fmt.Print(formatLinkingUsage(orderID, itemID, batches))
+
+	return nil
+}
+
+// formatLinkingUsage renders the slot usage report for an order. Each active
+// batch corresponds to one linked device, so the batch count is the number of
+// device slots in use.
+func formatLinkingUsage(orderID, itemID string, batches []model.TLV2ActiveBatch) string {
+	var b strings.Builder
+
+	scope := fmt.Sprintf("order %s", orderID)
+	if itemID != "" {
+		scope = fmt.Sprintf("order %s (item %s)", orderID, itemID)
+	}
+
+	if len(batches) == 0 {
+		fmt.Fprintf(&b, "No device slots are in use for %s.\n", scope)
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "%d device slot(s) in use for %s.\n\n", len(batches), scope)
+
+	fmt.Fprintf(&b, "  %-40s  %s\n", "request_id", "oldest_valid_from (UTC)")
+	fmt.Fprintf(&b, "  %-40s  %s\n", strings.Repeat("-", 40), strings.Repeat("-", 24))
+	for _, batch := range batches {
+		fmt.Fprintf(&b, "  %-40s  %s\n", batch.RequestID, batch.OldestValidFrom.UTC().Format(time.RFC3339))
+	}
+
+	return b.String()
 }
 
 type activeSubsResp struct {

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -162,11 +162,8 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--seats must be a positive integer")
 	}
 
-	switch {
-	case orderID == "" && email == "":
-		return fmt.Errorf("one of --order-id or --email is required")
-	case orderID != "" && email != "":
-		return fmt.Errorf("--order-id and --email are mutually exclusive")
+	if err := requireOrderRef(orderID, email); err != nil {
+		return err
 	}
 
 	privKey, err := loadED25519PrivateKey(viper.GetString("private-key"))
@@ -177,30 +174,15 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	if email != "" {
-		subsBaseURL := strings.TrimRight(viper.GetString("subscriptions-base-url"), "/")
-		subsToken := viper.GetString("subscriptions-token")
+	subsBaseURL := strings.TrimRight(viper.GetString("subscriptions-base-url"), "/")
+	subsToken := viper.GetString("subscriptions-token")
 
-		if subsBaseURL == "" {
-			return fmt.Errorf("--subscriptions-base-url is required when using --email")
-		}
-
-		if subsToken == "" {
-			return fmt.Errorf("--subscriptions-token is required when using --email")
-		}
-
-		orderID, err = resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
-		if err != nil {
-			return err
-		}
+	orderID, err = resolveOrderID(ctx, client, orderID, email, subsBaseURL, subsToken)
+	if err != nil {
+		return err
 	}
 
-	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
-	if itemID != "" {
-		listURL += "?" + url.Values{"item_id": {itemID}}.Encode()
-	}
-
-	batches, err := listBatches(ctx, client, listURL, privKey)
+	batches, err := listBatches(ctx, client, batchesURL(baseURL, orderID, itemID), privKey)
 	if err != nil {
 		return fmt.Errorf("failed to list batches: %w", err)
 	}
@@ -218,11 +200,7 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Oldest %d batch(es) at time of listing:\n\n", seats)
-	fmt.Printf("  %-40s  %s\n", "request_id", "oldest_valid_from (UTC)")
-	fmt.Printf("  %-40s  %s\n", strings.Repeat("-", 40), strings.Repeat("-", 24))
-	for _, b := range batches[:seats] {
-		fmt.Printf("  %-40s  %s\n", b.RequestID, b.OldestValidFrom.UTC().Format(time.RFC3339))
-	}
+	fmt.Print(formatBatchTable(batches[:seats]))
 	fmt.Println()
 	fmt.Println("Note: the server selects the oldest N batches independently at delete time.")
 	fmt.Println("      If the order changes before the request arrives, the result may differ.")
@@ -233,8 +211,7 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	deleteURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
-	if err := deleteBatchSeats(ctx, client, deleteURL, privKey, seats, itemID); err != nil {
+	if err := deleteBatchSeats(ctx, client, batchesURL(baseURL, orderID, ""), privKey, seats, itemID); err != nil {
 		return fmt.Errorf("failed to delete batch seats: %w", err)
 	}
 
@@ -273,11 +250,8 @@ func runShowLinkingUsage(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--private-key (or SKUS_SUPPORT_PRIVATE_KEY) is required")
 	}
 
-	switch {
-	case orderID == "" && email == "":
-		return fmt.Errorf("one of --order-id or --email is required")
-	case orderID != "" && email != "":
-		return fmt.Errorf("--order-id and --email are mutually exclusive")
+	if err := requireOrderRef(orderID, email); err != nil {
+		return err
 	}
 
 	privKey, err := loadED25519PrivateKey(privKeyPath)
@@ -288,30 +262,15 @@ func runShowLinkingUsage(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	client := &http.Client{Timeout: 30 * time.Second}
 
-	if email != "" {
-		subsBaseURL := strings.TrimRight(flagOrEnv(cmd, "subscriptions-base-url", "SUBSCRIPTIONS_BASE_URL"), "/")
-		subsToken := flagOrEnv(cmd, "subscriptions-token", "SUBSCRIPTIONS_SUPPORT_TOKEN")
+	subsBaseURL := strings.TrimRight(flagOrEnv(cmd, "subscriptions-base-url", "SUBSCRIPTIONS_BASE_URL"), "/")
+	subsToken := flagOrEnv(cmd, "subscriptions-token", "SUBSCRIPTIONS_SUPPORT_TOKEN")
 
-		if subsBaseURL == "" {
-			return fmt.Errorf("--subscriptions-base-url is required when using --email")
-		}
-
-		if subsToken == "" {
-			return fmt.Errorf("--subscriptions-token is required when using --email")
-		}
-
-		orderID, err = resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
-		if err != nil {
-			return err
-		}
+	orderID, err = resolveOrderID(ctx, client, orderID, email, subsBaseURL, subsToken)
+	if err != nil {
+		return err
 	}
 
-	listURL := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
-	if itemID != "" {
-		listURL += "?" + url.Values{"item_id": {itemID}}.Encode()
-	}
-
-	batches, err := listBatches(ctx, client, listURL, privKey)
+	batches, err := listBatches(ctx, client, batchesURL(baseURL, orderID, itemID), privKey)
 	if err != nil {
 		return fmt.Errorf("failed to list batches: %w", err)
 	}
@@ -319,6 +278,47 @@ func runShowLinkingUsage(cmd *cobra.Command, args []string) error {
 	fmt.Print(formatLinkingUsage(orderID, itemID, batches))
 
 	return nil
+}
+
+// requireOrderRef validates that exactly one of --order-id and --email was given.
+func requireOrderRef(orderID, email string) error {
+	switch {
+	case orderID == "" && email == "":
+		return fmt.Errorf("one of --order-id or --email is required")
+	case orderID != "" && email != "":
+		return fmt.Errorf("--order-id and --email are mutually exclusive")
+	}
+
+	return nil
+}
+
+// resolveOrderID returns orderID as-is when set, otherwise resolves email to an
+// order ID via the subscriptions support API, validating the flags it needs.
+func resolveOrderID(ctx context.Context, client *http.Client, orderID, email, subsBaseURL, subsToken string) (string, error) {
+	if orderID != "" {
+		return orderID, nil
+	}
+
+	if subsBaseURL == "" {
+		return "", fmt.Errorf("--subscriptions-base-url is required when using --email")
+	}
+
+	if subsToken == "" {
+		return "", fmt.Errorf("--subscriptions-token is required when using --email")
+	}
+
+	return resolveOrderIDByEmail(ctx, client, subsBaseURL, email, subsToken)
+}
+
+// batchesURL builds the SKUs credential batches endpoint URL for an order,
+// scoped to an order item when itemID is non-empty.
+func batchesURL(baseURL, orderID, itemID string) string {
+	u := fmt.Sprintf("%s/v1/orders/%s/credentials/batches", baseURL, orderID)
+	if itemID != "" {
+		u += "?" + url.Values{"item_id": {itemID}}.Encode()
+	}
+
+	return u
 }
 
 // formatLinkingUsage renders the slot usage report for an order. Each active
@@ -338,6 +338,15 @@ func formatLinkingUsage(orderID, itemID string, batches []model.TLV2ActiveBatch)
 	}
 
 	fmt.Fprintf(&b, "%d device slot(s) in use for %s.\n\n", len(batches), scope)
+	b.WriteString(formatBatchTable(batches))
+
+	return b.String()
+}
+
+// formatBatchTable renders the request_id / oldest_valid_from table shared by
+// the usage report and the reset confirmation listing.
+func formatBatchTable(batches []model.TLV2ActiveBatch) string {
+	var b strings.Builder
 
 	fmt.Fprintf(&b, "  %-40s  %s\n", "request_id", "oldest_valid_from (UTC)")
 	fmt.Fprintf(&b, "  %-40s  %s\n", strings.Repeat("-", 40), strings.Repeat("-", 24))

--- a/tools/skus/cmd/skus.go
+++ b/tools/skus/cmd/skus.go
@@ -43,9 +43,9 @@ email you will be prompted to choose one.
 The command shows which batches will be removed and asks for confirmation
 before making any changes.
 
-Note: email lookup only works for desktop/browser orders created through
-the subscriptions service. iOS and Android orders use anonymous receipts
-and cannot be looked up by email.`,
+Note: email lookup requires the order to be linked to a Premium account.
+Mobile (iOS/Android) purchases are found by email once linked; an order that
+has only been created anonymously and not yet linked has no associated email.`,
 	RunE: runResetLinkingLimit,
 }
 
@@ -221,8 +221,7 @@ func runResetLinkingLimit(cmd *cobra.Command, args []string) error {
 }
 
 // flagOrEnv returns the command-line flag value, falling back to the environment
-// variable when the flag is unset. show-linking-usage reads its flags this way
-// rather than through the shared viper bindings used by reset-linking-limit.
+// variable when the flag is unset.
 func flagOrEnv(cmd *cobra.Command, flag, env string) string {
 	if v, _ := cmd.Flags().GetString(flag); v != "" {
 		return v
@@ -280,7 +279,6 @@ func runShowLinkingUsage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// requireOrderRef validates that exactly one of --order-id and --email was given.
 func requireOrderRef(orderID, email string) error {
 	switch {
 	case orderID == "" && email == "":
@@ -343,8 +341,7 @@ func formatLinkingUsage(orderID, itemID string, batches []model.TLV2ActiveBatch)
 	return b.String()
 }
 
-// formatBatchTable renders the request_id / oldest_valid_from table shared by
-// the usage report and the reset confirmation listing.
+// formatBatchTable renders active batches as a request_id / oldest_valid_from table.
 func formatBatchTable(batches []model.TLV2ActiveBatch) string {
 	var b strings.Builder
 

--- a/tools/skus/cmd/skus_test.go
+++ b/tools/skus/cmd/skus_test.go
@@ -365,3 +365,64 @@ func TestFormatLinkingUsage(t *testing.T) {
 		should.Contains(t, got, "2026-01-02T08:04:05Z")
 	})
 }
+
+func TestRequireOrderRef(t *testing.T) {
+	should.Error(t, requireOrderRef("", ""))
+	should.Error(t, requireOrderRef("some-order", "user@example.com"))
+	should.NoError(t, requireOrderRef("some-order", ""))
+	should.NoError(t, requireOrderRef("", "user@example.com"))
+}
+
+func TestResolveOrderID(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	t.Run("order_id_passes_through", func(t *testing.T) {
+		got, err := resolveOrderID(context.Background(), client, "some-order", "", "", "")
+		must.NoError(t, err)
+		should.Equal(t, "some-order", got)
+	})
+
+	t.Run("email_requires_subs_base_url", func(t *testing.T) {
+		_, err := resolveOrderID(context.Background(), client, "", "user@example.com", "", "tok")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "--subscriptions-base-url")
+	})
+
+	t.Run("email_requires_subs_token", func(t *testing.T) {
+		_, err := resolveOrderID(context.Background(), client, "", "user@example.com", "http://localhost", "")
+		must.Error(t, err)
+		should.Contains(t, err.Error(), "--subscriptions-token")
+	})
+
+	t.Run("email_resolves_via_support_api", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			should.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			should.Equal(t, "/v1/support/subscribers/user@example.com", r.URL.Path)
+			json.NewEncoder(w).Encode(activeSubsListResp{Results: []activeSubsResp{
+				{Email: "user@example.com", OrderID: "ord-1", ProductName: "VPN"},
+			}})
+		}))
+		defer srv.Close()
+
+		got, err := resolveOrderID(context.Background(), client, "", "user@example.com", srv.URL, "tok")
+		must.NoError(t, err)
+		should.Equal(t, "ord-1", got)
+	})
+}
+
+func TestBatchesURL(t *testing.T) {
+	const base = "https://payment.example.com"
+	const orderID = "550e8400-e29b-41d4-a716-446655440000"
+
+	t.Run("without_item_id", func(t *testing.T) {
+		should.Equal(t,
+			base+"/v1/orders/"+orderID+"/credentials/batches",
+			batchesURL(base, orderID, ""))
+	})
+
+	t.Run("with_item_id", func(t *testing.T) {
+		should.Equal(t,
+			base+"/v1/orders/"+orderID+"/credentials/batches?item_id=ad0be000-0000-4000-a000-000000000000",
+			batchesURL(base, orderID, "ad0be000-0000-4000-a000-000000000000"))
+	})
+}

--- a/tools/skus/cmd/skus_test.go
+++ b/tools/skus/cmd/skus_test.go
@@ -17,6 +17,8 @@ import (
 
 	"golang.org/x/crypto/ssh"
 
+	"github.com/spf13/cobra"
+
 	should "github.com/stretchr/testify/assert"
 	must "github.com/stretchr/testify/require"
 
@@ -293,4 +295,73 @@ func TestListBatchesBodyLimit(t *testing.T) {
 	_, err := listBatches(context.Background(), client, srv.URL, priv)
 	// We expect an error (JSON parse failure), not a panic or timeout.
 	must.Error(t, err)
+}
+
+func TestFlagOrEnv(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("some-flag", "", "")
+		return cmd
+	}
+
+	t.Run("flag_set_wins", func(t *testing.T) {
+		t.Setenv("SOME_TEST_ENV", "from-env")
+
+		cmd := newCmd()
+		must.NoError(t, cmd.Flags().Set("some-flag", "from-flag"))
+
+		should.Equal(t, "from-flag", flagOrEnv(cmd, "some-flag", "SOME_TEST_ENV"))
+	})
+
+	t.Run("falls_back_to_env", func(t *testing.T) {
+		t.Setenv("SOME_TEST_ENV", "from-env")
+
+		should.Equal(t, "from-env", flagOrEnv(newCmd(), "some-flag", "SOME_TEST_ENV"))
+	})
+
+	t.Run("empty_when_neither_set", func(t *testing.T) {
+		should.Equal(t, "", flagOrEnv(newCmd(), "some-flag", "SOME_TEST_ENV_UNSET"))
+	})
+}
+
+func TestFormatLinkingUsage(t *testing.T) {
+	const orderID = "550e8400-e29b-41d4-a716-446655440000"
+	const itemID = "1f14a340-edfb-4d14-bbdb-06a6c441568b"
+
+	t.Run("no_batches", func(t *testing.T) {
+		got := formatLinkingUsage(orderID, "", nil)
+		should.Equal(t, "No device slots are in use for order "+orderID+".\n", got)
+	})
+
+	t.Run("no_batches_with_item_scope", func(t *testing.T) {
+		got := formatLinkingUsage(orderID, itemID, nil)
+		should.Contains(t, got, "No device slots are in use")
+		should.Contains(t, got, "order "+orderID+" (item "+itemID+")")
+	})
+
+	t.Run("counts_and_lists_batches", func(t *testing.T) {
+		batches := []model.TLV2ActiveBatch{
+			{RequestID: "req-1", OldestValidFrom: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)},
+			{RequestID: "req-2", OldestValidFrom: time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC)},
+			{RequestID: "req-3", OldestValidFrom: time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)},
+		}
+
+		got := formatLinkingUsage(orderID, "", batches)
+		should.Contains(t, got, "3 device slot(s) in use for order "+orderID+".")
+		should.Contains(t, got, "req-1")
+		should.Contains(t, got, "req-2")
+		should.Contains(t, got, "req-3")
+		should.Contains(t, got, "2026-01-02T03:04:05Z")
+		should.Contains(t, got, "2026-03-04T05:06:07Z")
+	})
+
+	t.Run("formats_timestamps_in_utc", func(t *testing.T) {
+		est := time.FixedZone("EST", -5*60*60)
+		batches := []model.TLV2ActiveBatch{
+			{RequestID: "req-1", OldestValidFrom: time.Date(2026, 1, 2, 3, 4, 5, 0, est)},
+		}
+
+		got := formatLinkingUsage(orderID, "", batches)
+		should.Contains(t, got, "2026-01-02T08:04:05Z")
+	})
 }


### PR DESCRIPTION
### Summary

Adds `bat-go skus show-linking-usage`, a read-only support CLI command that shows
how many device linking slots are in use for a premium order.

Support asked for a way to see a subscriber's slot usage without touching anything.
The deletion flow (`reset-linking-limit`) already reveals this during its
confirmation step; this command exposes the same listing — active credential
batches via the signed `GET /v1/orders/{orderID}/credentials/batches` endpoint,
where each batch is one linked device — without any mutation or confirmation
prompt. The order is identified by `--order-id` or `--email` (subscriptions
support API lookup, with interactive selection when several match), optionally
scoped with `--item-id`.

The shared logic between the two commands is extracted into helpers used by both
(`requireOrderRef`, `resolveOrderID`, `batchesURL`, `formatBatchTable`) rather than
duplicated; `reset-linking-limit`'s behavior and output are unchanged.

Note: the report shows slots **in use** only, not used-of-total — the batches
endpoint does not return the item's `max_active_batches_tlv2_creds`, so a
used/total display would need a small SKUs server change. Possible follow-up.

The new command's flags are deliberately not bound to viper: `reset-linking-limit`
already binds the shared global keys, and `viper.BindPFlag` is global, so rebinding
would clobber that command. Flags are read directly from cobra with env fallback.

### Type of Change

- [x] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production

### Before Requesting Review

- [x] Does your code build cleanly without any errors or warnings?
- [x] Have you used auto closing keywords?
- [x] Have you added tests for new functionality?
- [x] Have validated query efficiency for new database queries? (n/a — no DB queries; reuses the existing signed SKUs
endpoint)
- [x] Have documented new functionality in README or in comments?
- [x] Have you squashed all intermediate commits?
- [x] Is there a clear title that explains what the PR does?
- [x] Have you used intuitive function, variable and other naming?
- [x] Have you requested security and/or privacy review if needed
- [x] Have you performed a self review of this PR?

### Manual Test Plan

bat-go skus show-linking-usage
  --skus-base-url https://<skus-host>
  --private-key <operator-key-path>
  --email subscriber@example.com
  --subscriptions-base-url https://<subscriptions-host>
  --subscriptions-token <SUPPORT_TOKEN>

- Resolves the order by email (prompts when several match) and prints the slot
  count plus a per-device table (request_id, oldest_valid_from), making no changes.
- `--order-id <uuid>` targets an order directly without the email lookup.
- `--item-id <uuid>` scopes the listing to one order item.
- `reset-linking-limit` is unaffected: same prompts, output, and behavior as before.