### PR TITLE
feat: add support linking limit endpoint to skus

### DIFF
--- a/services/skus/controllers.go
+++ b/services/skus/controllers.go
@@ -125,6 +125,7 @@ func Router(
 		cr.Method(http.MethodGet, "/batches", metricsMwr("ListActiveBatches", authMwr(handlers.AppHandler(credh.ListActiveBatches))))
 		cr.Method(http.MethodDelete, "/batches", metricsMwr("DeleteBatches", authMwr(handlers.AppHandler(credh.DeleteBatches))))
 		cr.Method(http.MethodPost, "/items/{itemID}/batches/extend", metricsMwr("ExtendLinkingLimit", authMwr(handlers.AppHandler(credh.ExtendLinkingLimit))))
+		cr.Method(http.MethodPut, "/items/{itemID}/batches/limit", metricsMwr("SetLinkingLimit", authMwr(handlers.AppHandler(credh.SetLinkingLimit))))
 
 		// Handle the old endpoint while the new is being rolled out:
 		// - true: the handler uses itemID as the request id, which is the old mode;

--- a/services/skus/datastore.go
+++ b/services/skus/datastore.go
@@ -115,6 +115,7 @@ type orderItemStore interface {
 	FindByOrderID(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
 	InsertMany(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
 	ApplyExtensionCAS(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expected *time.Time, newLimit int) error
+	ApplySupportLimitCAS(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expectedLimit, newLimit int) error
 }
 
 type orderPayHistoryStore interface {

--- a/services/skus/handler/cred.go
+++ b/services/skus/handler/cred.go
@@ -20,6 +20,7 @@ type tlv2Svc interface {
 	ListActiveBatches(ctx context.Context, orderID, itemID uuid.UUID) ([]model.TLV2ActiveBatch, error)
 	DeleteBatches(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
 	ExtendLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, write model.ExtensionWrite) error
+	SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, write model.SupportLimitWrite) error
 }
 
 type Cred struct {
@@ -233,6 +234,68 @@ func (h *Cred) ExtendLinkingLimit(w http.ResponseWriter, r *http.Request) *handl
 
 		case errors.Is(err, model.ErrExtensionConflict):
 			return withErrorCode(handlers.WrapError(err, "extension version conflict", http.StatusConflict), model.ExtensionCodeConflict)
+
+		default:
+			return handlers.WrapError(model.ErrSomethingWentWrong, "something went wrong", http.StatusInternalServerError)
+		}
+	}
+
+	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+}
+
+// SetLinkingLimit sets an order item's device linking limit, leaving the
+// self-service extension counters unchanged.
+//
+// PUT /v1/orders/{orderID}/credentials/items/{itemID}/batches/limit
+func (h *Cred) SetLinkingLimit(w http.ResponseWriter, r *http.Request) *handlers.AppError {
+	ctx := r.Context()
+
+	orderID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "orderID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"orderID": err.Error()})
+	}
+
+	itemID, err := uuid.FromString(chi.URLParamFromCtx(ctx, "itemID"))
+	if err != nil {
+		return handlers.ValidationError("request", map[string]interface{}{"itemID": err.Error()})
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, reqBodyLimit10MB))
+	if err != nil {
+		return withErrorCode(handlers.WrapError(err, "failed to read request body", http.StatusBadRequest), model.ExtensionCodeMalformedBody)
+	}
+
+	var write model.SupportLimitWrite
+	if err := json.Unmarshal(body, &write); err != nil {
+		return withErrorCode(handlers.WrapError(err, "failed to parse request body", http.StatusBadRequest), model.ExtensionCodeMalformedBody)
+	}
+
+	if err := h.tlv2.SetLinkingLimit(ctx, orderID, itemID, write); err != nil {
+		lg := logging.Logger(ctx, "skus").With().Str("func", "SetLinkingLimit").Logger()
+
+		lg.Error().Err(err).Msg("failed to set linking limit")
+
+		switch {
+		case errors.Is(err, context.Canceled):
+			return handlers.WrapError(err, "client ended request", model.StatusClientClosedConn)
+
+		case errors.Is(err, context.DeadlineExceeded):
+			return handlers.WrapError(err, "request timed out", http.StatusGatewayTimeout)
+
+		case errors.Is(err, model.ErrOrderNotFound), errors.Is(err, model.ErrInvalidOrderNoItems), errors.Is(err, model.ErrOrderItemNotFound):
+			return withErrorCode(handlers.WrapError(err, "order not found", http.StatusNotFound), model.ExtensionCodeOrderNotFound)
+
+		case errors.Is(err, model.ErrOrderNotPaid):
+			return withErrorCode(handlers.WrapError(err, "order not paid", http.StatusPaymentRequired), model.ExtensionCodeOrderNotPaid)
+
+		case errors.Is(err, model.ErrUnsupportedCredType):
+			return withErrorCode(handlers.WrapError(err, "credential type not supported", http.StatusBadRequest), model.ExtensionCodeUnsupportedCredType)
+
+		case errors.Is(err, model.ErrExtensionInvalidLimit):
+			return withErrorCode(handlers.WrapError(err, "new limit invalid", http.StatusUnprocessableEntity), model.ExtensionCodeInvalidLimit)
+
+		case errors.Is(err, model.ErrExtensionConflict):
+			return withErrorCode(handlers.WrapError(err, "limit version conflict", http.StatusConflict), model.ExtensionCodeConflict)
 
 		default:
 			return handlers.WrapError(model.ErrSomethingWentWrong, "something went wrong", http.StatusInternalServerError)

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -27,6 +27,7 @@ type mockTLV2Svc struct {
 	FnListActiveBatches  func(ctx context.Context, orderID, itemID uuid.UUID) ([]model.TLV2ActiveBatch, error)
 	FnDeleteBatches      func(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
 	FnExtendLinkingLimit func(ctx context.Context, orderID, itemID uuid.UUID, write model.ExtensionWrite) error
+	FnSetLinkingLimit    func(ctx context.Context, orderID, itemID uuid.UUID, write model.SupportLimitWrite) error
 }
 
 func (s *mockTLV2Svc) UniqBatches(ctx context.Context, orderID, itemID uuid.UUID) (*model.BatchesStatus, error) {
@@ -59,6 +60,98 @@ func (s *mockTLV2Svc) ExtendLinkingLimit(ctx context.Context, orderID, itemID uu
 	}
 
 	return s.FnExtendLinkingLimit(ctx, orderID, itemID, write)
+}
+
+func (s *mockTLV2Svc) SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, write model.SupportLimitWrite) error {
+	if s.FnSetLinkingLimit == nil {
+		return nil
+	}
+
+	return s.FnSetLinkingLimit(ctx, orderID, itemID, write)
+}
+
+func TestCred_SetLinkingLimit(t *testing.T) {
+	newReq := func(t *testing.T, orderID, itemID, body string) *http.Request {
+		t.Helper()
+
+		req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(body))
+
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("orderID", orderID)
+		rctx.URLParams.Add("itemID", itemID)
+
+		return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	}
+
+	const (
+		orderID = "facade00-0000-4000-a000-000000000000"
+		itemID  = "decade00-0000-4000-a000-000000000000"
+	)
+
+	t.Run("passes both limits through to the service", func(t *testing.T) {
+		var got model.SupportLimitWrite
+
+		svc := &mockTLV2Svc{
+			FnSetLinkingLimit: func(ctx context.Context, oid, iid uuid.UUID, write model.SupportLimitWrite) error {
+				got = write
+				return nil
+			},
+		}
+
+		rw := httptest.NewRecorder()
+		h := handler.NewCred(svc)
+
+		resp := h.SetLinkingLimit(rw, newReq(t, orderID, itemID, `{"expected_limit":10,"new_limit":16}`))
+
+		should.Nil(t, resp)
+		should.Equal(t, 10, got.ExpectedLimit)
+		should.Equal(t, 16, got.NewLimit)
+	})
+
+	t.Run("a lost CAS race is a 409, not a silent overwrite", func(t *testing.T) {
+		svc := &mockTLV2Svc{
+			FnSetLinkingLimit: func(ctx context.Context, oid, iid uuid.UUID, write model.SupportLimitWrite) error {
+				return model.ErrExtensionConflict
+			},
+		}
+
+		rw := httptest.NewRecorder()
+		h := handler.NewCred(svc)
+
+		resp := h.SetLinkingLimit(rw, newReq(t, orderID, itemID, `{"expected_limit":10,"new_limit":16}`))
+
+		must.NotNil(t, resp)
+		should.Equal(t, http.StatusConflict, resp.Code)
+		should.Equal(t, model.ExtensionCodeConflict, resp.ErrorCode)
+	})
+
+	t.Run("rejects a limit past the ceiling", func(t *testing.T) {
+		svc := &mockTLV2Svc{
+			FnSetLinkingLimit: func(ctx context.Context, oid, iid uuid.UUID, write model.SupportLimitWrite) error {
+				return model.ErrExtensionInvalidLimit
+			},
+		}
+
+		rw := httptest.NewRecorder()
+		h := handler.NewCred(svc)
+
+		resp := h.SetLinkingLimit(rw, newReq(t, orderID, itemID, `{"expected_limit":10,"new_limit":99999}`))
+
+		must.NotNil(t, resp)
+		should.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+		should.Equal(t, model.ExtensionCodeInvalidLimit, resp.ErrorCode)
+	})
+
+	t.Run("rejects a malformed body", func(t *testing.T) {
+		rw := httptest.NewRecorder()
+		h := handler.NewCred(&mockTLV2Svc{})
+
+		resp := h.SetLinkingLimit(rw, newReq(t, orderID, itemID, `{`))
+
+		must.NotNil(t, resp)
+		should.Equal(t, http.StatusBadRequest, resp.Code)
+		should.Equal(t, model.ExtensionCodeMalformedBody, resp.ErrorCode)
+	})
 }
 
 func TestCred_CountBatches(t *testing.T) {

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -121,6 +121,14 @@ type ExtensionWrite struct {
 	NewLimit                    int        `json:"new_limit"`
 }
 
+// SupportLimitWrite is a limit change that does not count as a self-service
+// extension. ExpectedLimit is the CAS version token: the limit the caller last
+// observed, against which the write is rejected if it no longer holds.
+type SupportLimitWrite struct {
+	ExpectedLimit int `json:"expected_limit"`
+	NewLimit      int `json:"new_limit"`
+}
+
 // Vendor represents an app store vendor.
 type Vendor string
 

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -1436,29 +1436,74 @@ func (s *Service) extendLinkingLimitTx(ctx context.Context, dbi sqlx.ExtContext,
 		return model.ErrExtensionInvalidLimit
 	}
 
-	ord, err := s.getOrderFullTx(ctx, dbi, orderID)
+	item, err := s.tlv2ItemForLimitWriteTx(ctx, dbi, orderID, itemID)
 	if err != nil {
 		return err
 	}
 
+	return s.orderItemRepo.ApplyExtensionCAS(ctx, dbi, item.ID, write.ExpectedLastSelfExtensionAt, write.NewLimit)
+}
+
+// tlv2ItemForLimitWriteTx returns the order item a linking-limit write targets,
+// after checking the order is paid and the item carries TLV2 credentials.
+func (s *Service) tlv2ItemForLimitWriteTx(ctx context.Context, dbi sqlx.ExtContext, orderID, itemID uuid.UUID) (*model.OrderItem, error) {
+	ord, err := s.getOrderFullTx(ctx, dbi, orderID)
+	if err != nil {
+		return nil, err
+	}
+
 	if !ord.IsPaid() {
-		return model.ErrOrderNotPaid
+		return nil, model.ErrOrderNotPaid
 	}
 
 	if len(ord.Items) == 0 {
-		return model.ErrInvalidOrderNoItems
+		return nil, model.ErrInvalidOrderNoItems
 	}
 
 	item, ok := ord.HasItem(itemID)
 	if !ok {
-		return model.ErrOrderItemNotFound
+		return nil, model.ErrOrderItemNotFound
 	}
 
 	if !item.IsCredTLV2() {
-		return model.ErrUnsupportedCredType
+		return nil, model.ErrUnsupportedCredType
 	}
 
-	return s.orderItemRepo.ApplyExtensionCAS(ctx, dbi, item.ID, write.ExpectedLastSelfExtensionAt, write.NewLimit)
+	return item, nil
+}
+
+// SetLinkingLimit sets an order item's device linking limit, leaving the
+// self-service extension counters unchanged. It applies no extension policy of
+// its own beyond the ceiling and the CAS check.
+func (s *Service) SetLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, write model.SupportLimitWrite) error {
+	tx, err := s.Datastore.RawDB().BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := s.setLinkingLimitTx(ctx, tx, orderID, itemID, write); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+func (s *Service) setLinkingLimitTx(ctx context.Context, dbi sqlx.ExtContext, orderID, itemID uuid.UUID, write model.SupportLimitWrite) error {
+	if write.NewLimit <= 0 || write.NewLimit > model.ExtensionMaxLimitCeiling {
+		return model.ErrExtensionInvalidLimit
+	}
+
+	if write.ExpectedLimit <= 0 {
+		return model.ErrExtensionInvalidLimit
+	}
+
+	item, err := s.tlv2ItemForLimitWriteTx(ctx, dbi, orderID, itemID)
+	if err != nil {
+		return err
+	}
+
+	return s.orderItemRepo.ApplySupportLimitCAS(ctx, dbi, item.ID, write.ExpectedLimit, write.NewLimit)
 }
 
 // isValidBatchReq validates that the order contains TLV2 credentials. When itemID is

--- a/services/skus/storage/repository/mock.go
+++ b/services/skus/storage/repository/mock.go
@@ -152,10 +152,11 @@ func (r *MockOrder) IncrementNumPayFailed(ctx context.Context, dbi sqlx.ExecerCo
 }
 
 type MockOrderItem struct {
-	FnGet               func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error)
-	FnFindByOrderID     func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
-	FnInsertMany        func(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
-	FnApplyExtensionCAS func(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expected *time.Time, newLimit int) error
+	FnGet                  func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error)
+	FnFindByOrderID        func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error)
+	FnInsertMany           func(ctx context.Context, dbi sqlx.ExtContext, items ...model.OrderItem) ([]model.OrderItem, error)
+	FnApplyExtensionCAS    func(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expected *time.Time, newLimit int) error
+	FnApplySupportLimitCAS func(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expectedLimit, newLimit int) error
 }
 
 func (r *MockOrderItem) Get(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error) {
@@ -188,6 +189,14 @@ func (r *MockOrderItem) ApplyExtensionCAS(ctx context.Context, dbi sqlx.ExtConte
 	}
 
 	return r.FnApplyExtensionCAS(ctx, dbi, id, expected, newLimit)
+}
+
+func (r *MockOrderItem) ApplySupportLimitCAS(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expectedLimit, newLimit int) error {
+	if r.FnApplySupportLimitCAS == nil {
+		return nil
+	}
+
+	return r.FnApplySupportLimitCAS(ctx, dbi, id, expectedLimit, newLimit)
 }
 
 type MockIssuer struct {

--- a/services/skus/storage/repository/order_item.go
+++ b/services/skus/storage/repository/order_item.go
@@ -114,6 +114,38 @@ func (r *OrderItem) ApplyExtensionCAS(ctx context.Context, dbi sqlx.ExtContext, 
 	return nil
 }
 
+// ApplySupportLimitCAS sets max_active_batches_tlv2_creds, leaving
+// num_self_extensions and last_self_extension_at unchanged. It versions on the
+// limit column rather than the extension timestamp, so concurrent writes
+// conflict instead of overwriting one another.
+func (r *OrderItem) ApplySupportLimitCAS(ctx context.Context, dbi sqlx.ExtContext, id uuid.UUID, expectedLimit, newLimit int) error {
+	const q = `
+	UPDATE order_items
+	SET max_active_batches_tlv2_creds = $2
+	WHERE id = $1
+	  AND max_active_batches_tlv2_creds = $3`
+
+	result, err := dbi.ExecContext(ctx, q, id, newLimit, expectedLimit)
+	if err != nil {
+		if isErrExtensionInvalidLimit(err) {
+			return model.ErrExtensionInvalidLimit
+		}
+
+		return err
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if n == 0 {
+		return model.ErrExtensionConflict
+	}
+
+	return nil
+}
+
 func isErrExtensionInvalidLimit(err error) bool {
 	var perr *pq.Error
 	if !errors.As(err, &perr) {


### PR DESCRIPTION
Adds PUT `/v1/orders/{orderID}/credentials/items/{itemID}/batches/limit`, which sets an order item's device linking limit without counting as a self-service extension.

The existing extend endpoint versions its CAS on last_self_extension_at, which is safe only because that write also updates the column. A support write must leave num_self_extensions and last_self_extension_at alone, so it versions on the limit column it does change instead. Concurrent support writes therefore conflict rather than silently overwriting one another.

Extracts `tlv2ItemForLimitWriteTx`, shared by both write paths, which were repeating the same paid/items/TLV2 validation.

### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
