### PR TITLE
refactor: add response body to endpoint can extend linking limit with receipt

### DIFF
--- a/services/skus/credentials.go
+++ b/services/skus/credentials.go
@@ -859,8 +859,12 @@ func shouldTruncateTLV2Creds(ord *model.Order, item *model.OrderItem, ncreds int
 	return target, true
 }
 
+type policyStore interface {
+	GetPolicy(item *OrderItem) (model.CredExtensionPolicy, error)
+}
+
 type TLV2CredExtender struct {
-	policies model.CredExtensionPolicies
+	policies policyStore
 	tlv2Repo tlv2Store
 }
 
@@ -871,60 +875,23 @@ func NewTLV2CredExtender(policies model.CredExtensionPolicies, tlv2Repo tlv2Stor
 	}
 }
 
-type NextExtension struct {
-	maxActiveBatches int
-	numSelfExt       int
-}
-
-func (e *TLV2CredExtender) GetNextExtIfValid(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-	if !item.IsCredTLV2() {
-		return NextExtension{}, model.ErrUnsupportedCredType
-	}
-
-	pol, err := e.policies.GetPolicy(item.SKUVnt)
+func (e *TLV2CredExtender) GetExtensionFor(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+	pol, err := e.policies.GetPolicy(item)
 	if err != nil {
-		return NextExtension{}, err
-	}
-
-	if item.NumSelfExtensions >= pol.MaxPerItem {
-		return NextExtension{}, model.ErrExtensionMaxPerItem
-	}
-
-	if err := checkNextAllowedExtensionTime(pol, item, now); err != nil {
-		return NextExtension{}, err
+		return model.CredExtension{}, err
 	}
 
 	active, err := e.tlv2Repo.UniqBatches(ctx, dbi, item.OrderID, item.ID, now, now)
 	if err != nil {
-		return NextExtension{}, err
+		return model.CredExtension{}, err
 	}
 
 	limit, err := item.MaxActiveBatchesTLV2CredsOrDefault()
 	if err != nil {
-		return NextExtension{}, err
+		return model.CredExtension{}, err
 	}
 
-	if active < limit {
-		return NextExtension{}, model.ErrExtensionNotAtLimit
-	}
+	st := model.ExtensionState{Item: item, ActiveBatches: active, Limit: limit}
 
-	nxt := NextExtension{
-		maxActiveBatches: limit + pol.SlotsPerGrant,
-		numSelfExt:       item.NumSelfExtensions + 1,
-	}
-
-	return nxt, nil
-}
-
-func checkNextAllowedExtensionTime(pol model.CredExtensionPolicy, item *model.OrderItem, now time.Time) error {
-	if item.LastSelfExtensionAt == nil {
-		return nil
-	}
-
-	nextAllowed := item.LastSelfExtensionAt.Add(time.Duration(pol.MinIntervalSeconds) * time.Second)
-	if now.Before(nextAllowed) {
-		return model.ErrExtensionRateLimited
-	}
-
-	return nil
+	return model.NewCredExtension(pol, st, now), nil
 }

--- a/services/skus/credentials_noint_test.go
+++ b/services/skus/credentials_noint_test.go
@@ -248,16 +248,16 @@ func TestShouldTruncateTLV2Creds(t *testing.T) {
 	}
 }
 
-func TestTlV2CredExtender_GetNextExtIfValid(t *testing.T) {
+func TestTlV2CredExtender_GetExtensionFor(t *testing.T) {
 	type tcGiven struct {
 		item     *model.OrderItem
 		now      time.Time
-		policies model.CredExtensionPolicies
+		policies policyStore
 		tlv2Repo tlv2Store
 	}
 
 	type tcExpected struct {
-		nxt NextExtension
+		ext model.CredExtension
 		err error
 	}
 
@@ -269,64 +269,16 @@ func TestTlV2CredExtender_GetNextExtIfValid(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "error_unsupported_cred_type",
-			given: tcGiven{
-				item: &model.OrderItem{},
-			},
-			exp: tcExpected{
-				err: model.ErrUnsupportedCredType,
-			},
-		},
-
-		{
 			name: "error_get_policy",
 			given: tcGiven{
-				item: &model.OrderItem{
-					CredentialType: timeLimitedV2,
-				},
-			},
-			exp: tcExpected{
-				err: model.ErrNoExtensionPolicy,
-			},
-		},
-
-		{
-			name: "error_extension_max_per_item",
-			given: tcGiven{
-				item: &model.OrderItem{
-					NumSelfExtensions: 1,
-					SKUVnt:            "some_sku",
-					CredentialType:    timeLimitedV2,
-				},
-				policies: model.CredExtensionPolicies{
-					"some_sku": model.CredExtensionPolicy{
-						MaxPerItem: 1,
+				policies: &mockPolicyStore{
+					fnGetPolicy: func(item *OrderItem) (model.CredExtensionPolicy, error) {
+						return model.CredExtensionPolicy{}, model.Error("error_get_policy")
 					},
 				},
 			},
 			exp: tcExpected{
-				err: model.ErrExtensionMaxPerItem,
-			},
-		},
-
-		{
-			name: "error_check_next_allowed_extension_time",
-			given: tcGiven{
-				item: &model.OrderItem{
-					NumSelfExtensions:   1,
-					LastSelfExtensionAt: ptrTo(time.Date(2026, 06, 06, 0, 0, 0, 0, time.UTC)),
-					SKUVnt:              "some_sku",
-					CredentialType:      timeLimitedV2,
-				},
-				policies: model.CredExtensionPolicies{
-					"some_sku": model.CredExtensionPolicy{
-						MaxPerItem:         2,
-						MinIntervalSeconds: 1,
-					},
-				},
-			},
-			exp: tcExpected{
-				err: model.ErrExtensionRateLimited,
+				err: model.Error("error_get_policy"),
 			},
 		},
 
@@ -355,42 +307,12 @@ func TestTlV2CredExtender_GetNextExtIfValid(t *testing.T) {
 		},
 
 		{
-			name: "error_active_not_at_limit",
-			given: tcGiven{
-				item: &model.OrderItem{
-					NumSelfExtensions: 1,
-					SKUVnt:            "some_sku",
-					CredentialType:    timeLimitedV2,
-				},
-				policies: model.CredExtensionPolicies{
-					"some_sku": model.CredExtensionPolicy{
-						MaxPerItem: 2,
-					},
-				},
-				tlv2Repo: &repository.MockTLV2{
-					FnUniqBatches: func(ctx context.Context, dbi sqlx.QueryerContext, orderID, itemID uuid.UUID, from, to time.Time) (int, error) {
-						return 0, nil
-					},
-				},
-			},
-			exp: tcExpected{
-				err: model.ErrExtensionNotAtLimit,
-			},
-		},
-
-		{
 			name: "success",
 			given: tcGiven{
-				item: &model.OrderItem{
-					MaxActiveBatchesTLV2Creds: ptrTo(13),
-					NumSelfExtensions:         1,
-					SKUVnt:                    "some_sku",
-					CredentialType:            timeLimitedV2,
-				},
-				policies: model.CredExtensionPolicies{
-					"some_sku": model.CredExtensionPolicy{
-						SlotsPerGrant: 3,
-						MaxPerItem:    2,
+				item: &model.OrderItem{CredentialType: "time-limited-v2", MaxActiveBatchesTLV2Creds: ptrTo(100)},
+				policies: &mockPolicyStore{
+					fnGetPolicy: func(item *OrderItem) (model.CredExtensionPolicy, error) {
+						return model.CredExtensionPolicy{SlotsPerGrant: 1}, nil
 					},
 				},
 				tlv2Repo: &repository.MockTLV2{
@@ -400,10 +322,7 @@ func TestTlV2CredExtender_GetNextExtIfValid(t *testing.T) {
 				},
 			},
 			exp: tcExpected{
-				nxt: NextExtension{
-					maxActiveBatches: 16,
-					numSelfExt:       2,
-				},
+				ext: model.NewCredExtension(model.CredExtensionPolicy{SlotsPerGrant: 1}, model.ExtensionState{Item: &model.OrderItem{CredentialType: "time-limited-v2", MaxActiveBatchesTLV2Creds: ptrTo(100)}, ActiveBatches: 13, Limit: 100}, time.Time{}),
 			},
 		},
 	}
@@ -419,93 +338,24 @@ func TestTlV2CredExtender_GetNextExtIfValid(t *testing.T) {
 
 			ctx := context.Background()
 
-			actual, err := ext.GetNextExtIfValid(ctx, nil, tc.given.item, tc.given.now)
+			actual, err := ext.GetExtensionFor(ctx, nil, tc.given.item, tc.given.now)
 			must.ErrorIs(t, err, tc.exp.err)
 
-			should.Equal(t, tc.exp.nxt, actual)
+			should.Equal(t, tc.exp.ext, actual)
 		})
 	}
 }
 
-func TestCheckNextAllowedExtensionTime(t *testing.T) {
-	type tcGiven struct {
-		pol  model.CredExtensionPolicy
-		item *model.OrderItem
-		now  time.Time
+type mockPolicyStore struct {
+	fnGetPolicy func(item *OrderItem) (model.CredExtensionPolicy, error)
+}
+
+func (s *mockPolicyStore) GetPolicy(item *OrderItem) (model.CredExtensionPolicy, error) {
+	if s.fnGetPolicy == nil {
+		return model.CredExtensionPolicy{}, nil
 	}
 
-	type tcExpected struct {
-		err error
-	}
-
-	type testCase struct {
-		name  string
-		given tcGiven
-		exp   tcExpected
-	}
-
-	tests := []testCase{
-		{
-			name: "last_self_extension_at_nil",
-			given: tcGiven{
-				item: &model.OrderItem{},
-			},
-		},
-
-		{
-			name: "now_before_next_allowed",
-			given: tcGiven{
-				pol: model.CredExtensionPolicy{
-					MinIntervalSeconds: 1,
-				},
-				item: &model.OrderItem{
-					LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 10, 0, time.UTC)),
-				},
-				now: time.Date(2026, 1, 1, 1, 1, 1, 0, time.UTC),
-			},
-			exp: tcExpected{
-				err: model.ErrExtensionRateLimited,
-			},
-		},
-
-		{
-			name: "now_same_as_next_allowed",
-			given: tcGiven{
-				pol: model.CredExtensionPolicy{
-					MinIntervalSeconds: 1,
-				},
-				item: &model.OrderItem{
-					LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 10, 0, time.UTC)),
-				},
-				now: time.Date(2026, 1, 1, 1, 1, 10, 0, time.UTC),
-			},
-			exp: tcExpected{
-				err: model.ErrExtensionRateLimited,
-			},
-		},
-
-		{
-			name: "now_after_next_allowed",
-			given: tcGiven{
-				pol: model.CredExtensionPolicy{
-					MinIntervalSeconds: 1,
-				},
-				item: &model.OrderItem{
-					LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 10, 0, time.UTC)),
-				},
-				now: time.Date(2026, 1, 1, 1, 1, 30, 0, time.UTC),
-			},
-		},
-	}
-
-	for i := range tests {
-		tc := tests[i]
-
-		t.Run(tc.name, func(t *testing.T) {
-			actual := checkNextAllowedExtensionTime(tc.given.pol, tc.given.item, tc.given.now)
-			should.Equal(t, tc.exp.err, actual)
-		})
-	}
+	return s.fnGetPolicy(item)
 }
 
 func genNumStrings(n int) []string {

--- a/services/skus/handler/cred.go
+++ b/services/skus/handler/cred.go
@@ -21,7 +21,7 @@ type tlv2Svc interface {
 	DeleteBatches(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
 	ExtendLinkingLimit(ctx context.Context, orderID, itemID uuid.UUID, write model.ExtensionWrite) error
 	ExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error
-	CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error
+	CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error)
 }
 
 type Cred struct {
@@ -319,6 +319,11 @@ func (h *Cred) ExtendLinkingLimitWithReceipt(w http.ResponseWriter, r *http.Requ
 	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
 }
 
+type canExtendLinkingLimitWithReceiptResp struct {
+	AtLimit   bool `json:"at_limit"`
+	CanExtend bool `json:"can_extend"`
+}
+
 func (h *Cred) CanExtendLinkingLimitWithReceipt(w http.ResponseWriter, r *http.Request) *handlers.AppError {
 	ctx := r.Context()
 
@@ -345,7 +350,8 @@ func (h *Cred) CanExtendLinkingLimitWithReceipt(w http.ResponseWriter, r *http.R
 		return handlers.WrapErrorWithErrorCode(err, "failed to parse request body", http.StatusBadRequest, model.ExtensionCodeMalformedBody)
 	}
 
-	if err := h.tlv2.CanExtendLinkingLimitWithReceipt(ctx, orderID, req); err != nil {
+	credExt, err := h.tlv2.CanExtendLinkingLimitWithReceipt(ctx, orderID, req)
+	if err != nil {
 		lg.Error().Err(err).Msg("failed to check can extend linking limit")
 
 		switch {
@@ -373,15 +379,6 @@ func (h *Cred) CanExtendLinkingLimitWithReceipt(w http.ResponseWriter, r *http.R
 		case errors.Is(err, model.ErrNoExtensionPolicy):
 			return handlers.WrapErrorWithErrorCode(err, "item does not support extension", http.StatusUnprocessableEntity, model.ExtensionNotSupported)
 
-		case errors.Is(err, model.ErrExtensionRateLimited):
-			return handlers.WrapErrorWithErrorCode(err, "extension rate limited", http.StatusTooManyRequests, model.ExtensionCodeRateLimited)
-
-		case errors.Is(err, model.ErrExtensionMaxPerItem):
-			return handlers.WrapErrorWithErrorCode(err, "max extensions per item reached", http.StatusUnprocessableEntity, model.ExtensionCodeMaxPerItem)
-
-		case errors.Is(err, model.ErrExtensionNotAtLimit):
-			return handlers.WrapErrorWithErrorCode(err, "not at limit; extension not needed", http.StatusUnprocessableEntity, model.ExtensionCodeNotAtLimit)
-
 		default:
 			if rverr := new(model.ReceiptValidError); errors.As(err, &rverr) {
 				return model.HandleReceiptErr(rverr.Err)
@@ -391,7 +388,12 @@ func (h *Cred) CanExtendLinkingLimitWithReceipt(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	return handlers.RenderContent(ctx, struct{}{}, w, http.StatusOK)
+	resp := canExtendLinkingLimitWithReceiptResp{
+		AtLimit:   credExt.AtLimit(),
+		CanExtend: credExt.CanExtend(),
+	}
+
+	return handlers.RenderContent(ctx, resp, w, http.StatusOK)
 }
 
 // Deprecated: use handlers.WrapErrorWithErrorCode

--- a/services/skus/handler/cred_test.go
+++ b/services/skus/handler/cred_test.go
@@ -1,4 +1,4 @@
-package handler_test
+package handler
 
 import (
 	"bytes"
@@ -18,7 +18,6 @@ import (
 
 	"github.com/brave-intl/bat-go/libs/handlers"
 
-	"github.com/brave-intl/bat-go/services/skus/handler"
 	"github.com/brave-intl/bat-go/services/skus/model"
 )
 
@@ -28,7 +27,7 @@ type mockTLV2Svc struct {
 	FnDeleteBatches                    func(ctx context.Context, orderID, itemID uuid.UUID, seats int) error
 	FnExtendLinkingLimit               func(ctx context.Context, orderID, itemID uuid.UUID, write model.ExtensionWrite) error
 	FnExtendLinkingLimitWithReceipt    func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error
-	FnCanExtendLinkingLimitWithReceipt func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error
+	FnCanExtendLinkingLimitWithReceipt func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error)
 }
 
 func (s *mockTLV2Svc) ExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
@@ -39,9 +38,9 @@ func (s *mockTLV2Svc) ExtendLinkingLimitWithReceipt(ctx context.Context, orderID
 	return s.FnExtendLinkingLimitWithReceipt(ctx, orderID, req)
 }
 
-func (s *mockTLV2Svc) CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
+func (s *mockTLV2Svc) CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
 	if s.FnCanExtendLinkingLimitWithReceipt == nil {
-		return nil
+		return model.CredExtension{}, nil
 	}
 
 	return s.FnCanExtendLinkingLimitWithReceipt(ctx, orderID, req)
@@ -280,7 +279,7 @@ func TestCred_CountBatches(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			h := handler.NewCred(tc.given.svc)
+			h := NewCred(tc.given.svc)
 
 			req := httptest.NewRequest(http.MethodGet, "http://localhost", nil)
 			req = req.WithContext(tc.given.ctx)
@@ -511,7 +510,7 @@ func TestCred_ListActiveBatches(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			h := handler.NewCred(tc.given.svc)
+			h := NewCred(tc.given.svc)
 
 			target := "http://localhost"
 			if tc.given.itemID != "" {
@@ -739,7 +738,7 @@ func TestCred_DeleteBatches(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			h := handler.NewCred(tc.given.svc)
+			h := NewCred(tc.given.svc)
 
 			req := httptest.NewRequest(http.MethodDelete, "http://localhost", strings.NewReader(tc.given.body))
 			req = req.WithContext(tc.given.ctx)
@@ -993,7 +992,7 @@ func TestCred_ExtendLinkingLimit(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			h := handler.NewCred(tc.given.svc)
+			h := NewCred(tc.given.svc)
 
 			var body io.Reader = strings.NewReader(tc.given.body)
 			if tc.given.bodyReader != nil {
@@ -1551,7 +1550,7 @@ func TestCred_ExtendLinkingLimitWithReceipt(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			ch := handler.NewCred(tc.given.svc)
+			ch := NewCred(tc.given.svc)
 
 			r := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewBufferString(tc.given.body))
 			r = r.WithContext(tc.given.ctx)
@@ -1591,6 +1590,7 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 
 	type tcExpected struct {
 		code int
+		resp canExtendLinkingLimitWithReceiptResp
 		err  *appErrorExp
 	}
 
@@ -1653,8 +1653,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return context.Canceled
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, context.Canceled
 					},
 				},
 			},
@@ -1681,8 +1681,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return context.DeadlineExceeded
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, context.DeadlineExceeded
 					},
 				},
 			},
@@ -1709,8 +1709,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrNoMatchOrderReceipt
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrNoMatchOrderReceipt
 					},
 				},
 			},
@@ -1737,8 +1737,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrOrderNotFound
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrOrderNotFound
 					},
 				},
 			},
@@ -1766,8 +1766,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrInvalidOrderNoItems
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrInvalidOrderNoItems
 					},
 				},
 			},
@@ -1795,8 +1795,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrOrderItemNotFound
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrOrderItemNotFound
 					},
 				},
 			},
@@ -1824,8 +1824,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrOrderNotPaid
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrOrderNotPaid
 					},
 				},
 			},
@@ -1853,8 +1853,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrUnsupportedCredType
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrUnsupportedCredType
 					},
 				},
 			},
@@ -1882,8 +1882,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrExtensionInvalidLimit
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrExtensionInvalidLimit
 					},
 				},
 			},
@@ -1911,8 +1911,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrNoExtensionPolicy
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrNoExtensionPolicy
 					},
 				},
 			},
@@ -1930,93 +1930,6 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 		},
 
 		{
-			name: "error_extension_rate_limited",
-			given: tcGiven{
-				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
-					URLParams: chi.RouteParams{
-						Keys:   []string{"orderID"},
-						Values: []string{"facade00-0000-4000-a000-000000000000"},
-					},
-				}),
-				body: "{}",
-				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrExtensionRateLimited
-					},
-				},
-			},
-			exp: tcExpected{
-				code: http.StatusTooManyRequests,
-				err: &appErrorExp{
-					code:    http.StatusTooManyRequests,
-					errCode: model.ExtensionCodeRateLimited,
-					message: "extension rate limited",
-					mustCause: func(t must.TestingT, err error, i ...interface{}) {
-						must.ErrorIs(t, err, model.ErrExtensionRateLimited)
-					},
-				},
-			},
-		},
-
-		{
-			name: "error_max_extension_per_item_reached",
-			given: tcGiven{
-				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
-					URLParams: chi.RouteParams{
-						Keys:   []string{"orderID"},
-						Values: []string{"facade00-0000-4000-a000-000000000000"},
-					},
-				}),
-				body: "{}",
-				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrExtensionMaxPerItem
-					},
-				},
-			},
-			exp: tcExpected{
-				code: http.StatusUnprocessableEntity,
-				err: &appErrorExp{
-					code:    http.StatusUnprocessableEntity,
-					errCode: model.ExtensionCodeMaxPerItem,
-					message: "max extensions per item reached",
-					mustCause: func(t must.TestingT, err error, i ...interface{}) {
-						must.ErrorIs(t, err, model.ErrExtensionMaxPerItem)
-					},
-				},
-			},
-		},
-
-		{
-			name: "error_extension_not_at_limit",
-			given: tcGiven{
-				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
-					URLParams: chi.RouteParams{
-						Keys:   []string{"orderID"},
-						Values: []string{"facade00-0000-4000-a000-000000000000"},
-					},
-				}),
-				body: "{}",
-				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrExtensionNotAtLimit
-					},
-				},
-			},
-			exp: tcExpected{
-				code: http.StatusUnprocessableEntity,
-				err: &appErrorExp{
-					code:    http.StatusUnprocessableEntity,
-					errCode: model.ExtensionCodeNotAtLimit,
-					message: "not at limit; extension not needed",
-					mustCause: func(t must.TestingT, err error, i ...interface{}) {
-						must.ErrorIs(t, err, model.ErrExtensionNotAtLimit)
-					},
-				},
-			},
-		},
-
-		{
 			name: "error_receipt_valid_error",
 			given: tcGiven{
 				ctx: context.WithValue(context.Background(), chi.RouteCtxKey, &chi.Context{
@@ -2027,8 +1940,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return &model.ReceiptValidError{Err: model.Error("some_error")}
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, &model.ReceiptValidError{Err: model.Error("some_error")}
 					},
 				},
 			},
@@ -2057,8 +1970,8 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: "{}",
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
-						return model.ErrSomethingWentWrong
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
+						return model.CredExtension{}, model.ErrSomethingWentWrong
 					},
 				},
 			},
@@ -2085,33 +1998,37 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				}),
 				body: `{ "type": "some_type", "raw_receipt": "blob", "package": "package", "subscription_id": "subscription_id" }`,
 				svc: &mockTLV2Svc{
-					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
+					FnCanExtendLinkingLimitWithReceipt: func(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
 						if orderID.String() != "facade00-0000-4000-a000-000000000000" {
-							return model.Error("unexpected_order_id")
+							return model.CredExtension{}, model.Error("unexpected_order_id")
 						}
 
 						if req.Type != "some_type" {
-							return model.Error("unexpected_type")
+							return model.CredExtension{}, model.Error("unexpected_type")
 						}
 
 						if req.Blob != "blob" {
-							return model.Error("unexpected_blob")
+							return model.CredExtension{}, model.Error("unexpected_blob")
 						}
 
 						if req.Package != "package" {
-							return model.Error("unexpected_package")
+							return model.CredExtension{}, model.Error("unexpected_package")
 						}
 
 						if req.SubscriptionID != "subscription_id" {
-							return model.Error("unexpected_subscription_id")
+							return model.CredExtension{}, model.Error("unexpected_subscription_id")
 						}
 
-						return nil
+						return model.CredExtension{}, nil
 					},
 				},
 			},
 			exp: tcExpected{
 				code: http.StatusOK,
+				resp: canExtendLinkingLimitWithReceiptResp{
+					AtLimit:   false,
+					CanExtend: false,
+				},
 			},
 		},
 	}
@@ -2120,12 +2037,13 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 		tc := tests[i]
 
 		t.Run(tc.name, func(t *testing.T) {
-			ch := handler.NewCred(tc.given.svc)
+			ch := NewCred(tc.given.svc)
 
 			r := httptest.NewRequest(http.MethodGet, "http://localhost", bytes.NewBufferString(tc.given.body))
 			r = r.WithContext(tc.given.ctx)
 
 			rw := httptest.NewRecorder()
+			rw.Header().Set("content-type", "application/json")
 
 			aerr := ch.CanExtendLinkingLimitWithReceipt(rw, r)
 
@@ -2136,9 +2054,16 @@ func TestCred_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 				must.Contains(t, tc.exp.err.message, aerr.Message)
 				must.Equal(t, tc.exp.err.data, aerr.Data)
 				tc.exp.err.mustCause(t, aerr.Cause)
+				return
 			}
 
 			should.Equal(t, tc.exp.code, rw.Code)
+
+			var resp canExtendLinkingLimitWithReceiptResp
+			err := json.Unmarshal(rw.Body.Bytes(), &resp)
+			must.NoError(t, err)
+
+			should.Equal(t, tc.exp.resp, resp)
 		})
 	}
 }

--- a/services/skus/model/credextension.go
+++ b/services/skus/model/credextension.go
@@ -1,0 +1,132 @@
+package model
+
+import (
+	"time"
+)
+
+const (
+	// ExtensionMaxLimitCeiling Hard sanity ceiling enforced by DB CHECK on max_active_batches_tlv2_creds.
+	ExtensionMaxLimitCeiling = 1000
+
+	ExtensionCodeMalformedBody       = "malformed_body"
+	ExtensionCodeOrderNotFound       = "order_not_found"
+	ExtensionCodeOrderNotPaid        = "order_not_paid"
+	ExtensionCodeUnsupportedCredType = "unsupported_cred_type"
+	ExtensionCodeConflict            = "extension_conflict"
+
+	// Deprecated: will be replaced by ExtensionCodeInvalidLimitX
+	ExtensionCodeInvalidLimit = "extension_invalid_limit"
+
+	ExtensionCodeInvalidLimitX = "invalid_limit"
+	ExtensionCodeRateLimited   = "rate_limited"
+	ExtensionCodeMaxPerItem    = "max_per_item"
+	ExtensionCodeNotAtLimit    = "not_at_limit"
+	ExtensionNotSupported      = "extension_not_supported"
+
+	ErrNoExtensionPolicy    Error = "model: extension: no policy"
+	ErrExtensionRateLimited Error = "model: extension: rate limited"
+	ErrExtensionMaxPerItem  Error = "model: extension: max per item reached"
+	ErrExtensionNotAtLimit  Error = "model: extension: not at limit"
+	ErrExtensionStateItem   Error = "model: cred extension item nil"
+)
+
+type CredExtensionPolicy struct {
+	SlotsPerGrant      int
+	MinIntervalSeconds int
+	MaxPerItem         int
+}
+
+type CredExtensionPolicies map[string]CredExtensionPolicy
+
+func NewPoliciesBySKUVnt() CredExtensionPolicies {
+	origin := CredExtensionPolicy{
+		SlotsPerGrant:      3,
+		MinIntervalSeconds: 30 * 24 * 60 * 60, // 30 Days.
+		MaxPerItem:         5,
+	}
+
+	return CredExtensionPolicies{
+		"brave-origin-premium-perpetual-license": origin,
+	}
+}
+
+func (s CredExtensionPolicies) GetPolicy(item *OrderItem) (CredExtensionPolicy, error) {
+	if !item.IsCredTLV2() {
+		return CredExtensionPolicy{}, ErrUnsupportedCredType
+	}
+
+	p, ok := s[item.SKUVnt]
+	if !ok {
+		return CredExtensionPolicy{}, ErrNoExtensionPolicy
+	}
+
+	return p, nil
+}
+
+type ExtensionState struct {
+	Item          *OrderItem
+	ActiveBatches int
+	Limit         int
+}
+
+func (s ExtensionState) AtLimit() bool {
+	return s.ActiveBatches >= s.Limit
+}
+
+type CredExtension struct {
+	pol CredExtensionPolicy
+	st  ExtensionState
+	now time.Time
+}
+
+func NewCredExtension(pol CredExtensionPolicy, st ExtensionState, now time.Time) CredExtension {
+	return CredExtension{pol: pol, st: st, now: now}
+}
+
+type ExtensionGrant struct {
+	NextMaxActiveBatchLimit int
+	NextNumSelfExt          int
+}
+
+func (x CredExtension) AtLimit() bool {
+	return x.st.Item != nil && x.st.AtLimit()
+}
+
+func (x CredExtension) CanExtend() bool {
+	_, err := x.Grant()
+
+	return err == nil
+}
+
+func (x CredExtension) Grant() (ExtensionGrant, error) {
+	if x.st.Item == nil {
+		return ExtensionGrant{}, ErrExtensionStateItem
+	}
+
+	switch {
+	case x.st.Item.NumSelfExtensions >= x.pol.MaxPerItem:
+		return ExtensionGrant{}, ErrExtensionMaxPerItem
+
+	case x.rateLimited():
+		return ExtensionGrant{}, ErrExtensionRateLimited
+
+	case !x.st.AtLimit():
+		return ExtensionGrant{}, ErrExtensionNotAtLimit
+
+	default:
+		return ExtensionGrant{
+			NextMaxActiveBatchLimit: x.st.Limit + x.pol.SlotsPerGrant,
+			NextNumSelfExt:          x.st.Item.NumSelfExtensions + 1,
+		}, nil
+	}
+}
+
+func (x CredExtension) rateLimited() bool {
+	if x.st.Item.LastSelfExtensionAt == nil {
+		return false
+	}
+
+	nextAllowed := x.st.Item.LastSelfExtensionAt.Add(time.Duration(x.pol.MinIntervalSeconds) * time.Second)
+
+	return x.now.Before(nextAllowed)
+}

--- a/services/skus/model/credextension_test.go
+++ b/services/skus/model/credextension_test.go
@@ -1,0 +1,454 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	should "github.com/stretchr/testify/assert"
+)
+
+func TestCredExtensionPolicies_GetPolicy(t *testing.T) {
+	type tcGiven struct {
+		item *OrderItem
+	}
+
+	type tcExpected struct {
+		pol CredExtensionPolicy
+		err error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "error_unsupported_cred_type",
+			given: tcGiven{
+				item: &OrderItem{},
+			},
+			exp: tcExpected{
+				err: ErrUnsupportedCredType,
+			},
+		},
+
+		{
+			name: "error_no_extension_policy",
+			given: tcGiven{
+				item: &OrderItem{CredentialType: "time-limited-v2"},
+			},
+			exp: tcExpected{
+				err: ErrNoExtensionPolicy,
+			},
+		},
+
+		{
+			name: "success_origin_policy",
+			given: tcGiven{
+				item: &OrderItem{SKUVnt: "brave-origin-premium-perpetual-license", CredentialType: "time-limited-v2"},
+			},
+			exp: tcExpected{
+				pol: CredExtensionPolicy{
+					SlotsPerGrant:      3,
+					MinIntervalSeconds: 30 * 24 * 60 * 60, // 30 Days.
+					MaxPerItem:         5,
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			policies := NewPoliciesBySKUVnt()
+
+			actual, err := policies.GetPolicy(tc.given.item)
+			should.ErrorIs(t, err, tc.exp.err)
+			should.Equal(t, tc.exp.pol, actual)
+		})
+	}
+}
+
+func TestExtensionState_AtLimit(t *testing.T) {
+	type tcGiven struct {
+		st ExtensionState
+	}
+
+	type tcExpected struct {
+		atLimit bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "not_at_limit",
+			given: tcGiven{
+				st: ExtensionState{
+					ActiveBatches: 0,
+					Limit:         1,
+				},
+			},
+		},
+
+		{
+			name: "at_limit_equal",
+			given: tcGiven{
+				st: ExtensionState{
+					ActiveBatches: 1,
+					Limit:         1,
+				},
+			},
+			exp: tcExpected{atLimit: true},
+		},
+
+		{
+			name: "at_limit_greater_than",
+			given: tcGiven{
+				st: ExtensionState{
+					ActiveBatches: 2,
+					Limit:         1,
+				},
+			},
+			exp: tcExpected{atLimit: true},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.given.st.AtLimit()
+			should.Equal(t, tc.exp.atLimit, actual)
+		})
+	}
+}
+
+func TestCredExtension_AtLimit(t *testing.T) {
+	type tcGiven struct {
+		pol CredExtensionPolicy
+		st  ExtensionState
+		now time.Time
+	}
+
+	type tcExpected struct {
+		atLimit bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "not_at_limit_item_nil",
+		},
+
+		{
+			name: "not_at_limit_state",
+			given: tcGiven{
+				st: ExtensionState{
+					Item:          &OrderItem{},
+					ActiveBatches: 1,
+					Limit:         2,
+				},
+			},
+		},
+
+		{
+			name: "at_limit_state",
+			given: tcGiven{
+				st: ExtensionState{
+					Item:          &OrderItem{},
+					ActiveBatches: 2,
+					Limit:         2,
+				},
+			},
+			exp: tcExpected{
+				atLimit: true,
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ext := NewCredExtension(tc.given.pol, tc.given.st, tc.given.now)
+
+			actual := ext.AtLimit()
+			should.Equal(t, tc.exp.atLimit, actual)
+		})
+	}
+}
+
+func TestCredExtension_CanExtend(t *testing.T) {
+	type tcGiven struct {
+		pol CredExtensionPolicy
+		st  ExtensionState
+		now time.Time
+	}
+
+	type tcExpected struct {
+		canExt bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "false",
+		},
+
+		{
+			name: "true",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MaxPerItem: 1,
+				},
+				st: ExtensionState{
+					Item:          &OrderItem{},
+					ActiveBatches: 1,
+					Limit:         2,
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ext := NewCredExtension(tc.given.pol, tc.given.st, tc.given.now)
+
+			actual := ext.CanExtend()
+			should.Equal(t, tc.exp.canExt, actual)
+		})
+	}
+}
+
+func TestCredExtension_Grant(t *testing.T) {
+	type tcGiven struct {
+		pol CredExtensionPolicy
+		st  ExtensionState
+		now time.Time
+	}
+
+	type tcExpected struct {
+		grant ExtensionGrant
+		err   error
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "item_nil",
+			exp: tcExpected{
+				err: ErrExtensionStateItem,
+			},
+		},
+
+		{
+			name: "self_ext_equal_to_max",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MaxPerItem: 1,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						NumSelfExtensions: 1,
+					},
+				},
+			},
+			exp: tcExpected{
+				err: ErrExtensionMaxPerItem,
+			},
+		},
+
+		{
+			name: "self_ext_greater_than_max",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MaxPerItem: 1,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						NumSelfExtensions: 2,
+					},
+				},
+			},
+			exp: tcExpected{
+				err: ErrExtensionMaxPerItem,
+			},
+		},
+
+		{
+			name: "rate_limited",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MaxPerItem:         2,
+					MinIntervalSeconds: 10,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						NumSelfExtensions:   1,
+						LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 10, 1, time.UTC)),
+					},
+				},
+				now: time.Date(2026, 1, 1, 1, 1, 0, 1, time.UTC),
+			},
+			exp: tcExpected{
+				err: ErrExtensionRateLimited,
+			},
+		},
+
+		{
+			name: "ext_not_at_limit",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MaxPerItem: 2,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						NumSelfExtensions: 1,
+					},
+					ActiveBatches: 1,
+					Limit:         2,
+				},
+			},
+			exp: tcExpected{
+				err: ErrExtensionNotAtLimit,
+			},
+		},
+
+		{
+			name: "success",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					SlotsPerGrant: 3,
+					MaxPerItem:    2,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						NumSelfExtensions: 1,
+					},
+					ActiveBatches: 2,
+					Limit:         2,
+				},
+			},
+			exp: tcExpected{
+				grant: ExtensionGrant{
+					NextMaxActiveBatchLimit: 5,
+					NextNumSelfExt:          2,
+				},
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ext := NewCredExtension(tc.given.pol, tc.given.st, tc.given.now)
+
+			actual, err := ext.Grant()
+			should.Equal(t, tc.exp.grant, actual)
+			should.ErrorIs(t, err, tc.exp.err)
+		})
+	}
+}
+
+func TestCredExtension_rateLimited(t *testing.T) {
+	type tcGiven struct {
+		pol CredExtensionPolicy
+		st  ExtensionState
+		now time.Time
+	}
+
+	type tcExpected struct {
+		rateLimited bool
+	}
+
+	type testCase struct {
+		name  string
+		given tcGiven
+		exp   tcExpected
+	}
+
+	tests := []testCase{
+		{
+			name: "rate_limited_last_self_ext_at_nil",
+			given: tcGiven{
+				st: ExtensionState{
+					Item: &OrderItem{},
+				},
+			},
+		},
+
+		{
+			name: "rate_limited_time_before",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MinIntervalSeconds: 10,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 1, 1, time.UTC)),
+					},
+				},
+				now: time.Date(2026, 1, 1, 1, 1, 1, 1, time.UTC),
+			},
+			exp: tcExpected{
+				rateLimited: true,
+			},
+		},
+
+		{
+			name: "not_rate_limited_time_after",
+			given: tcGiven{
+				pol: CredExtensionPolicy{
+					MinIntervalSeconds: 10,
+				},
+				st: ExtensionState{
+					Item: &OrderItem{
+						LastSelfExtensionAt: ptrTo(time.Date(2026, 1, 1, 1, 1, 1, 1, time.UTC)),
+					},
+				},
+				now: time.Date(2026, 1, 1, 1, 1, 20, 1, time.UTC),
+			},
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			ext := NewCredExtension(tc.given.pol, tc.given.st, tc.given.now)
+
+			actual := ext.rateLimited()
+			should.Equal(t, tc.exp.rateLimited, actual)
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/services/skus/model/model.go
+++ b/services/skus/model/model.go
@@ -70,11 +70,6 @@ const (
 	errInvalidNumConversion Error = "model: invalid numeric conversion"
 
 	ErrStripePaymentIntentMissing Error = "model: stripe payment intent id missing"
-
-	ErrNoExtensionPolicy    Error = "model: extension: no policy"
-	ErrExtensionRateLimited Error = "model: extension: rate limited"
-	ErrExtensionMaxPerItem  Error = "model: extension: max per item reached"
-	ErrExtensionNotAtLimit  Error = "model: extension: not at limit"
 )
 
 const (
@@ -93,26 +88,6 @@ const (
 	issuerBufferDefault              = 30
 	issuerOverlapDefault             = 5
 	MaxActiveBatchesTLV2CredsDefault = 10
-)
-
-// Hard sanity ceiling enforced by DB CHECK on max_active_batches_tlv2_creds.
-const ExtensionMaxLimitCeiling = 1000
-
-const (
-	ExtensionCodeMalformedBody       = "malformed_body"
-	ExtensionCodeOrderNotFound       = "order_not_found"
-	ExtensionCodeOrderNotPaid        = "order_not_paid"
-	ExtensionCodeUnsupportedCredType = "unsupported_cred_type"
-	ExtensionCodeConflict            = "extension_conflict"
-
-	// Deprecated: will be replaced by ExtensionCodeInvalidLimitX
-	ExtensionCodeInvalidLimit = "extension_invalid_limit"
-
-	ExtensionCodeInvalidLimitX = "invalid_limit"
-	ExtensionCodeRateLimited   = "rate_limited"
-	ExtensionCodeMaxPerItem    = "max_per_item"
-	ExtensionCodeNotAtLimit    = "not_at_limit"
-	ExtensionNotSupported      = "extension_not_supported"
 )
 
 const (
@@ -911,35 +886,6 @@ type VerifyCredentialOpaque struct {
 type SetTrialDaysRequest struct {
 	Email     string `json:"email"` // TODO: Make it required.
 	TrialDays int64  `json:"trialDays"`
-}
-
-type CredExtensionPolicy struct {
-	SlotsPerGrant      int
-	MinIntervalSeconds int
-	MaxPerItem         int
-}
-
-type CredExtensionPolicies map[string]CredExtensionPolicy
-
-func NewPoliciesBySKUVnt() CredExtensionPolicies {
-	origin := CredExtensionPolicy{
-		SlotsPerGrant:      3,
-		MinIntervalSeconds: 30 * 24 * 60 * 60, // 30 Days.
-		MaxPerItem:         5,
-	}
-
-	return CredExtensionPolicies{
-		"brave-origin-premium-perpetual-license": origin,
-	}
-}
-
-func (s CredExtensionPolicies) GetPolicy(id string) (CredExtensionPolicy, error) {
-	p, ok := s[id]
-	if !ok {
-		return CredExtensionPolicy{}, ErrNoExtensionPolicy
-	}
-
-	return p, nil
 }
 
 func addURLParam(src, name, val string) (string, error) {

--- a/services/skus/service.go
+++ b/services/skus/service.go
@@ -146,7 +146,7 @@ type radomMessageAuthenticator interface {
 }
 
 type credExtender interface {
-	GetNextExtIfValid(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error)
+	GetExtensionFor(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error)
 }
 
 type Service struct {
@@ -1511,50 +1511,49 @@ func (s *Service) increaseMaxActiveBatches(ctx context.Context, dbi sqlx.ExtCont
 		return err
 	}
 
-	nxt, err := s.credExtender.GetNextExtIfValid(ctx, dbi, item, now)
+	credExt, err := s.credExtender.GetExtensionFor(ctx, dbi, item, now)
 	if err != nil {
 		return err
 	}
 
-	return s.orderItemRepo.UpdateMaxActiveBatchesTLV2Creds(ctx, dbi, item.ID, nxt.maxActiveBatches, nxt.numSelfExt, now)
+	grant, err := credExt.Grant()
+	if err != nil {
+		return err
+	}
+
+	return s.orderItemRepo.UpdateMaxActiveBatchesTLV2Creds(ctx, dbi, item.ID, grant.NextMaxActiveBatchLimit, grant.NextNumSelfExt, now)
 }
 
-func (s *Service) CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) error {
+func (s *Service) CanExtendLinkingLimitWithReceipt(ctx context.Context, orderID uuid.UUID, req model.ReceiptRequest) (model.CredExtension, error) {
 	dbi := s.Datastore.RawDB()
 
-	return s.canExtendLinkingLimitWithReceiptTx(ctx, dbi, orderID, req)
+	return s.canExtendLinkingLimitWithReceiptTx(ctx, dbi, orderID, req, time.Now())
 }
 
-func (s *Service) canExtendLinkingLimitWithReceiptTx(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID, req model.ReceiptRequest) error {
+func (s *Service) canExtendLinkingLimitWithReceiptTx(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID, req model.ReceiptRequest, now time.Time) (model.CredExtension, error) {
 	if err := s.checkOrderReceiptTx(ctx, dbi, req, orderID); err != nil {
-		return err
+		return model.CredExtension{}, err
 	}
 
 	ord, err := s.getOrderFullTx(ctx, dbi, orderID)
 	if err != nil {
-		return err
+		return model.CredExtension{}, err
 	}
 
 	if !ord.IsPaid() {
-		return model.ErrOrderNotPaid
+		return model.CredExtension{}, model.ErrOrderNotPaid
 	}
 
 	if len(ord.Items) == 0 {
-		return model.ErrInvalidOrderNoItems
+		return model.CredExtension{}, model.ErrInvalidOrderNoItems
 	}
 
-	return s.canIncreaseMaxActiveBatches(ctx, dbi, ord.Items[0].ID, time.Now())
-}
-
-func (s *Service) canIncreaseMaxActiveBatches(ctx context.Context, dbi sqlx.QueryerContext, itemID uuid.UUID, now time.Time) error {
-	item, err := s.orderItemRepo.Get(ctx, dbi, itemID)
+	item, err := s.orderItemRepo.Get(ctx, dbi, ord.Items[0].ID)
 	if err != nil {
-		return err
+		return model.CredExtension{}, err
 	}
 
-	_, err = s.credExtender.GetNextExtIfValid(ctx, dbi, item, now)
-
-	return err
+	return s.credExtender.GetExtensionFor(ctx, dbi, item, now)
 }
 
 func (s *Service) checkOrderReceiptTx(ctx context.Context, dbi sqlx.QueryerContext, req model.ReceiptRequest, orderID uuid.UUID) error {

--- a/services/skus/service_nonint_test.go
+++ b/services/skus/service_nonint_test.go
@@ -8602,7 +8602,7 @@ func TestService_extendLinkingLimitByOrderID(t *testing.T) {
 		},
 
 		{
-			name: "error_get_nxt_if_valid",
+			name: "error_get_extension_for",
 			given: tcGiven{
 				orderID: uuid.Must(uuid.FromString("17614fac-ef87-4120-a231-dfdf55e15823")),
 				orderRepo: &repository.MockOrder{
@@ -8622,13 +8622,45 @@ func TestService_extendLinkingLimitByOrderID(t *testing.T) {
 					},
 				},
 				credExt: &mockCredExtender{
-					fnGetNextExtIfValid: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-						return NextExtension{}, model.Error("error_get_nxt_if_valid")
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+
+						return model.CredExtension{}, model.Error("error_get_extension_for")
 					},
 				},
 			},
 			exp: tcExpected{
-				err: model.Error("error_get_nxt_if_valid"),
+				err: model.Error("error_get_extension_for"),
+			},
+		},
+
+		{
+			name: "error_cred_extension_grant",
+			given: tcGiven{
+				orderID: uuid.Must(uuid.FromString("17614fac-ef87-4120-a231-dfdf55e15823")),
+				orderRepo: &repository.MockOrder{
+					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
+						result := &model.Order{Status: model.OrderStatusPaid}
+
+						return result, nil
+					},
+				},
+				orderItemRepo: &repository.MockOrderItem{
+					FnFindByOrderID: func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error) {
+						return []model.OrderItem{{}}, nil
+					},
+
+					FnGetForUpdate: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error) {
+						return &model.OrderItem{}, nil
+					},
+				},
+				credExt: &mockCredExtender{
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+						return model.CredExtension{}, nil
+					},
+				},
+			},
+			exp: tcExpected{
+				err: model.ErrExtensionStateItem,
 			},
 		},
 
@@ -8657,8 +8689,14 @@ func TestService_extendLinkingLimitByOrderID(t *testing.T) {
 					},
 				},
 				credExt: &mockCredExtender{
-					fnGetNextExtIfValid: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-						return NextExtension{}, nil
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+						pol := model.CredExtensionPolicy{MaxPerItem: 1}
+
+						st := model.ExtensionState{Item: &model.OrderItem{}}
+
+						ext := model.NewCredExtension(pol, st, time.Date(2026, 9, 26, 0, 0, 0, 0, time.UTC))
+
+						return ext, nil
 					},
 				},
 			},
@@ -8692,8 +8730,14 @@ func TestService_extendLinkingLimitByOrderID(t *testing.T) {
 					},
 				},
 				credExt: &mockCredExtender{
-					fnGetNextExtIfValid: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-						return NextExtension{}, nil
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+						pol := model.CredExtensionPolicy{MaxPerItem: 1}
+
+						st := model.ExtensionState{Item: &model.OrderItem{}}
+
+						ext := model.NewCredExtension(pol, st, time.Date(2026, 9, 26, 0, 0, 0, 0, time.UTC))
+
+						return ext, nil
 					},
 				},
 			},
@@ -8723,6 +8767,7 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 	type tcGiven struct {
 		orderID       uuid.UUID
 		req           model.ReceiptRequest
+		now           time.Time
 		orderRepo     *repository.MockOrder
 		orderItemRepo *repository.MockOrderItem
 		tlv2Repo      *repository.MockTLV2
@@ -8731,7 +8776,8 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 	}
 
 	type tcExpected struct {
-		err error
+		credExt model.CredExtension
+		err     error
 	}
 
 	type testCase struct {
@@ -8914,8 +8960,8 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 					},
 				},
 				credExt: &mockCredExtender{
-					fnGetNextExtIfValid: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-						return NextExtension{}, model.Error("error_get_nxt_ext")
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+						return model.CredExtension{}, model.Error("error_get_nxt_ext")
 					},
 				},
 			},
@@ -8929,6 +8975,7 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 			given: tcGiven{
 				orderID: uuid.Must(uuid.FromString("17614fac-ef87-4120-a231-dfdf55e15823")),
 				req:     model.ReceiptRequest{Type: model.VendorApple},
+				now:     time.Date(2026, 9, 7, 0, 0, 0, 0, time.UTC),
 				orderRepo: &repository.MockOrder{
 					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.Order, error) {
 						return &model.Order{Status: OrderStatusPaid}, nil
@@ -8939,18 +8986,8 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 					},
 				},
 				orderItemRepo: &repository.MockOrderItem{
-					FnFindByOrderID: func(ctx context.Context, dbi sqlx.QueryerContext, orderID uuid.UUID) ([]model.OrderItem, error) {
-						items := []model.OrderItem{
-							{
-								ID: uuid.Must(uuid.FromString("991028c0-94dc-4aca-9812-102a750ff238")),
-							},
-						}
-
-						return items, nil
-					},
-
 					FnGet: func(ctx context.Context, dbi sqlx.QueryerContext, id uuid.UUID) (*model.OrderItem, error) {
-						return &model.OrderItem{}, nil
+						return &model.OrderItem{ID: uuid.Must(uuid.FromString("991028c0-94dc-4aca-9812-102a750ff238"))}, nil
 					},
 				},
 				valReceipt: &mockReceiptValidater{
@@ -8959,11 +8996,14 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 					},
 				},
 				credExt: &mockCredExtender{
-					fnGetNextExtIfValid: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-						return NextExtension{}, nil
+					fnGetExtensionFor: func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+						ext := model.NewCredExtension(model.CredExtensionPolicy{}, model.ExtensionState{Item: item}, now)
+
+						return ext, nil
 					},
 				},
 			},
+			exp: tcExpected{credExt: model.NewCredExtension(model.CredExtensionPolicy{}, model.ExtensionState{Item: &model.OrderItem{ID: uuid.Must(uuid.FromString("991028c0-94dc-4aca-9812-102a750ff238"))}}, time.Date(2026, 9, 7, 0, 0, 0, 0, time.UTC))},
 		},
 	}
 
@@ -8981,8 +9021,9 @@ func TestServer_CanExtendLinkingLimitWithReceipt(t *testing.T) {
 
 			ctx := context.Background()
 
-			actual := s.canExtendLinkingLimitWithReceiptTx(ctx, nil, tc.given.orderID, tc.given.req)
-			should.Equal(t, tc.exp.err, actual)
+			actual, err := s.canExtendLinkingLimitWithReceiptTx(ctx, nil, tc.given.orderID, tc.given.req, tc.given.now)
+			should.Equal(t, tc.exp.credExt, actual)
+			should.Equal(t, tc.exp.err, err)
 		})
 	}
 }
@@ -9018,13 +9059,13 @@ func (v *mockReceiptValidater) fetchSubPlayStore(ctx context.Context, pkgName, s
 }
 
 type mockCredExtender struct {
-	fnGetNextExtIfValid func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error)
+	fnGetExtensionFor func(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error)
 }
 
-func (e *mockCredExtender) GetNextExtIfValid(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (NextExtension, error) {
-	if e.fnGetNextExtIfValid == nil {
-		return NextExtension{}, nil
+func (e *mockCredExtender) GetExtensionFor(ctx context.Context, dbi sqlx.QueryerContext, item *model.OrderItem, now time.Time) (model.CredExtension, error) {
+	if e.fnGetExtensionFor == nil {
+		return model.CredExtension{}, nil
 	}
 
-	return e.fnGetNextExtIfValid(ctx, dbi, item, now)
+	return e.fnGetExtensionFor(ctx, dbi, item, now)
 }


### PR DESCRIPTION
### Summary

In additions to being able to determine whether a client can extend their linking limit mobile clients need to be able to determine it the limit has been reached. This PR adds a can extend and at limit response to the can extend linking limit with receipt endpoint.

<!-- What does this pr do? Use the fixes syntax where possible (fixes #x) -->


### Type of Change

- [ ] Product feature
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactor
- [ ] Other

<!-- Provide link if applicable. -->


### Tested Environments

- [ ] Development
- [ ] Staging
- [ ] Production


### Before Requesting Review

- [ ] Does your code build cleanly without any errors or warnings?
- [ ] Have you used auto closing keywords?
- [ ] Have you added tests for new functionality?
- [ ] Have validated query efficiency for new database queries?
- [ ] Have documented new functionality in README or in comments?
- [ ] Have you squashed all intermediate commits?
- [ ] Is there a clear title that explains what the PR does?
- [ ] Have you used intuitive function, variable and other naming?
- [ ] Have you requested security and/or privacy review if needed
- [ ] Have you performed a self review of this PR?


### Manual Test Plan

<!-- if needed - e.g. prod branch release PR, otherwise remove this section -->
