### PR TITLE
feat: adds new expire order endpoint to SKUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ env:
   BITFLYER_SERVER: ${{secrets.BITFLYER_SERVER}}
   BITFLYER_TOKEN: ${{secrets.BITFLYER_TOKEN}}
   REDIS_ADDR: redis://grant-redis/
+  KAFKA_ENABLED: false
 
 jobs:
   CI:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,6 +275,37 @@ services:
     container_name: challenge-bypass-kafka
     image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
     restart: always
+    security_opt: [no-new-privileges=true]
+    environment:
+      - "ENV=devtest"
+      - "SENTRY_DSN"
+      - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
+      - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
+      - KAFKA_BROKERS=kafka:19092
+      - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
+      - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem
+      - KAFKA_SSL_KEY_LOCATION=/etc/kafka/secrets/consumer.client.key
+      - KAFKA_REQUIRED_ACKS=1
+      - KAFKA_CONSUMERS_PER_NODE=1
+      - REDEEM_CONSUMER_TOPIC=redeem.consumer
+      - REDEEM_PRODUCER_TOPIC=redeem.producer
+      - SIGN_CONSUMER_TOPIC=sign.consumer # unsigned order creds request
+      - SIGN_PRODUCER_TOPIC=sign.producer # signed orders creds result
+      - CONSUMER_GROUP=consumer.group
+      - "DYNAMODB_ENDPOINT=http://dynamodb:8000"
+      - AWS_ACCESS_KEY_ID=dummy
+      - AWS_SECRET_ACCESS_KEY=dummy
+      - AWS_REGION=us-west-2
+    depends_on:
+      postgres:
+        condition: service_healthy
+      dynamodb:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    container_name: challenge-bypass-kafka
+    image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
+    restart: always
     security_opt:
       - no-new-privileges:true
     read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -277,6 +277,7 @@ services:
     image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
     restart: always
     security_opt: [no-new-privileges=true]
+    read_only: true
     environment:
       - "ENV=devtest"
       - "SENTRY_DSN"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,7 @@ services:
     container_name: challenge-bypass
     image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
     restart: always
+    security_opt: [no-new-privileges=true]
     ports:
       - "2416:2416"
     environment:
@@ -276,41 +277,6 @@ services:
     image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
     restart: always
     security_opt: [no-new-privileges=true]
-    environment:
-      - "ENV=devtest"
-      - "SENTRY_DSN"
-      - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
-      - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
-      - KAFKA_BROKERS=kafka:19092
-      - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
-      - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem
-      - KAFKA_SSL_KEY_LOCATION=/etc/kafka/secrets/consumer.client.key
-      - KAFKA_REQUIRED_ACKS=1
-      - KAFKA_CONSUMERS_PER_NODE=1
-      - REDEEM_CONSUMER_TOPIC=redeem.consumer
-      - REDEEM_PRODUCER_TOPIC=redeem.producer
-      - SIGN_CONSUMER_TOPIC=sign.consumer # unsigned order creds request
-      - SIGN_PRODUCER_TOPIC=sign.producer # signed orders creds result
-      - CONSUMER_GROUP=consumer.group
-      - "DYNAMODB_ENDPOINT=http://dynamodb:8000"
-      - AWS_ACCESS_KEY_ID=dummy
-      - AWS_SECRET_ACCESS_KEY=dummy
-      - AWS_REGION=us-west-2
-    depends_on:
-      postgres:
-        condition: service_healthy
-      dynamodb:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy
-    container_name: challenge-bypass-kafka
-    image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
-    restart: always
-    security_opt:
-      - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp
     environment:
       - "ENV=devtest"
       - "SENTRY_DSN"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       postgres:
         condition: service_healthy
       challenge-bypass:
-        condition: service_healthy
+        condition: service_started
       kafka:
         condition: service_healthy
     networks:
@@ -184,7 +184,7 @@ services:
       postgres:
         condition: service_healthy
       challenge-bypass:
-        condition: service_healthy
+        condition: service_started
       kafka:
         condition: service_healthy
     networks:
@@ -258,16 +258,12 @@ services:
         condition: service_healthy
       dynamodb:
         condition: service_healthy
+      kafka:
+        condition: service_healthy
     volumes:
       - ./test/secrets:/etc/kafka/secrets
     networks:
       - grant
-    healthcheck:
-      test: ["CMD-SHELL", "ps aux | grep -v grep | grep challenge-bypass-server || exit 1"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
-      start_period: 10s
 
   zookeeper:
     container_name: grant-zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       postgres:
         condition: service_healthy
       challenge-bypass:
-        condition: service_started
+        condition: service_healthy
       kafka:
         condition: service_healthy
     networks:
@@ -184,7 +184,7 @@ services:
       postgres:
         condition: service_healthy
       challenge-bypass:
-        condition: service_started
+        condition: service_healthy
       kafka:
         condition: service_healthy
     networks:
@@ -262,6 +262,12 @@ services:
       - ./test/secrets:/etc/kafka/secrets
     networks:
       - grant
+    healthcheck:
+      test: ["CMD-SHELL", "ps aux | grep -v grep | grep challenge-bypass-server || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   zookeeper:
     container_name: grant-zookeeper

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -238,6 +238,7 @@ services:
       - "SENTRY_DSN"
       - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
       - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
+      - KAFKA_ENABLED=false
       - KAFKA_BROKERS=kafka:19092
       - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
       - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
         condition: service_healthy
       challenge-bypass:
         condition: service_started
+      challenge-bypass-kafka:
+        condition: service_started
       kafka:
         condition: service_healthy
     networks:
@@ -185,6 +187,8 @@ services:
         condition: service_healthy
       challenge-bypass:
         condition: service_started
+      challenge-bypass-kafka:
+        condition: service_started
       kafka:
         condition: service_healthy
     networks:
@@ -227,6 +231,9 @@ services:
       retries: 5
       start_period: 5s
 
+  # The challenge-bypass image runs either the HTTP API (KAFKA_ENABLED=false)
+  # or the Kafka consumers (default), so it takes two containers to provide
+  # both.
   challenge-bypass:
     container_name: challenge-bypass
     image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
@@ -235,10 +242,49 @@ services:
       - "2416:2416"
     environment:
       - "ENV=devtest"
+      - KAFKA_ENABLED=false
       - "SENTRY_DSN"
       - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
       - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
-      - KAFKA_ENABLED=false
+      - KAFKA_BROKERS=kafka:19092
+      - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
+      - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem
+      - KAFKA_SSL_KEY_LOCATION=/etc/kafka/secrets/consumer.client.key
+      - KAFKA_REQUIRED_ACKS=1
+      - KAFKA_CONSUMERS_PER_NODE=1
+      - REDEEM_CONSUMER_TOPIC=redeem.consumer
+      - REDEEM_PRODUCER_TOPIC=redeem.producer
+      - SIGN_CONSUMER_TOPIC=sign.consumer # unsigned order creds request
+      - SIGN_PRODUCER_TOPIC=sign.producer # signed orders creds result
+      - CONSUMER_GROUP=consumer.group
+      - "DYNAMODB_ENDPOINT=http://dynamodb:8000"
+      - AWS_ACCESS_KEY_ID=dummy
+      - AWS_SECRET_ACCESS_KEY=dummy
+      - AWS_REGION=us-west-2
+    depends_on:
+      postgres:
+        condition: service_healthy
+      dynamodb:
+        condition: service_healthy
+    volumes:
+      - ./test/secrets:/etc/kafka/secrets
+    networks:
+      - grant
+
+  challenge-bypass-kafka:
+    container_name: challenge-bypass-kafka
+    image: 078933103932.dkr.ecr.us-west-2.amazonaws.com/challenge-bypass:latest
+    restart: always
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    environment:
+      - "ENV=devtest"
+      - "SENTRY_DSN"
+      - "DATABASE_URL=postgres://btokens:password@grant-postgres/btokens?sslmode=disable"
+      - "DATABASE_MIGRATIONS_URL=file:///src/migrations"
       - KAFKA_BROKERS=kafka:19092
       - KAFKA_SSL_CA_LOCATION=/etc/kafka/secrets/snakeoil-ca-1.crt
       - KAFKA_SSL_CERTIFICATE_LOCATION=/etc/kafka/secrets/consumer-ca1-signed.pem

--- a/services/grant/cmd/grant.go
+++ b/services/grant/cmd/grant.go
@@ -532,7 +532,7 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 			http.MethodPut,
 			"/{orderID}/expire",
 			middleware.InstrumentHandler(
-				"ExpireOrderNew",
+				"ExpireOrder",
 				corsMwrPut(authMwr(handlers.AppHandler(orderh.Expire))),
 			),
 		)

--- a/services/grant/cmd/grant.go
+++ b/services/grant/cmd/grant.go
@@ -526,14 +526,14 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 			),
 		)
 
-		corsMwrPut := skus.NewCORSMwr(corsOpts, http.MethodPut)
+		corsMwrPatch := skus.NewCORSMwr(corsOpts, http.MethodPatch)
 
 		subr.Method(
-			http.MethodPut,
+			http.MethodPatch,
 			"/{orderID}/expire",
 			middleware.InstrumentHandler(
 				"ExpireOrder",
-				corsMwrPut(authMwr(handlers.AppHandler(orderh.Expire))),
+				corsMwrPatch(authMwr(handlers.AppHandler(orderh.Expire))),
 			),
 		)
 

--- a/services/grant/cmd/grant.go
+++ b/services/grant/cmd/grant.go
@@ -526,6 +526,17 @@ func setupRouter(ctx context.Context, logger *zerolog.Logger) (context.Context, 
 			),
 		)
 
+		corsMwrPut := skus.NewCORSMwr(corsOpts, http.MethodPut)
+
+		subr.Method(
+			http.MethodPut,
+			"/{orderID}/expire",
+			middleware.InstrumentHandler(
+				"ExpireOrderNew",
+				corsMwrPut(authMwr(handlers.AppHandler(orderh.Expire))),
+			),
+		)
+
 		r.Mount("/v1/orders-new", subr)
 	}
 

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -155,15 +155,15 @@ func (h *Order) Expire(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 	lg := logging.Logger(ctx, "skus").With().Str("func", "ExpireOrder").Logger()
 
 	if err := h.svc.ExpireOrder(ctx, orderID); err != nil {
-		if errors.Is(err, model.ErrNoRowsChangedOrder) {
-			return handlers.WrapError(model.ErrOrderNotFound, "order not found", http.StatusNotFound)
-		}
-
-		if errors.Is(err, context.Canceled) {
-			return handlers.WrapError(model.ErrSomethingWentWrong, "client ended request", model.StatusClientClosedConn)
-		}
-
 		lg.Err(err).Str("order_id", orderID.String()).Msg("failed to expire order")
+
+		switch {
+		case errors.Is(err, model.ErrNoRowsChangedOrder):
+			return handlers.WrapError(model.ErrOrderNotFound, "order not found", http.StatusNotFound)
+
+		case errors.Is(err, context.Canceled):
+			return handlers.WrapError(err, "client ended request", model.StatusClientClosedConn)
+		}
 
 		return handlers.WrapError(model.ErrSomethingWentWrong, "could not expire order", http.StatusInternalServerError)
 	}

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -163,9 +163,10 @@ func (h *Order) Expire(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 
 		case errors.Is(err, context.Canceled):
 			return handlers.WrapError(err, "client ended request", model.StatusClientClosedConn)
-		}
 
-		return handlers.WrapError(model.ErrSomethingWentWrong, "could not expire order", http.StatusInternalServerError)
+		default:
+			return handlers.WrapError(model.ErrSomethingWentWrong, "could not expire order", http.StatusInternalServerError)
+		}
 	}
 
 	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)

--- a/services/skus/handler/handler.go
+++ b/services/skus/handler/handler.go
@@ -27,6 +27,7 @@ type orderService interface {
 	CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 	CreateOrder(ctx context.Context, req *model.CreateOrderRequestNew) (*model.Order, error)
 	CancelOrder(ctx context.Context, id uuid.UUID) error
+	ExpireOrder(ctx context.Context, id uuid.UUID) error
 }
 
 type Order struct {
@@ -138,6 +139,33 @@ func (h *Order) Cancel(w http.ResponseWriter, r *http.Request) *handlers.AppErro
 		}
 
 		return handlers.WrapError(model.ErrSomethingWentWrong, "could not cancel order", http.StatusInternalServerError)
+	}
+
+	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+}
+
+func (h *Order) Expire(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"orderID": model.ErrInvalidUUID})
+	}
+
+	lg := logging.Logger(ctx, "skus").With().Str("func", "ExpireOrder").Logger()
+
+	if err := h.svc.ExpireOrder(ctx, orderID); err != nil {
+		if errors.Is(err, model.ErrNoRowsChangedOrder) {
+			return handlers.WrapError(model.ErrOrderNotFound, "order not found", http.StatusNotFound)
+		}
+
+		if errors.Is(err, context.Canceled) {
+			return handlers.WrapError(model.ErrSomethingWentWrong, "client ended request", model.StatusClientClosedConn)
+		}
+
+		lg.Err(err).Str("order_id", orderID.String()).Msg("failed to expire order")
+
+		return handlers.WrapError(model.ErrSomethingWentWrong, "could not expire order", http.StatusInternalServerError)
 	}
 
 	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -33,6 +33,7 @@ type mockOrderService struct {
 	fnCreateOrderFromRequest func(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error)
 	fnCreateOrder            func(ctx context.Context, req *model.CreateOrderRequestNew) (*model.Order, error)
 	fnCancelOrder            func(ctx context.Context, id uuid.UUID) error
+	fnExpireOrder            func(ctx context.Context, id uuid.UUID) error
 }
 
 func (s *mockOrderService) CreateOrderFromRequest(ctx context.Context, req model.CreateOrderRequest) (*model.Order, error) {
@@ -57,6 +58,14 @@ func (s *mockOrderService) CancelOrder(ctx context.Context, id uuid.UUID) error 
 	}
 
 	return s.fnCancelOrder(ctx, id)
+}
+
+func (s *mockOrderService) ExpireOrder(ctx context.Context, id uuid.UUID) error {
+	if s.fnExpireOrder == nil {
+		return nil
+	}
+
+	return s.fnExpireOrder(ctx, id)
 }
 
 func TestOrder_Create(t *testing.T) {
@@ -755,6 +764,150 @@ func TestOrder_Cancel(t *testing.T) {
 			rw.Header().Set("content-type", "application/json")
 
 			actual1 := h.Cancel(rw, req)
+			must.Equal(t, tc.exp.err, actual1)
+
+			if tc.exp.err != nil {
+				actual1.ServeHTTP(rw, req)
+				resp := rw.Body.Bytes()
+
+				exp, err := json.Marshal(tc.exp.err)
+				must.NoError(t, err)
+
+				should.Equal(t, exp, bytes.TrimSpace(resp))
+				return
+			}
+		})
+	}
+}
+
+func TestOrder_Expire(t *testing.T) {
+	type tcGiven struct {
+		ctx context.Context
+		svc *mockOrderService
+		oid uuid.UUID
+	}
+
+	type tcExpected struct {
+		err *handlers.AppError
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "invalid_orderID",
+			given: tcGiven{
+				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+					URLParams: chi.RouteParams{
+						Keys:   []string{"orderID"},
+						Values: []string{"invalid_id"},
+					},
+				}),
+				svc: &mockOrderService{},
+				oid: uuid.Nil,
+			},
+			exp: tcExpected{
+				err: handlers.ValidationError("request", map[string]interface{}{"orderID": model.ErrInvalidUUID}),
+			},
+		},
+
+		{
+			name: "order_not_found",
+			given: tcGiven{
+				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+					URLParams: chi.RouteParams{
+						Keys:   []string{"orderID"},
+						Values: []string{"facade00-0000-4000-a000-000000000000"},
+					},
+				}),
+				svc: &mockOrderService{
+					fnExpireOrder: func(ctx context.Context, id uuid.UUID) error {
+						return model.ErrNoRowsChangedOrder
+					},
+				},
+				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrOrderNotFound, "order not found", http.StatusNotFound),
+			},
+		},
+
+		{
+			name: "context_cancelled",
+			given: tcGiven{
+				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+					URLParams: chi.RouteParams{
+						Keys:   []string{"orderID"},
+						Values: []string{"facade00-0000-4000-a000-000000000000"},
+					},
+				}),
+				svc: &mockOrderService{
+					fnExpireOrder: func(ctx context.Context, id uuid.UUID) error {
+						return context.Canceled
+					},
+				},
+				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrSomethingWentWrong, "client ended request", model.StatusClientClosedConn),
+			},
+		},
+
+		{
+			name: "something_went_wrong",
+			given: tcGiven{
+				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+					URLParams: chi.RouteParams{
+						Keys:   []string{"orderID"},
+						Values: []string{"facade00-0000-4000-a000-000000000000"},
+					},
+				}),
+				svc: &mockOrderService{
+					fnExpireOrder: func(ctx context.Context, id uuid.UUID) error {
+						return model.Error("any_error")
+					},
+				},
+				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+			},
+			exp: tcExpected{
+				err: handlers.WrapError(model.ErrSomethingWentWrong, "could not expire order", http.StatusInternalServerError),
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
+					URLParams: chi.RouteParams{
+						Keys:   []string{"orderID"},
+						Values: []string{"facade00-0000-4000-a000-000000000000"},
+					},
+				}),
+				svc: &mockOrderService{},
+				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
+			},
+			exp: tcExpected{},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			h := handler.NewOrder(tc.given.svc)
+
+			uri := "http://localhost/v1/orders-new/" + tc.given.oid.String() + "/expire"
+			req := httptest.NewRequest(http.MethodPut, uri, nil)
+			req = req.WithContext(tc.given.ctx)
+
+			rw := httptest.NewRecorder()
+			rw.Header().Set("content-type", "application/json")
+
+			actual1 := h.Expire(rw, req)
 			must.Equal(t, tc.exp.err, actual1)
 
 			if tc.exp.err != nil {

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -853,7 +853,7 @@ func TestOrder_Expire(t *testing.T) {
 				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
 			},
 			exp: tcExpected{
-				err: handlers.WrapError(model.ErrSomethingWentWrong, "client ended request", model.StatusClientClosedConn),
+				err: handlers.WrapError(context.Canceled, "client ended request", model.StatusClientClosedConn),
 			},
 		},
 
@@ -900,24 +900,27 @@ func TestOrder_Expire(t *testing.T) {
 			h := handler.NewOrder(tc.given.svc)
 
 			uri := "http://localhost/v1/orders-new/" + tc.given.oid.String() + "/expire"
-			req := httptest.NewRequest(http.MethodPut, uri, nil)
+			req := httptest.NewRequest(http.MethodPatch, uri, nil)
 			req = req.WithContext(tc.given.ctx)
 
 			rw := httptest.NewRecorder()
 			rw.Header().Set("content-type", "application/json")
 
-			actual1 := h.Expire(rw, req)
-			must.Equal(t, tc.exp.err, actual1)
+			actual := h.Expire(rw, req)
+			must.Equal(t, tc.exp.err, actual)
 
 			if tc.exp.err != nil {
-				actual1.ServeHTTP(rw, req)
+				must.Equal(t, tc.exp.err.Code, actual.Code)
+			}
+
+			if tc.exp.err != nil {
+				actual.ServeHTTP(rw, req)
 				resp := rw.Body.Bytes()
 
 				exp, err := json.Marshal(tc.exp.err)
 				must.NoError(t, err)
 
-				should.Equal(t, exp, bytes.TrimSpace(resp))
-				return
+				should.JSONEq(t, string(exp), string(resp))
 			}
 		})
 	}

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -890,7 +890,6 @@ func TestOrder_Expire(t *testing.T) {
 				svc: &mockOrderService{},
 				oid: uuid.Must(uuid.FromString("facade00-0000-4000-a000-000000000000")),
 			},
-			exp: tcExpected{},
 		},
 	}
 

--- a/services/skus/handler/handler_test.go
+++ b/services/skus/handler/handler_test.go
@@ -911,6 +911,8 @@ func TestOrder_Expire(t *testing.T) {
 
 			if tc.exp.err != nil {
 				must.Equal(t, tc.exp.err.Code, actual.Code)
+			} else {
+				must.Equal(t, http.StatusOK, rw.Code)
 			}
 
 			if tc.exp.err != nil {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -897,19 +897,19 @@ func (s *Service) ExpireOrder(ctx context.Context, id uuid.UUID) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := s.cancelOrderTx(ctx, tx, id); err != nil {
-		return err
-	}
-
-	if err := s.expireOrderTx(ctx, tx, id); err != nil {
+	if err := s.expireOrderTx(ctx, tx, id, time.Now()); err != nil {
 		return err
 	}
 
 	return tx.Commit()
 }
 
-func (s *Service) expireOrderTx(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID) error {
-	return s.orderRepo.SetExpiresAt(ctx, dbi, id, time.Now())
+func (s *Service) expireOrderTx(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, t time.Time) error {
+	if err := s.cancelOrderTx(ctx, dbi, id); err != nil {
+		return err
+	}
+
+	return s.orderRepo.SetExpiresAt(ctx, dbi, id, t)
 }
 
 func (s *Service) setOrderTrialDays(ctx context.Context, orderID uuid.UUID, req *model.SetTrialDaysRequest, now time.Time) error {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -890,6 +890,28 @@ func (s *Service) CancelOrderLegacy(orderID uuid.UUID) error {
 	return s.Datastore.UpdateOrder(orderID, OrderStatusCanceled)
 }
 
+func (s *Service) ExpireOrder(ctx context.Context, id uuid.UUID) error {
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.cancelOrderTx(ctx, tx, id); err != nil {
+		return err
+	}
+
+	if err := s.expireOrderTx(ctx, tx, id); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s *Service) expireOrderTx(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID) error {
+	return s.orderRepo.SetExpiresAt(ctx, dbi, id, time.Now())
+}
+
 func (s *Service) setOrderTrialDays(ctx context.Context, orderID uuid.UUID, req *model.SetTrialDaysRequest, now time.Time) error {
 	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
 	if err != nil {

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -8339,3 +8339,141 @@ func TestService_extendLinkingLimitTx(t *testing.T) {
 		})
 	}
 }
+
+func TestService_ExpireOrder(t *testing.T) {
+	type tcGiven struct {
+		id    uuid.UUID
+		orepo *repository.MockOrder
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   error
+	}
+
+	tests := []testCase{
+		{
+			name: "cancel_failed_set_status",
+			given: tcGiven{
+				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				orepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return model.Error("something_went_wrong")
+					},
+				},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "expire_failed_set_expires_at",
+			given: tcGiven{
+				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				orepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return nil
+					},
+					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
+						return model.Error("something_went_wrong")
+					},
+				},
+			},
+			exp: model.Error("something_went_wrong"),
+		},
+
+		{
+			name: "order_not_found_in_cancel",
+			given: tcGiven{
+				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				orepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return model.ErrNoRowsChangedOrder
+					},
+				},
+			},
+			exp: model.ErrNoRowsChangedOrder,
+		},
+
+		{
+			name: "order_not_found_in_expire",
+			given: tcGiven{
+				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				orepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						return nil
+					},
+					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
+						return model.ErrNoRowsChangedOrder
+					},
+				},
+			},
+			exp: model.ErrNoRowsChangedOrder,
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				orepo: &repository.MockOrder{
+					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
+						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
+							return model.Error("unexpected: id")
+						}
+
+						if status != model.OrderStatusCanceled {
+							return model.Error("unexpected: status")
+						}
+
+						return nil
+					},
+
+					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
+						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
+							return model.Error("unexpected: id")
+						}
+
+						if time.Now().Before(when) {
+							return model.Error("unexpected: expiry time in the future")
+						}
+
+						return nil
+					},
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			ds := NewMockDatastore(ctrl)
+
+			mockDB, sqlMock, err := sqlmock.New()
+			must.Equal(t, nil, err)
+			t.Cleanup(func() { mockDB.Close() })
+
+			sqlMock.ExpectBegin()
+			if tc.exp == nil {
+				sqlMock.ExpectCommit()
+			}
+
+			db := sqlx.NewDb(mockDB, "sqlmock")
+			ds.EXPECT().RawDB().AnyTimes().Return(db)
+
+			svc := &Service{
+				Datastore: ds,
+				orderRepo: tc.given.orepo,
+			}
+
+			ctx := context.Background()
+
+			err = svc.ExpireOrder(ctx, tc.given.id)
+			should.Equal(t, true, errors.Is(err, tc.exp))
+		})
+	}
+}

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -8340,9 +8340,13 @@ func TestService_extendLinkingLimitTx(t *testing.T) {
 	}
 }
 
-func TestService_ExpireOrder(t *testing.T) {
+func TestService_expireOrderTx(t *testing.T) {
+	orderID := uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))
+	expiryTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
 	type tcGiven struct {
 		id    uuid.UUID
+		when  time.Time
 		orepo *repository.MockOrder
 	}
 
@@ -8356,7 +8360,8 @@ func TestService_ExpireOrder(t *testing.T) {
 		{
 			name: "cancel_failed_set_status",
 			given: tcGiven{
-				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				id:   orderID,
+				when: expiryTime,
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return model.Error("something_went_wrong")
@@ -8369,7 +8374,8 @@ func TestService_ExpireOrder(t *testing.T) {
 		{
 			name: "expire_failed_set_expires_at",
 			given: tcGiven{
-				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				id:   orderID,
+				when: expiryTime,
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return nil
@@ -8385,7 +8391,8 @@ func TestService_ExpireOrder(t *testing.T) {
 		{
 			name: "order_not_found_in_cancel",
 			given: tcGiven{
-				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				id:   orderID,
+				when: expiryTime,
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return model.ErrNoRowsChangedOrder
@@ -8398,7 +8405,8 @@ func TestService_ExpireOrder(t *testing.T) {
 		{
 			name: "order_not_found_in_expire",
 			given: tcGiven{
-				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				id:   orderID,
+				when: expiryTime,
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return nil
@@ -8414,10 +8422,11 @@ func TestService_ExpireOrder(t *testing.T) {
 		{
 			name: "success",
 			given: tcGiven{
-				id: uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				id:   orderID,
+				when: expiryTime,
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
-						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
+						if !uuid.Equal(id, orderID) {
 							return model.Error("unexpected: id")
 						}
 
@@ -8429,12 +8438,12 @@ func TestService_ExpireOrder(t *testing.T) {
 					},
 
 					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
-						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
+						if !uuid.Equal(id, orderID) {
 							return model.Error("unexpected: id")
 						}
 
-						if time.Now().Before(when) {
-							return model.Error("unexpected: expiry time in the future")
+						if !when.Equal(expiryTime) {
+							return model.Error("unexpected: when")
 						}
 
 						return nil
@@ -8448,32 +8457,14 @@ func TestService_ExpireOrder(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			ds := NewMockDatastore(ctrl)
-
-			mockDB, sqlMock, err := sqlmock.New()
-			must.Equal(t, nil, err)
-			t.Cleanup(func() { mockDB.Close() })
-
-			sqlMock.ExpectBegin()
-			if tc.exp == nil {
-				sqlMock.ExpectCommit()
-			}
-
-			db := sqlx.NewDb(mockDB, "sqlmock")
-			ds.EXPECT().RawDB().AnyTimes().Return(db)
-
 			svc := &Service{
-				Datastore: ds,
 				orderRepo: tc.given.orepo,
 			}
 
 			ctx := context.Background()
 
-			err = svc.ExpireOrder(ctx, tc.given.id)
-			should.Equal(t, true, errors.Is(err, tc.exp))
+			err := svc.expireOrderTx(ctx, nil, tc.given.id, tc.given.when)
+			should.ErrorIs(t, err, tc.exp)
 		})
 	}
 }

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -8341,9 +8341,6 @@ func TestService_extendLinkingLimitTx(t *testing.T) {
 }
 
 func TestService_expireOrderTx(t *testing.T) {
-	orderID := uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))
-	expiryTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-
 	type tcGiven struct {
 		id    uuid.UUID
 		when  time.Time
@@ -8360,8 +8357,8 @@ func TestService_expireOrderTx(t *testing.T) {
 		{
 			name: "cancel_failed_set_status",
 			given: tcGiven{
-				id:   orderID,
-				when: expiryTime,
+				id:   uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				when: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return model.Error("something_went_wrong")
@@ -8374,8 +8371,8 @@ func TestService_expireOrderTx(t *testing.T) {
 		{
 			name: "expire_failed_set_expires_at",
 			given: tcGiven{
-				id:   orderID,
-				when: expiryTime,
+				id:   uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				when: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return nil
@@ -8391,8 +8388,8 @@ func TestService_expireOrderTx(t *testing.T) {
 		{
 			name: "order_not_found_in_cancel",
 			given: tcGiven{
-				id:   orderID,
-				when: expiryTime,
+				id:   uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				when: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return model.ErrNoRowsChangedOrder
@@ -8405,8 +8402,8 @@ func TestService_expireOrderTx(t *testing.T) {
 		{
 			name: "order_not_found_in_expire",
 			given: tcGiven{
-				id:   orderID,
-				when: expiryTime,
+				id:   uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				when: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
 						return nil
@@ -8422,11 +8419,11 @@ func TestService_expireOrderTx(t *testing.T) {
 		{
 			name: "success",
 			given: tcGiven{
-				id:   orderID,
-				when: expiryTime,
+				id:   uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000")),
+				when: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				orepo: &repository.MockOrder{
 					FnSetStatus: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, status string) error {
-						if !uuid.Equal(id, orderID) {
+						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
 							return model.Error("unexpected: id")
 						}
 
@@ -8438,11 +8435,11 @@ func TestService_expireOrderTx(t *testing.T) {
 					},
 
 					FnSetExpiresAt: func(ctx context.Context, dbi sqlx.ExecerContext, id uuid.UUID, when time.Time) error {
-						if !uuid.Equal(id, orderID) {
+						if !uuid.Equal(id, uuid.Must(uuid.FromString("c0c0a000-0000-4000-a000-000000000000"))) {
 							return model.Error("unexpected: id")
 						}
 
-						if !when.Equal(expiryTime) {
+						if !when.Equal(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)) {
 							return model.Error("unexpected: when")
 						}
 


### PR DESCRIPTION
### Summary

Presently the SKUs service has a cancel order endpoint that simply sets the order's `status` to `canceled` while leaving the `expires_at` time alone. This is desired behaviour but we now have the requirement of being able to immediately expire an order upon cancellation and this is not supported via the existing cancelation endpoint. 

This PRs adds a new `/expire` endpoint which will also cancel the order if it hasn't already been cancelled. This will be used by a new support endpoint on the subscription service to allow support engineers to cancel and immediately expires orders after issuing refunds. 

