### PR TITLE
fix: expand customer when recreate stripe session to get email

### DIFF
--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -3027,7 +3027,7 @@ func (s *Service) processStripeMtoA(ctx context.Context, dbi sqlx.ExtContext, nt
 }
 
 func (s *Service) recreateStripeSession(ctx context.Context, dbi sqlx.ExecerContext, ord *model.Order, oldSessID, email string) (string, error) {
-	oldSess, err := s.stripeCl.Session(ctx, oldSessID, nil)
+	oldSess, err := s.stripeCl.Session(ctx, oldSessID, &stripe.CheckoutSessionParams{Params: stripe.Params{Expand: []*string{stripe.String("customer")}}})
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
### Summary

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->
The customer was not expanded when retrieving the session so the email field was always empty. This PR expands the customer and sets the email.

closes https://github.com/brave-intl/bat-go/issues/3183

### Type of Change

- [ ] Product feature
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [x] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
